### PR TITLE
Change default PollInterval to 60s

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ err := ffclient.Init(ffclient.Config{
 })
 defer ffclient.Close()
 ```
-*This example will load a file from an HTTP endpoint and will refresh the flags every 3 seconds.*
+*This example will load a file from an HTTP endpoint and will refresh the flags every 3 seconds (if you omit the
+PollInterval, default value is 60s).*
 
 Now you can evalute your flags anywhere in your code.
 ```go

--- a/feature_flag.go
+++ b/feature_flag.go
@@ -29,9 +29,9 @@ func Init(config Config) error {
 	}
 	flagUpdater = *gocron.NewScheduler(time.UTC)
 
-	// The default value for poll interval is 1
+	// The default value for poll interval is 60 seconds
 	if config.PollInterval == 0 {
-		config.PollInterval = 1
+		config.PollInterval = 60
 	}
 
 	logger = config.Logger


### PR DESCRIPTION
# Description
Move the default PollInterval to 60 seconds.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
Resolve #34

# Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
