### PR TITLE
Use context when retrieve the flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ defer ffclient.Close()
 PollInterval, default value is 60s).*
 
 Now you can evalute your flags anywhere in your code.
+
 ```go
 user := ffuser.NewUser("user-unique-key")
 hasFlag, _ := ffclient.BoolVariation("test-flag", user, false)
@@ -53,9 +54,30 @@ if hasFlag {
 }
 ```
 
+## Configuration
+
+The configuration is set with `ffclient.Config{}` and you can give it to ``ffclient.Init()`` the initialization
+function.
+
+Example:
+```go 
+ffclient.Init(ffclient.Config{ 
+    PollInterval:   3,
+    Logger:         log.New(file, "/tmp/log", 0)
+    Context         context.Background(),
+})
+```
+
+|   |   |
+|---|---|
+|`PollInterval`   | Number of seconds to wait before refreshing the flags. The default value is 60 seconds.|
+|`Logger`   | Logger used to log what `go-feature-flag` is doing. If no logger provided no log will be output.|
+|`Context`  | The context used by the retriever. The default value is `context.Background()`.|
+
 ## Where do I store my flags file
 `go-feature-flags` support different ways of retrieving the flag file.  
-We can have only one source for the file, if you set multiple sources in your configuration, only one will be take in consideration.
+We can have only one source for the file, if you set multiple sources in your configuration, only one will be take in
+consideration.
 
 ### From GitHub
 ```go

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package ffclient
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
@@ -19,6 +20,7 @@ import (
 type Config struct {
 	PollInterval    int // Poll every X seconds
 	Logger          *log.Logger
+	Context         context.Context // default is context.Background()
 	LocalFile       string
 	HTTPRetriever   *HTTPRetriever
 	S3Retriever     *S3Retriever

--- a/feature_flag.go
+++ b/feature_flag.go
@@ -52,7 +52,7 @@ func retrieveFlagsAndUpdateCache(config Config) error {
 		return err
 	}
 
-	loadedFlags, err := retriever.Retrieve()
+	loadedFlags, err := retriever.Retrieve(config.Context)
 	if err != nil {
 		log.Printf("error: impossible to retrieve flags from the config file: %v", err)
 		return err

--- a/internal/retriever/retriever.go
+++ b/internal/retriever/retriever.go
@@ -1,7 +1,9 @@
 package retriever
 
+import "context"
+
 // FlagRetriever is an interface that force to have a Retrieve() function for
 // different way of getting the config file.
 type FlagRetriever interface {
-	Retrieve() ([]byte, error)
+	Retrieve(ctx context.Context) ([]byte, error)
 }

--- a/internal/retriever/retriever_file.go
+++ b/internal/retriever/retriever_file.go
@@ -1,6 +1,7 @@
 package retriever
 
 import (
+	"context"
 	"io/ioutil"
 )
 
@@ -13,7 +14,7 @@ type localRetriever struct {
 	path string
 }
 
-func (l *localRetriever) Retrieve() ([]byte, error) {
+func (l *localRetriever) Retrieve(ctx context.Context) ([]byte, error) {
 	content, err := ioutil.ReadFile(l.path)
 	if err != nil {
 		return nil, err

--- a/internal/retriever/retriever_file_test.go
+++ b/internal/retriever/retriever_file_test.go
@@ -1,6 +1,7 @@
 package retriever_test
 
 import (
+	"context"
 	"github.com/google/go-cmp/cmp"
 	"testing"
 
@@ -52,7 +53,7 @@ func Test_localRetriever_Retrieve(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := retriever.NewLocalRetriever(tt.fields.path)
-			got, err := l.Retrieve()
+			got, err := l.Retrieve(context.Background())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Retrieve() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/retriever/retriever_http.go
+++ b/internal/retriever/retriever_http.go
@@ -33,7 +33,7 @@ type httpRetriever struct {
 	header     http.Header
 }
 
-func (h *httpRetriever) Retrieve() ([]byte, error) {
+func (h *httpRetriever) Retrieve(ctx context.Context) ([]byte, error) {
 	if h.url == "" {
 		return nil, errors.New("URL is a mandatory parameter when using HTTPRetriever")
 	}
@@ -43,7 +43,11 @@ func (h *httpRetriever) Retrieve() ([]byte, error) {
 		method = http.MethodGet
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), method, h.url, strings.NewReader(h.body))
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, h.url, strings.NewReader(h.body))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/retriever/retriever_http_test.go
+++ b/internal/retriever/retriever_http_test.go
@@ -2,6 +2,7 @@ package retriever_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -138,7 +139,7 @@ func Test_httpRetriever_Retrieve(t *testing.T) {
 				tt.fields.body,
 				tt.fields.header,
 			)
-			got, err := h.Retrieve()
+			got, err := h.Retrieve(context.Background())
 			assert.Equal(t, tt.wantErr, err != nil, "Retrieve() error = %v, wantErr %v", err, tt.wantErr)
 
 			if tt.fields.method == "" {

--- a/internal/retriever/retriever_http_test.go
+++ b/internal/retriever/retriever_http_test.go
@@ -54,6 +54,7 @@ func Test_httpRetriever_Retrieve(t *testing.T) {
 		method     string
 		body       string
 		header     http.Header
+		context    context.Context
 	}
 	tests := []struct {
 		name    string
@@ -69,6 +70,25 @@ func Test_httpRetriever_Retrieve(t *testing.T) {
 				method:     http.MethodGet,
 				body:       "",
 				header:     nil,
+			},
+			want: []byte(`test-flag:
+  rule: key eq "random-key"
+  percentage: 100
+  true: true
+  false: false
+  default: false
+`),
+			wantErr: false,
+		},
+		{
+			name: "Success with context",
+			fields: fields{
+				httpClient: &mockHTTP{},
+				url:        "http://localhost.example/file",
+				method:     http.MethodGet,
+				body:       "",
+				header:     nil,
+				context:    context.Background(),
 			},
 			want: []byte(`test-flag:
   rule: key eq "random-key"
