### PR TITLE
Variation return default value only if an error appear

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ pr: present
 not: not of a logical expression
 ```
 
+## Variation
+The Variation methods determine whether a flag is enabled or not for a specific user.
+There is a Variation method for each type: `BoolVariation`, `IntVariation`, `Float64Variation`, `StringVariation`, `JSONArrayVariation` and `JSONVariation`. (and JSONVariation, which can be any JSON type):
+
+```go
+result, _ := ffclient.BoolVariation("your.feature.key", user, false)
+
+// result is now true or false depending on the setting of this boolean feature flag
+```
+Variation methods take the feature flag key, a User, and a default value.
+
+The default value is return when an error is encountered _(`ffclient` not initialized, variation with wrong type, flag does not exist ...)._  
+In the example, if the flag `your.feature.key` does not exists, result will be `false`.  
+Not that you will always have a usable value in the result. 
+
 ### Examples
 
 - Select a specific user: `key eq "example@example.com"`

--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ in: in a list
 pr: present
 not: not of a logical expression
 ```
+### Examples
+
+- Select a specific user: `key eq "example@example.com"`
+- Select all identified users: `anonymous ne true`
+- Select a user with a custom property: `userId eq "12345"`
 
 ## Variation
 The Variation methods determine whether a flag is enabled or not for a specific user.
@@ -162,12 +167,6 @@ Variation methods take the feature flag key, a User, and a default value.
 The default value is return when an error is encountered _(`ffclient` not initialized, variation with wrong type, flag does not exist ...)._  
 In the example, if the flag `your.feature.key` does not exists, result will be `false`.  
 Not that you will always have a usable value in the result. 
-
-### Examples
-
-- Select a specific user: `key eq "example@example.com"`
-- Select all identified users: `anonymous ne true`
-- Select a user with a custom property: `userId eq "12345"`
 
 # How can I contribute?
 This project is open for contribution, see the [contributor's guide](CONTRIBUTING.md) for some helpful tips.

--- a/variation.go
+++ b/variation.go
@@ -2,29 +2,32 @@ package ffclient
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/thomaspoignant/go-feature-flag/ffuser"
 	"github.com/thomaspoignant/go-feature-flag/internal/cache"
 )
 
 const errorCacheNotInit = "impossible to read the toggle before the initialisation"
