### PR TITLE
Force to use only one retriever at the time 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ First, you need to initialize the `ffclient` with the location of your backend f
 ```go
 err := ffclient.Init(ffclient.Config{
     PollInterval: 3,
-    HTTPRetriever: &ffClient.HTTPRetriever{
+    Retriever: &ffclient.HTTPRetriever{
         URL:    "http://example.com/test.yaml",
     },
 })
 defer ffclient.Close()
 ```
 *This example will load a file from an HTTP endpoint and will refresh the flags every 3 seconds (if you omit the
-PollInterval, default value is 60s).*
+PollInterval, the default value is 60 seconds).*
 
-Now you can evalute your flags anywhere in your code.
+Now you can evaluate your flags anywhere in your code.
 
 ```go
 user := ffuser.NewUser("user-unique-key")
@@ -73,6 +73,7 @@ ffclient.Init(ffclient.Config{
 |`PollInterval`   | Number of seconds to wait before refreshing the flags. The default value is 60 seconds.|
 |`Logger`   | Logger used to log what `go-feature-flag` is doing. If no logger provided no log will be output.|
 |`Context`  | The context used by the retriever. The default value is `context.Background()`.|
+|`Retriever`  | The configuration retriever you want to use to get your flag file *(see [Where do I store my flags file](#where-do-i-store-my-flags-file) for the details*.|
 
 ## Where do I store my flags file
 `go-feature-flags` support different ways of retrieving the flag file.  
@@ -83,7 +84,7 @@ consideration.
 ```go
 err := ffclient.Init(ffclient.Config{
     PollInterval: 3,
-    GithubRetriever: &ffClient.GithubRetriever{
+    Retriever: &ffclient.GithubRetriever{
         RepositorySlug: "thomaspoignant/go-feature-flag",
         Branch: "main",
         FilePath: "testdata/test.yaml",
@@ -100,13 +101,13 @@ To configure the access to your GitHub file:
 - **GithubToken**: Github token is used to access a private repository, you need the `repo` permission *([how to create a GitHub token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token))*.
 - **Timeout**: Timeout for the HTTP call (default is 10 seconds).
 
-**Warning**: GitHub has rate limits, so be sure to not reach them when setting your `PollInterval`.
+:warning: GitHub has rate limits, so be sure to not reach them when setting your `PollInterval`.
 
 ### From an HTTP endpoint
 ```go
 err := ffclient.Init(ffclient.Config{
     PollInterval: 3,
-     HTTPRetriever: &ffClient.HTTPRetriever{
+    Retriever: &ffclient.HTTPRetriever{
         URL:    "http://example.com/test.yaml",
         Timeout: 2 * time.Second,
     },
@@ -125,7 +126,7 @@ To configure your HTTP endpoint:
 ```go
 err := ffclient.Init(ffclient.Config{
     PollInterval: 3,
-    S3Retriever: &ffClient.S3Retriever{
+    Retriever: &ffclient.S3Retriever{
         Bucket: "tpoi-test",
         Item:   "test.yaml",
         AwsConfig: aws.Config{
@@ -145,10 +146,15 @@ To configure your S3 file location:
 ```go
 err := ffclient.Init(ffclient.Config{
     PollInterval: 3,
-    LocalFile: "file-example.yaml",
+    Retriever: &ffclient.FileRetriever{
+        Path: "file-example.yaml",
+    },
 })
 defer ffclient.Close()
 ```
+
+To configure your File retriever:
+- **Path**: location of your file. **MANDATORY**
 
 *I will not recommend using a file to store your flags except if it is in a shared folder for all your services.*
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ ffclient.Init(ffclient.Config{
 
 |   |   |
 |---|---|
-|`PollInterval`   | Number of seconds to wait before refreshing the flags. The default value is 60 seconds.|
-|`Logger`   | Logger used to log what `go-feature-flag` is doing. If no logger provided no log will be output.|
-|`Context`  | The context used by the retriever. The default value is `context.Background()`.|
-|`Retriever`  | The configuration retriever you want to use to get your flag file *(see [Where do I store my flags file](#where-do-i-store-my-flags-file) for the details*.|
+|`PollInterval`   | Number of seconds to wait before refreshing the flags.<br />The default value is 60 seconds.|
+|`Logger`   | Logger used to log what `go-feature-flag` is doing.<br />If no logger is provided the module will not log anything.|
+|`Context`  | The context used by the retriever.<br />The default value is `context.Background()`.|
+|`Retriever`  | The configuration retriever you want to use to get your flag file *(see [Where do I store my flags file](#where-do-i-store-my-flags-file) for the configuration details)*.|
 
 ## Where do I store my flags file
 `go-feature-flags` support different ways of retrieving the flag file.  

--- a/config.go
+++ b/config.go
@@ -22,9 +22,31 @@ type Config struct {
 	Logger          *log.Logger
 	Context         context.Context // default is context.Background()
 	LocalFile       string
+	Retriever       Retriever
 	HTTPRetriever   *HTTPRetriever
 	S3Retriever     *S3Retriever
 	GithubRetriever *GithubRetriever
+}
+
+// GetRetriever returns a retriever.FlagRetriever configure with the retriever available in the config.
+func (c *Config) GetRetriever() (retriever.FlagRetriever, error) {
+	if c.Retriever == nil {
+		return nil, errors.New("no retriever in the configuration, impossible to get the flags")
+	}
+	return c.Retriever.getFlagRetriever()
+}
+
+type Retriever interface {
+	getFlagRetriever() (retriever.FlagRetriever, error)
+}
+
+// FileRetriever is a configuration struct for a local flat file.
+type FileRetriever struct {
+	Path string
+}
+
+func (r *FileRetriever) getFlagRetriever() (retriever.FlagRetriever, error) { // nolint: unparam
+	return retriever.NewLocalRetriever(r.Path), nil
 }
 
 // HTTPRetriever is a configuration struct for an HTTP endpoint retriever.
@@ -36,11 +58,44 @@ type HTTPRetriever struct {
 	Timeout time.Duration
 }
 
+func (r *HTTPRetriever) getFlagRetriever() (retriever.FlagRetriever, error) {
+	timeout := r.Timeout
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+
+	return retriever.NewHTTPRetriever(
+		&http.Client{
+			Timeout: timeout,
+		},
+		r.URL,
+		r.Method,
+		r.Body,
+		r.Header,
+	), nil
+}
+
 // S3Retriever is a configuration struct for a S3 retriever.
 type S3Retriever struct {
 	Bucket    string
 	Item      string
 	AwsConfig aws.Config
+}
+
+func (r *S3Retriever) getFlagRetriever() (retriever.FlagRetriever, error) {
+	// Create an AWS session
+	sess, err := session.NewSession(&r.AwsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new AWS S3 downloader
+	downloader := s3manager.NewDownloader(sess)
+	return retriever.NewS3Retriever(
+		downloader,
+		r.Bucket,
+		r.Item,
+	), nil
 }
 
 // GithubRetriever is a configuration struct for a GitHub retriever.
@@ -52,40 +107,7 @@ type GithubRetriever struct {
 	Timeout        time.Duration // default is 10 seconds
 }
 
-// GetRetriever is used to get the retriever we will use to load the flags file.
-func (c *Config) GetRetriever() (retriever.FlagRetriever, error) {
-	if c.GithubRetriever != nil {
-		return initGithubRetriever(*c.GithubRetriever)
-	}
-
-	if c.S3Retriever != nil {
-		// Create an AWS session
-		sess, err := session.NewSession(&c.S3Retriever.AwsConfig)
-		if err != nil {
-			return nil, err
-		}
-
-		// Create a new AWS S3 downloader
-		downloader := s3manager.NewDownloader(sess)
-		return retriever.NewS3Retriever(
-			downloader,
-			c.S3Retriever.Bucket,
-			c.S3Retriever.Item,
-		), nil
-	}
-
-	if c.HTTPRetriever != nil {
-		return initHTTPRetriever(*c.HTTPRetriever)
-	}
-
-	if c.LocalFile != "" {
-		return retriever.NewLocalRetriever(c.LocalFile), nil
-	}
-	return nil, errors.New("please add a config to get the flag config file")
-}
-
-// initGithubRetriever creates a HTTP retriever that allows to get changes from Github.
-func initGithubRetriever(r GithubRetriever) (retriever.FlagRetriever, error) {
+func (r *GithubRetriever) getFlagRetriever() (retriever.FlagRetriever, error) {
 	// default branch is main
 	branch := r.Branch
 	if branch == "" {
@@ -104,28 +126,12 @@ func initGithubRetriever(r GithubRetriever) (retriever.FlagRetriever, error) {
 		branch,
 		r.FilePath)
 
-	return initHTTPRetriever(HTTPRetriever{
+	httpRetriever := HTTPRetriever{
 		URL:     URL,
 		Method:  http.MethodGet,
 		Header:  header,
 		Timeout: r.Timeout,
-	})
-}
-
-// initHttpRetriever creates a HTTP retriever
-func initHTTPRetriever(r HTTPRetriever) (retriever.FlagRetriever, error) {
-	timeout := r.Timeout
-	if timeout <= 0 {
-		timeout = 10 * time.Second
 	}
 
-	return retriever.NewHTTPRetriever(
-		&http.Client{
-			Timeout: timeout,
-		},
-		r.URL,
-		r.Method,
-		r.Body,
-		r.Header,
-	), nil
+	return httpRetriever.getFlagRetriever()
 }

--- a/config.go
+++ b/config.go
@@ -21,11 +21,7 @@ type Config struct {
 	PollInterval    int // Poll every X seconds
 	Logger          *log.Logger
 	Context         context.Context // default is context.Background()
-	LocalFile       string
 	Retriever       Retriever
-	HTTPRetriever   *HTTPRetriever
-	S3Retriever     *S3Retriever
-	GithubRetriever *GithubRetriever
 }
 
 // GetRetriever returns a retriever.FlagRetriever configure with the retriever available in the config.

--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -37,7 +37,7 @@ func TestS3RetrieverReturnError(t *testing.T) {
 	// Valid use case
 	err := ffclient.Init(ffclient.Config{
 		PollInterval: 0,
-		S3Retriever: &ffclient.S3Retriever{
+		Retriever: &ffclient.S3Retriever{
 			Bucket:    "unknown-bucket",
 			Item:      "unknown-item",
 			AwsConfig: aws.Config{},

--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -21,7 +21,7 @@ func TestValidUseCase(t *testing.T) {
 	// Valid use case
 	err := ffclient.Init(ffclient.Config{
 		PollInterval: 0,
-		LocalFile:    "testdata/test.yaml",
+		Retriever:    &ffclient.FileRetriever{Path: "testdata/test.yaml"},
 	})
 
 	assert.NoError(t, err)


### PR DESCRIPTION
# Description
⚠️  this PR include breaking changes.

In this PR I change the way to pass the `Retriever` in the config.
We don't have a property for each type of Retriever but only on `Retriever` which can manage all types of Retriever.

## Why?
The main reason is to have the `aws/aws-sdk-go` as a dependency only if you are using the `S3Retriever`. With this new syntax, we don't force you to have the SDK if you are not using it.

## How to migrate
If you were using `HTTPRetriever`, `S3Retriever` or `GithubRetriever`, the change consists only of changing the key in the config.

```go
// Before v0.5.0
err := ffclient.Init(ffclient.Config{
    PollInterval: 3,
    HTTPRetriever: &ffClient.HTTPRetriever{
        URL:    "http://example.com/test.yaml",
    },
})

// Since v0.5.0
err := ffclient.Init(ffclient.Config{
    PollInterval: 3,
    Retriever: &ffclient.HTTPRetriever{
        URL:    "http://example.com/test.yaml",
    },
})
```

It is a bit different for the flag configuration, I have introduced a `FileRetriever` to keep the same format for all retrievers.

```go
// Before v0.5.0
err := ffclient.Init(ffclient.Config{
    PollInterval: 3,
    LocalFile: "file-example.yaml",
})

// Since v0.5.0
err := ffclient.Init(ffclient.Config{
    PollInterval: 3,
    Retriever: &ffclient.FileRetriever{
        Path:    "file-example.yaml",
    },
})
```



# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #42

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