@@ -139,7 +159,7 @@ func Test_httpRetriever_Retrieve(t *testing.T) {
 				tt.fields.body,
 				tt.fields.header,
 			)
-			got, err := h.Retrieve(context.Background())
+			got, err := h.Retrieve(tt.fields.context)
 			assert.Equal(t, tt.wantErr, err != nil, "Retrieve() error = %v, wantErr %v", err, tt.wantErr)
 
 			if tt.fields.method == "" {

--- a/internal/retriever/retriever_s3_test.go
+++ b/internal/retriever/retriever_s3_test.go
@@ -39,6 +39,7 @@ func Test_s3Retriever_Retrieve(t *testing.T) {
 		downloader s3manageriface.DownloaderAPI
 		bucket     string
 		item       string
+		context    context.Context
 	}
 	tests := []struct {
 		name    string
@@ -65,11 +66,22 @@ func Test_s3Retriever_Retrieve(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "File on S3 with context",
+			fields: fields{
+				downloader: s3ManagerMock{},
+				bucket:     "Bucket",
+				item:       "valid",
+				context:    context.Background(),
+			},
+			want:    "../../testdata/test.yaml",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := retriever.NewS3Retriever(tt.fields.downloader, tt.fields.bucket, tt.fields.item)
-			got, err := s.Retrieve(context.Background())
+			got, err := s.Retrieve(tt.fields.context)
 			assert.Equal(t, tt.wantErr, err != nil, "Retrieve() error = %v, wantErr %v", err, tt.wantErr)
 			if err == nil {
 				want, err := ioutil.ReadFile(tt.want)

--- a/internal/retriever/retriever_s3_test.go
+++ b/internal/retriever/retriever_s3_test.go
@@ -1,6 +1,7 @@
 package retriever_test
 
 import (
+	"context"
 	"errors"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -68,7 +69,7 @@ func Test_s3Retriever_Retrieve(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := retriever.NewS3Retriever(tt.fields.downloader, tt.fields.bucket, tt.fields.item)
-			got, err := s.Retrieve()
+			got, err := s.Retrieve(context.Background())
 			assert.Equal(t, tt.wantErr, err != nil, "Retrieve() error = %v, wantErr %v", err, tt.wantErr)
 			if err == nil {
 				want, err := ioutil.ReadFile(tt.want)

--- a/variation_test.go
+++ b/variation_test.go
@@ -144,7 +144,6 @@ func TestBoolVariation(t *testing.T) {
 			// init logger
 			file, _ := ioutil.TempFile("", "log")
 			logger = log.New(file, "", 0)
-
 			cache.FlagsCache = tt.args.flagCache
 			got, err := BoolVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
 			cache.FlagsCache = nil


### PR DESCRIPTION
# Description
Now you can pass a `context` to the retriever.
The context is passed via the `ffclient.Context` configuration struct.

Change the signature for the retriever to use the context so now every retriever have to take care of the context if possible.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
