### PR TITLE
Ignore test in sonarcloud

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,4 @@
+sonar.sources=.
+sonar.exclusions=**/*_test.go
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go


### PR DESCRIPTION
# Description
Actually, sonarcloud can see code smell in tests, we want to avoid that.

