### PR TITLE
Add log when calling variation

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"log"
 	"net/http"
 
 	"github.com/thomaspoignant/go-feature-flag/internal/retriever"
@@ -15,6 +16,7 @@ import (
 // You should also have a retriever to specify where to read the flags file.
 type Config struct {
 	PollInterval  int // Poll every X seconds
+	Logger        *log.Logger
 	LocalFile     string
 	HTTPRetriever *HTTPRetriever
 	S3Retriever   *S3Retriever

--- a/feature_flag.go
+++ b/feature_flag.go
@@ -10,6 +10,7 @@ import (
 )
 
 var flagUpdater gocron.Scheduler
+var logger *log.Logger
 
 // Init the feature flag component with the configuration of ffclient.Config
 //  func main() {
@@ -32,6 +33,9 @@ func Init(config Config) error {
 	if config.PollInterval == 0 {
 		config.PollInterval = 1
 	}
+
+	logger = config.Logger
+
 	_, err = flagUpdater.Every(uint64(config.PollInterval)).Seconds().Do(retrieveFlagsAndUpdateCache, config)
 	if err != nil {
 		return fmt.Errorf("impossible to launch background updater: %v", err)

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/antlr/antlr4 v0.0.0-20201206235148-c87e55b61113 h1:+Je12tQpLUUQEfMUrL
 github.com/antlr/antlr4 v0.0.0-20201206235148-c87e55b61113/go.mod h1:T7PbCXFs94rrTttyxjbyT5+/1V8T2TYDejxUfHJjw1Y=
 github.com/aws/aws-sdk-go v1.36.10 h1:JCBOoVIEJkNcio01MNbmelgOc6+uxANTC3TYYPlcsEE=
 github.com/aws/aws-sdk-go v1.36.10/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.36.11 h1:6lVRjsmRpQwq58+YHBbBe7BZuY3l6onDBLN4twOXT7U=
 github.com/aws/aws-sdk-go v1.36.11/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=

--- a/variation.go
+++ b/variation.go
@@ -3,9 +3,11 @@ package ffclient
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/ffuser"
 	"github.com/thomaspoignant/go-feature-flag/internal/cache"
+	"github.com/thomaspoignant/go-feature-flag/internal/flags"
 )
 
 const errorCacheNotInit = "impossible to read the toggle before the initialisation"
@@ -16,19 +18,18 @@ const errorWrongVariation = "wrong variation used for flag %v"
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.
 func BoolVariation(flagKey string, user ffuser.User, defaultValue bool) (bool, error) {
-	if !cacheIsInitialized() {
-		return defaultValue, errors.New(errorCacheNotInit)
-	}
-
-	flag, ok := cache.FlagsCache[flagKey]
-	if !ok || flag.Disable {
-		return defaultValue, fmt.Errorf(errorFlagNotAvailable, flagKey)
+	flag, err := getFlagFromCache(flagKey)
+	if err != nil {
+		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		return defaultValue, err
 	}
 
 	res, ok := flag.Value(flagKey, user).(bool)
 	if !ok {
+		notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
+	notifyVariation(flagKey, user.GetKey(), res)
 	return res, nil
 }
 
@@ -36,19 +37,18 @@ func BoolVariation(flagKey string, user ffuser.User, defaultValue bool) (bool, e
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.
 func IntVariation(flagKey string, user ffuser.User, defaultValue int) (int, error) {
-	if !cacheIsInitialized() {
-		return defaultValue, errors.New(errorCacheNotInit)
-	}
-
-	flag, ok := cache.FlagsCache[flagKey]
-	if !ok || flag.Disable {
-		return defaultValue, fmt.Errorf(errorFlagNotAvailable, flagKey)
+	flag, err := getFlagFromCache(flagKey)
+	if err != nil {
+		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		return defaultValue, err
 	}
 
 	res, ok := flag.Value(flagKey, user).(int)
 	if !ok {
+		notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
+	notifyVariation(flagKey, user.GetKey(), res)
 	return res, nil
 }
 
@@ -56,19 +56,18 @@ func IntVariation(flagKey string, user ffuser.User, defaultValue int) (int, erro
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.
 func Float64Variation(flagKey string, user ffuser.User, defaultValue float64) (float64, error) {
-	if !cacheIsInitialized() {
-		return defaultValue, errors.New(errorCacheNotInit)
-	}
-
-	flag, ok := cache.FlagsCache[flagKey]
-	if !ok || flag.Disable {
-		return defaultValue, fmt.Errorf(errorFlagNotAvailable, flagKey)
+	flag, err := getFlagFromCache(flagKey)
+	if err != nil {
+		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		return defaultValue, err
 	}
 
 	res, ok := flag.Value(flagKey, user).(float64)
 	if !ok {
+		notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
+	notifyVariation(flagKey, user.GetKey(), res)
 	return res, nil
 }
 
@@ -76,19 +75,18 @@ func Float64Variation(flagKey string, user ffuser.User, defaultValue float64) (f
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.
 func StringVariation(flagKey string, user ffuser.User, defaultValue string) (string, error) {
-	if !cacheIsInitialized() {
-		return defaultValue, errors.New(errorCacheNotInit)
-	}
-
-	flag, ok := cache.FlagsCache[flagKey]
-	if !ok || flag.Disable {
-		return defaultValue, fmt.Errorf(errorFlagNotAvailable, flagKey)
+	flag, err := getFlagFromCache(flagKey)
+	if err != nil {
+		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		return defaultValue, err
 	}
 
 	res, ok := flag.Value(flagKey, user).(string)
-	if !ok || flag.Disable {
+	if !ok {
+		notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
+	notifyVariation(flagKey, user.GetKey(), res)
 	return res, nil
 }
 
@@ -96,19 +94,18 @@ func StringVariation(flagKey string, user ffuser.User, defaultValue string) (str
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.
 func JSONArrayVariation(flagKey string, user ffuser.User, defaultValue []interface{}) ([]interface{}, error) {
-	if !cacheIsInitialized() {
-		return defaultValue, errors.New(errorCacheNotInit)
-	}
-
-	flag, ok := cache.FlagsCache[flagKey]
-	if !ok || flag.Disable {
-		return defaultValue, fmt.Errorf(errorFlagNotAvailable, flagKey)
+	flag, err := getFlagFromCache(flagKey)
+	if err != nil {
+		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		return defaultValue, err
 	}
 
 	res, ok := flag.Value(flagKey, user).([]interface{})
 	if !ok {
+		notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
+	notifyVariation(flagKey, user.GetKey(), res)
 	return res, nil
 }
 
@@ -117,22 +114,41 @@ func JSONArrayVariation(flagKey string, user ffuser.User, defaultValue []interfa
 // If the key does not exist we return the default value.
 func JSONVariation(
 	flagKey string, user ffuser.User, defaultValue map[string]interface{}) (map[string]interface{}, error) {
-	if !cacheIsInitialized() {
-		return defaultValue, errors.New(errorCacheNotInit)
-	}
-
-	flag, ok := cache.FlagsCache[flagKey]
-	if !ok || flag.Disable {
-		return defaultValue, fmt.Errorf(errorFlagNotAvailable, flagKey)
+	flag, err := getFlagFromCache(flagKey)
+	if err != nil {
+		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		return defaultValue, err
 	}
 
 	res, ok := flag.Value(flagKey, user).(map[string]interface{})
 	if !ok {
+		notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
+	notifyVariation(flagKey, user.GetKey(), res)
 	return res, nil
 }
 
-func cacheIsInitialized() bool {
-	return cache.FlagsCache != nil
+// notifyVariation is logging the evaluation result for a flag
+// if no logger is provided in the configuration we are not logging anything.
+func notifyVariation(flagKey string, userKey string, value interface{}) {
+	if logger != nil {
+		logger.Printf(
+			"[%v] user=\"%s\", flag=\"%s\", value=\"%v\"",
+			time.Now().Format(time.RFC3339), userKey, flagKey, value)
+	}
+}
+
+// getFlagFromCache try to get the flag from the cache.
+// It returns an error if the cache is not init or if the flag is not present or disabled.
+func getFlagFromCache(flagKey string) (flags.Flag, error) {
+	if cache.FlagsCache == nil {
+		return flags.Flag{}, errors.New(errorCacheNotInit)
+	}
+
+	flag, ok := cache.FlagsCache[flagKey]
+	if !ok || flag.Disable {
+		return flag, fmt.Errorf(errorFlagNotAvailable, flagKey)
+	}
+	return flag, nil
 }


### PR DESCRIPTION
# Description
This PR adds support to logs when calling variation methods.

For that, you should configure a logger in `ffclient.Config{}`. If no logger is configured, the module is not logging anything.

The format of the log looks like:
```
[2020-12-18T15:04:42+01:00] user="random-key", flag="unknown-flag", value="false"
```

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
Resolve #17

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
