### PR TITLE
Add Github retriever

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We can have only one source for the file, if you set multiple sources in your co
 ```go
 err := ffclient.Init(ffclient.Config{
     PollInterval: 3,
-     GithubRetriever: &ffClient.GithubRetriever{
+    GithubRetriever: &ffClient.GithubRetriever{
         RepositorySlug: "thomaspoignant/go-feature-flag",
         Branch: "main",
         FilePath: "testdata/test.yaml",
@@ -69,7 +69,9 @@ To configure the access to your GitHub file:
 - **RepositorySlug**: your GitHub slug `org/repo-name`. **MANDATORY**
 - **FilePath**: the path of your file. **MANDATORY**
 - **Branch**: the branch where your file is *(default is `main`)*.
-- **GithubToken**: Github token is used to access private repository, you need the `repo` permission *([how to create a GitHub token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token))*.
+- **GithubToken**: Github token is used to access a private repository, you need the `repo` permission *([how to create a GitHub token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token))*.
+
+**Warning**: GitHub has rate limits, so be sure to not reach them when setting your `PollInterval`.
 
 ### From an HTTP endpoint
 ```go

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@
 
 
 
-A feature flag solution, with YAML file in the backend (S3, HTTP, local file ...).  
-No server to install, just add a file in a central system *(HTTP, S3, ...)* and all your services will react to the changes of this file.
+A feature flag solution, with YAML file in the backend (S3, GitHub, HTTP, local file ...).  
+No server to install, just add a file in a central system *(HTTP, S3, GitHub, ...)* and all your services will react to the changes of this file.
 
 
 If you are not familiar with feature flags also called feature Toggles you can read this [article of Martin Fowler](https://www.martinfowler.com/articles/feature-toggles.html)
-that explain why this is a great pattern.  
-I've also write an [article](https://medium.com/better-programming/feature-flags-and-how-to-iterate-quickly-7e3371b9986) that explain why feature flags can help you to iterate quickly.
+that explains why this is a great pattern.  
+I've also wrote an [article](https://medium.com/better-programming/feature-flags-and-how-to-iterate-quickly-7e3371b9986) that explains why feature flags can help you to iterate quickly.
 
 ## Installation
 ```bash
@@ -52,16 +52,24 @@ if hasFlag {
 `go-feature-flags` support different ways of retrieving the flag file.  
 We can have only one source for the file, if you set multiple sources in your configuration, only one will be take in consideration.
 
-### From a file
+### From GitHub
 ```go
 err := ffclient.Init(ffclient.Config{
     PollInterval: 3,
-    LocalFile: "file-example.yaml",
+     GithubRetriever: &ffClient.GithubRetriever{
+        RepositorySlug: "thomaspoignant/go-feature-flag",
+        Branch: "main",
+        FilePath: "testdata/test.yaml",
+        GithubToken: "XXXX",
+    },
 })
 defer ffclient.Close()
 ```
-
-I will not recommend using a file to store your flags except if it is in a shared folder for all your services.
+To configure the access to your GitHub file:
+- **RepositorySlug**: your GitHub slug `org/repo-name`. **MANDATORY**
+- **FilePath**: the path of your file. **MANDATORY**
+- **Branch**: the branch where your file is *(default is `main`)*.
+- **GithubToken**: Github token is used to access private repository, you need the `repo` permission *([how to create a GitHub token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token))*.
 
 ### From an HTTP endpoint
 ```go
@@ -99,6 +107,18 @@ To configure your S3 file location:
 - **Bucket**: The name of your bucket. **MANDATORY**
 - **Item**: The location of your file in the bucket. **MANDATORY**
 - **AwsConfig**: An instance of `aws.Config` that configure your access to AWS *(see [this documentation for more info](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html))*. **MANDATORY**
+
+### From a file
+```go
+err := ffclient.Init(ffclient.Config{
+    PollInterval: 3,
+    LocalFile: "file-example.yaml",
+})
+defer ffclient.Close()
+```
+
+*I will not recommend using a file to store your flags except if it is in a shared folder for all your services.*
+
 
 ## Flags file format
 `go-feature-flag` is to avoid to have to host a backend to manage your feature flags and to keep them centralized by using a file a source.  

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package ffclient
 
 import (
 	"errors"
+	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -15,11 +16,12 @@ import (
 // PollInterval is the interval in seconds where we gonna read the file to update the cache.
 // You should also have a retriever to specify where to read the flags file.
 type Config struct {
-	PollInterval  int // Poll every X seconds
-	Logger        *log.Logger
-	LocalFile     string
-	HTTPRetriever *HTTPRetriever
-	S3Retriever   *S3Retriever
+	PollInterval    int // Poll every X seconds
+	Logger          *log.Logger
+	LocalFile       string
+	HTTPRetriever   *HTTPRetriever
+	S3Retriever     *S3Retriever
+	GithubRetriever *GithubRetriever
 }
 
 // HTTPRetriever is a configuration struct for an HTTP endpoint retriever.
@@ -37,8 +39,20 @@ type S3Retriever struct {
 	AwsConfig aws.Config
 }
 
+// S3Retriever is a configuration struct for a S3 retriever.
+type GithubRetriever struct {
+	RepositorySlug string
+	Branch         string // default is main
+	FilePath       string
+	GithubToken    string
+}
+
 // GetRetriever is used to get the retriever we will use to load the flags file.
 func (c *Config) GetRetriever() (retriever.FlagRetriever, error) {
+	if c.GithubRetriever != nil {
+		return initGithubRetriever(*c.GithubRetriever)
+	}
+
 	if c.S3Retriever != nil {
 		// Create an AWS session
 		sess, err := session.NewSession(&c.S3Retriever.AwsConfig)
@@ -69,4 +83,33 @@ func (c *Config) GetRetriever() (retriever.FlagRetriever, error) {
 		return retriever.NewLocalRetriever(c.LocalFile), nil
 	}
 	return nil, errors.New("please add a config to get the flag config file")
+}
+
+// initGithubRetriever creates a HTTP retriever that allows to get changes from Github.
+func initGithubRetriever(r GithubRetriever) (retriever.FlagRetriever, error) {
+	// default branch is main
+	branch := r.Branch
+	if branch == "" {
+		branch = "main"
+	}
+
+	// add header for Github Token if specified
+	header := http.Header{}
+	if r.GithubToken != "" {
+		header.Add("Authorization", fmt.Sprintf("token %s", r.GithubToken))
+	}
+
+	URL := fmt.Sprintf(
+		"https://raw.githubusercontent.com/%s/%s/%s",
+		r.RepositorySlug,
+		branch,
+		r.FilePath)
+
+	return retriever.NewHTTPRetriever(
+		http.DefaultClient,
+		URL,
+		http.MethodGet,
+		"",
+		header,
+	), nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -12,10 +12,11 @@ import (
 
 func TestConfig_GetRetriever(t *testing.T) {
 	type fields struct {
-		PollInterval  int
-		LocalFile     string
-		HTTPRetriever *ffClient.HTTPRetriever
-		S3Retriever   *ffClient.S3Retriever
+		PollInterval    int
+		LocalFile       string
+		HTTPRetriever   *ffClient.HTTPRetriever
+		S3Retriever     *ffClient.S3Retriever
+		GithubRetriever *ffClient.GithubRetriever
 	}
 	tests := []struct {
 		name    string
@@ -56,6 +57,20 @@ func TestConfig_GetRetriever(t *testing.T) {
 					Method: http.MethodGet,
 				},
 			},
+			want:    "*retriever.httpRetriever",
+			wantErr: false,
+		},
+		{
+			name: "Github retriever",
+			fields: fields{
+				PollInterval: 3,
+				GithubRetriever: &ffClient.GithubRetriever{
+					RepositorySlug: "thomaspoignant/go-feature-flag",
+					Branch:         "main",
+					FilePath:       "testdata/test.yaml",
+				},
+			},
+			// we should have a http retriever because Github retriever is using httpRetriever
 			want:    "*retriever.httpRetriever",
 			wantErr: false,
 		},
@@ -103,10 +118,11 @@ func TestConfig_GetRetriever(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &ffClient.Config{
-				PollInterval:  tt.fields.PollInterval,
-				LocalFile:     tt.fields.LocalFile,
-				HTTPRetriever: tt.fields.HTTPRetriever,
-				S3Retriever:   tt.fields.S3Retriever,
+				PollInterval:    tt.fields.PollInterval,
+				LocalFile:       tt.fields.LocalFile,
+				HTTPRetriever:   tt.fields.HTTPRetriever,
+				S3Retriever:     tt.fields.S3Retriever,
+				GithubRetriever: tt.fields.GithubRetriever,
 			}
 			got, err := c.GetRetriever()
 			assert.Equal(t, tt.wantErr, err != nil)

--- a/config_test.go
+++ b/config_test.go
@@ -66,8 +66,8 @@ func TestConfig_GetRetriever(t *testing.T) {
 				PollInterval: 3,
 				GithubRetriever: &ffClient.GithubRetriever{
 					RepositorySlug: "thomaspoignant/go-feature-flag",
-					Branch:         "main",
 					FilePath:       "testdata/test.yaml",
+					GithubToken:    "XXX",
 				},
 			},
 			// we should have a http retriever because Github retriever is using httpRetriever


### PR DESCRIPTION
# Description
Add **GitHub** as a newly available backend.
It uses the `HttpRetriever` to get the file, but we add a high-level configuration format to make it easy to configure **GitHub** as your backend.

This also supports the usage of GitHub tokens if your file is in a private repository.


# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)

Resolve #28

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