+const errorFlagNotAvailable = "flag %v is not present or disabled"
+const errorWrongVariation = "wrong variation used for flag %v"
 
 // BoolVariation return the value of the flag in boolean.
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.
 func BoolVariation(flagKey string, user ffuser.User, defaultValue bool) (bool, error) {
 	if !cacheIsInitialized() {
-		return false, errors.New(errorCacheNotInit)
+		return defaultValue, errors.New(errorCacheNotInit)
 	}
 
 	flag, ok := cache.FlagsCache[flagKey]
 	if !ok || flag.Disable {
-		return defaultValue, nil
+		return defaultValue, fmt.Errorf(errorFlagNotAvailable, flagKey)
 	}
 
 	res, ok := flag.Value(flagKey, user).(bool)
 	if !ok {
-		return defaultValue, nil
+		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
 	return res, nil
 }
@@ -34,17 +37,17 @@ func BoolVariation(flagKey string, user ffuser.User, defaultValue bool) (bool, e
 // If the key does not exist we return the default value.
 func IntVariation(flagKey string, user ffuser.User, defaultValue int) (int, error) {
 	if !cacheIsInitialized() {
-		return 0, errors.New(errorCacheNotInit)
+		return defaultValue, errors.New(errorCacheNotInit)
 	}
 
 	flag, ok := cache.FlagsCache[flagKey]
 	if !ok || flag.Disable {
-		return defaultValue, nil
+		return defaultValue, fmt.Errorf(errorFlagNotAvailable, flagKey)
 	}
 
 	res, ok := flag.Value(flagKey, user).(int)
 	if !ok {
-		return defaultValue, nil
+		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
 	return res, nil
 }
@@ -54,17 +57,17 @@ func IntVariation(flagKey string, user ffuser.User, defaultValue int) (int, erro
 // If the key does not exist we return the default value.
 func Float64Variation(flagKey string, user ffuser.User, defaultValue float64) (float64, error) {
 	if !cacheIsInitialized() {
-		return 0, errors.New(errorCacheNotInit)
+		return defaultValue, errors.New(errorCacheNotInit)
 	}
 
 	flag, ok := cache.FlagsCache[flagKey]
 	if !ok || flag.Disable {
-		return defaultValue, nil
+		return defaultValue, fmt.Errorf(errorFlagNotAvailable, flagKey)
 	}
 
 	res, ok := flag.Value(flagKey, user).(float64)
 	if !ok {
-		return defaultValue, nil
+		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
 	return res, nil
 }
@@ -74,17 +77,17 @@ func Float64Variation(flagKey string, user ffuser.User, defaultValue float64) (f
 // If the key does not exist we return the default value.
 func StringVariation(flagKey string, user ffuser.User, defaultValue string) (string, error) {
 	if !cacheIsInitialized() {
-		return "", errors.New(errorCacheNotInit)
+		return defaultValue, errors.New(errorCacheNotInit)
 	}
 
 	flag, ok := cache.FlagsCache[flagKey]
 	if !ok || flag.Disable {
-		return defaultValue, nil
+		return defaultValue, fmt.Errorf(errorFlagNotAvailable, flagKey)
 	}
 
 	res, ok := flag.Value(flagKey, user).(string)
 	if !ok || flag.Disable {
-		return defaultValue, nil
+		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
 	return res, nil
 }
@@ -94,17 +97,17 @@ func StringVariation(flagKey string, user ffuser.User, defaultValue string) (str
 // If the key does not exist we return the default value.
 func JSONArrayVariation(flagKey string, user ffuser.User, defaultValue []interface{}) ([]interface{}, error) {
 	if !cacheIsInitialized() {
-		return nil, errors.New(errorCacheNotInit)
+		return defaultValue, errors.New(errorCacheNotInit)
 	}
 
 	flag, ok := cache.FlagsCache[flagKey]
 	if !ok || flag.Disable {
-		return defaultValue, nil
+		return defaultValue, fmt.Errorf(errorFlagNotAvailable, flagKey)
 	}
 
 	res, ok := flag.Value(flagKey, user).([]interface{})
 	if !ok {
-		return defaultValue, nil
+		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
 	return res, nil
 }
@@ -115,17 +118,17 @@ func JSONArrayVariation(flagKey string, user ffuser.User, defaultValue []interfa
 func JSONVariation(
 	flagKey string, user ffuser.User, defaultValue map[string]interface{}) (map[string]interface{}, error) {
 	if !cacheIsInitialized() {
-		return nil, errors.New(errorCacheNotInit)
+		return defaultValue, errors.New(errorCacheNotInit)
 	}
 
 	flag, ok := cache.FlagsCache[flagKey]
 	if !ok || flag.Disable {
-		return defaultValue, nil
+		return defaultValue, fmt.Errorf(errorFlagNotAvailable, flagKey)
 	}
 
 	res, ok := flag.Value(flagKey, user).(map[string]interface{})
 	if !ok {
-		return defaultValue, nil
+		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
 	return res, nil
 }

--- a/variation_test.go
+++ b/variation_test.go
@@ -49,7 +49,7 @@ func TestBoolVariation(t *testing.T) {
 				flagCache:    flagCacheMock,
 			},
 			want:    true,
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "Get error when not init",
@@ -59,6 +59,7 @@ func TestBoolVariation(t *testing.T) {
 				defaultValue: true,
 				flagCache:    nil,
 			},
+			want:    true,
 			wantErr: true,
 		},
 		{
@@ -70,7 +71,7 @@ func TestBoolVariation(t *testing.T) {
 				flagCache:    flagCacheMock,
 			},
 			want:    true,
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "Get default value, rule not apply",
@@ -122,7 +123,7 @@ func TestBoolVariation(t *testing.T) {
 				},
 			},
 			want:    true,
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -182,7 +183,7 @@ func TestFloat64Variation(t *testing.T) {
 				flagCache:    flagCacheMock,
 			},
 			want:    120.0,
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "Get error when not init",
@@ -192,6 +193,7 @@ func TestFloat64Variation(t *testing.T) {
 				defaultValue: 118.0,
 				flagCache:    nil,
 			},
+			want:    118.0,
 			wantErr: true,
 		},
 		{
@@ -203,7 +205,7 @@ func TestFloat64Variation(t *testing.T) {
 				flagCache:    flagCacheMock,
 			},
 			want:    118.0,
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "Get default value, rule not apply",
@@ -255,7 +257,7 @@ func TestFloat64Variation(t *testing.T) {
 				},
 			},
 			want:    118.0,
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -315,7 +317,7 @@ func TestJSONArrayVariation(t *testing.T) {
 				flagCache:    flagCacheMock,
 			},
 			want:    []interface{}{"toto"},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "Get error when not init",
@@ -325,6 +327,7 @@ func TestJSONArrayVariation(t *testing.T) {
 				defaultValue: []interface{}{"toto"},
 				flagCache:    nil,
 			},
+			want:    []interface{}{"toto"},
 			wantErr: true,
 		},
 		{
@@ -336,7 +339,7 @@ func TestJSONArrayVariation(t *testing.T) {
 				flagCache:    flagCacheMock,
 			},
 			want:    []interface{}{"toto"},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "Get default value, rule not apply",
@@ -388,7 +391,7 @@ func TestJSONArrayVariation(t *testing.T) {
 				},
 			},
 			want:    []interface{}{"toto"},
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -448,7 +451,7 @@ func TestJSONVariation(t *testing.T) {
 				flagCache:    flagCacheMock,
 			},
 			want:    map[string]interface{}{"default-notkey": true},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "Get error when not init",
@@ -458,6 +461,7 @@ func TestJSONVariation(t *testing.T) {
 				defaultValue: map[string]interface{}{"default-notkey": true},
 				flagCache:    nil,
 			},
+			want:    map[string]interface{}{"default-notkey": true},
 			wantErr: true,
 		},
 		{
@@ -469,7 +473,7 @@ func TestJSONVariation(t *testing.T) {
 				flagCache:    flagCacheMock,
 			},
 			want:    map[string]interface{}{"default-notkey": true},
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "Get default value, rule not apply",
@@ -521,7 +525,7 @@ func TestJSONVariation(t *testing.T) {
 				},
 			},
 			want:    map[string]interface{}{"default-notkey": true},
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -581,7 +585,7 @@ func TestStringVariation(t *testing.T) {
 				flagCache:    flagCacheMock,
 			},
 			want:    "default-notkey",
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "Get error when not init",
@@ -591,6 +595,7 @@ func TestStringVariation(t *testing.T) {
 				defaultValue: "default-notkey",
 				flagCache:    nil,
 			},
+			want:    "default-notkey",
 			wantErr: true,
 		},
 		{
@@ -602,7 +607,7 @@ func TestStringVariation(t *testing.T) {
 				flagCache:    flagCacheMock,
 			},
 			want:    "default-notkey",
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "Get default value, rule not apply",
@@ -654,7 +659,7 @@ func TestStringVariation(t *testing.T) {
 				},
 			},
 			want:    "default-notkey",
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -714,7 +719,7 @@ func TestIntVariation(t *testing.T) {
 				flagCache:    flagCacheMock,
 			},
 			want:    125,
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "Get error when not init",
@@ -724,6 +729,7 @@ func TestIntVariation(t *testing.T) {
 				defaultValue: 118,
 				flagCache:    nil,
 			},
+			want:    118,
 			wantErr: true,
 		},
 		{
@@ -735,7 +741,7 @@ func TestIntVariation(t *testing.T) {
 				flagCache:    flagCacheMock,
 			},
 			want:    118,
-			wantErr: false,
+			wantErr: true,
 		},
 		{
 			name: "Get default value rule not apply",
@@ -787,7 +793,7 @@ func TestIntVariation(t *testing.T) {
 				},
 			},
 			want:    118,
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Description
When you call variation methods you get the default result only if you have an error.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
Resolve #22 
Resolve #21 

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
