### PR TITLE
Allow multiple go-feature-flag

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,3 +52,4 @@ issues:
         - gocyclo
         - gochecknoinits
         - dupl
+        - staticcheck

--- a/README.md
+++ b/README.md
@@ -251,5 +251,36 @@ The default value is return when an error is encountered _(`ffclient` not initia
 In the example, if the flag `your.feature.key` does not exists, result will be `false`.  
 Not that you will always have a usable value in the result. 
 
+## Multiple flag configurations
+`go-feature-flag` comes ready to use out of the box by calling the `Init` function and after that it will be available everywhere.
+Since most applications will want to use a single central flag configuration, the `go-feature-flag` package provides this. It is similar to a singleton.
+
+In all of the examples above, they demonstrate using `go-feature-flag` in its singleton style approach.
+
+### Working with multiple go-feature-flag
+
+You can also create many different `go-feature-flag` client for use in your application. 
+Each will have its own unique set of configurations and flags. Each can read from a different config file and from different places. 
+All of the functions that `go-feature-flag` package supports are mirrored as methods on a `goFeatureFlag`.
+
+Example:
+
+```go
+// Valid use case
+x, err := ffclient.New(Config{ Retriever: &ffclient.HTTPRetriever{{URL: "http://example.com/test.yaml",}})
+defer x.Close()
+
+y, err := ffclient.New(Config{ Retriever: &ffclient.HTTPRetriever{{URL: "http://example.com/test2.yaml",}})
+defer y.Close()
+
+user := ffuser.NewUser("user-key")
+x.BoolVariation("test-flag", user, false)
+y.BoolVariation("test-flag", user, false)
+
+// ...
+```
+
+When working with multiple `go-feature-flag`, it is up to the user to keep track of the different `go-feature-flag` instances.
+
 # How can I contribute?
 This project is open for contribution, see the [contributor's guide](CONTRIBUTING.md) for some helpful tips.

--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ In all of the examples above, they demonstrate using `go-feature-flag` in its si
 
 ### Working with multiple go-feature-flag
 
-You can also create many different `go-feature-flag` client for use in your application. 
-Each will have its own unique set of configurations and flags. Each can read from a different config file and from different places. 
+You can also create many different `go-feature-flag` client for use in your application.  
+Each will have its own unique set of configurations and flags. Each can read from a different config file and from different places.  
 All of the functions that `go-feature-flag` package supports are mirrored as methods on a `goFeatureFlag`.
 
 ### Example:

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ You can also create many different `go-feature-flag` client for use in your appl
 Each will have its own unique set of configurations and flags. Each can read from a different config file and from different places. 
 All of the functions that `go-feature-flag` package supports are mirrored as methods on a `goFeatureFlag`.
 
-Example:
+### Example:
 
 ```go
 x, err := ffclient.New(Config{ Retriever: &ffclient.HTTPRetriever{{URL: "http://example.com/test.yaml",}})

--- a/README.md
+++ b/README.md
@@ -266,7 +266,6 @@ All of the functions that `go-feature-flag` package supports are mirrored as met
 Example:
 
 ```go
-// Valid use case
 x, err := ffclient.New(Config{ Retriever: &ffclient.HTTPRetriever{{URL: "http://example.com/test.yaml",}})
 defer x.Close()
 

--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -57,7 +57,6 @@ func TestS3RetrieverReturnError(t *testing.T) {
 }
 
 func Test2GoFeatureFlagInstance(t *testing.T) {
-	// Valid use case
 	gffClient1, err := New(Config{
 		PollInterval: 5,
 		Retriever:    &FileRetriever{Path: "testdata/test.yaml"},

--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -11,20 +11,18 @@ import (
 )
 
 func TestStartWithoutRetriever(t *testing.T) {
-	ff = newGoFeatureFlag(Config{
+	_, err := New(Config{
 		PollInterval: 60,
 	})
-	err := ff.startUpdater()
 	assert.Error(t, err)
 	ff = nil
 }
 
 func TestStartWithNegativeInterval(t *testing.T) {
-	ff = newGoFeatureFlag(Config{
+	_, err := New(Config{
 		PollInterval: -60,
 		Retriever:    &FileRetriever{Path: "testdata/test.yaml"},
 	})
-	err := ff.startUpdater()
 	assert.Error(t, err)
 	ff = nil
 }
@@ -47,7 +45,7 @@ func TestValidUseCase(t *testing.T) {
 }
 
 func TestS3RetrieverReturnError(t *testing.T) {
-	ff = newGoFeatureFlag(Config{
+	_, err := New(Config{
 		Retriever: &S3Retriever{
 			Bucket:    "unknown-bucket",
 			Item:      "unknown-item",
@@ -55,6 +53,36 @@ func TestS3RetrieverReturnError(t *testing.T) {
 		},
 	})
 
-	err := ff.startUpdater()
 	assert.Error(t, err)
+}
+
+func Test2GoFeatureFlagInstance(t *testing.T) {
+	// Valid use case
+	gffClient1, err := New(Config{
+		PollInterval: 5,
+		Retriever:    &FileRetriever{Path: "testdata/test.yaml"},
+		Logger:       log.New(os.Stdout, "", 0),
+	})
+	defer gffClient1.Close()
+
+	gffClient2, err2 := New(Config{
+		PollInterval: 10,
+		Retriever:    &FileRetriever{Path: "testdata/test-instance2.yaml"},
+		Logger:       log.New(os.Stdout, "", 0),
+	})
+	defer gffClient2.Close()
+
+	// Init should be OK for both clients.
+	assert.NoError(t, err)
+	assert.NoError(t, err2)
+
+	user := ffuser.NewUser("random-key")
+
+	// Client1 is supposed to have the flag at true
+	hasTestFlagClient1, _ := gffClient1.BoolVariation("test-flag", user, false)
+	assert.True(t, hasTestFlagClient1, "User should have test flag")
+
+	// Client2 is supposed to have the flag at true
+	hasTestFlagClient2, _ := gffClient2.BoolVariation("test-flag", user, false)
+	assert.False(t, hasTestFlagClient2, "User should have test flag")
 }

--- a/testdata/test-instance2.yaml
+++ b/testdata/test-instance2.yaml
@@ -1,0 +1,13 @@
+test-flag:
+  rule: key eq "random-key"
+  percentage: 0
+  true: true
+  false: false
+  default: false
+
+test-flag2:
+  rule: key eq "not-a-key"
+  percentage: 100
+  true: true
+  false: false
+  default: false

--- a/variation.go
+++ b/variation.go
@@ -15,122 +15,172 @@ const errorWrongVariation = "wrong variation used for flag %v"
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.
 func BoolVariation(flagKey string, user ffuser.User, defaultValue bool) (bool, error) {
-	flag, err := getFlagFromCache(flagKey)
+	return ff.BoolVariation(flagKey, user, defaultValue)
+}
+
+// IntVariation return the value of the flag in int.
+// An error is return if you don't have init the library before calling the function.
+// If the key does not exist we return the default value.
+func IntVariation(flagKey string, user ffuser.User, defaultValue int) (int, error) {
+	return ff.IntVariation(flagKey, user, defaultValue)
+}
+
+// Float64Variation return the value of the flag in float64.
+// An error is return if you don't have init the library before calling the function.
+// If the key does not exist we return the default value.
+func Float64Variation(flagKey string, user ffuser.User, defaultValue float64) (float64, error) {
+	return ff.Float64Variation(flagKey, user, defaultValue)
+}
+
+// StringVariation return the value of the flag in string.
+// An error is return if you don't have init the library before calling the function.
+// If the key does not exist we return the default value.
+func StringVariation(flagKey string, user ffuser.User, defaultValue string) (string, error) {
+	return ff.StringVariation(flagKey, user, defaultValue)
+}
+
+// JSONArrayVariation return the value of the flag in []interface{}.
+// An error is return if you don't have init the library before calling the function.
+// If the key does not exist we return the default value.
+func JSONArrayVariation(flagKey string, user ffuser.User, defaultValue []interface{}) ([]interface{}, error) {
+	return ff.JSONArrayVariation(flagKey, user, defaultValue)
+}
+
+// JSONVariation return the value of the flag in map[string]interface{}.
+// An error is return if you don't have init the library before calling the function.
+// If the key does not exist we return the default value.
+func JSONVariation(
+	flagKey string, user ffuser.User, defaultValue map[string]interface{}) (map[string]interface{}, error) {
+	return ff.JSONVariation(flagKey, user, defaultValue)
+}
+
+// BoolVariation return the value of the flag in boolean.
+// An error is return if you don't have init the library before calling the function.
+// If the key does not exist we return the default value.
+// Note: Use this function only if you are using multiple go-feature-flag instances.
+func (g *GoFeatureFlag) BoolVariation(flagKey string, user ffuser.User, defaultValue bool) (bool, error) {
+	flag, err := g.getFlagFromCache(flagKey)
 	if err != nil {
-		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		g.notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, err
 	}
 
 	res, ok := flag.Value(flagKey, user).(bool)
 	if !ok {
-		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		g.notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
-	notifyVariation(flagKey, user.GetKey(), res)
+	g.notifyVariation(flagKey, user.GetKey(), res)
 	return res, nil
 }
 
-// IntVariation return the value of the flag in boolean.
+// IntVariation return the value of the flag in int.
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.
-func IntVariation(flagKey string, user ffuser.User, defaultValue int) (int, error) {
-	flag, err := getFlagFromCache(flagKey)
+// Note: Use this function only if you are using multiple go-feature-flag instances.
+func (g *GoFeatureFlag) IntVariation(flagKey string, user ffuser.User, defaultValue int) (int, error) {
+	flag, err := g.getFlagFromCache(flagKey)
 	if err != nil {
-		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		g.notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, err
 	}
 
 	res, ok := flag.Value(flagKey, user).(int)
 	if !ok {
-		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		g.notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
-	notifyVariation(flagKey, user.GetKey(), res)
+	g.notifyVariation(flagKey, user.GetKey(), res)
 	return res, nil
 }
 
-// Float64Variation return the value of the flag in boolean.
+// Float64Variation return the value of the flag in float64.
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.
-func Float64Variation(flagKey string, user ffuser.User, defaultValue float64) (float64, error) {
-	flag, err := getFlagFromCache(flagKey)
+// Note: Use this function only if you are using multiple go-feature-flag instances.
+func (g *GoFeatureFlag) Float64Variation(flagKey string, user ffuser.User, defaultValue float64) (float64, error) {
+	flag, err := g.getFlagFromCache(flagKey)
 	if err != nil {
-		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		g.notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, err
 	}
 
 	res, ok := flag.Value(flagKey, user).(float64)
 	if !ok {
-		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		g.notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
-	notifyVariation(flagKey, user.GetKey(), res)
+	g.notifyVariation(flagKey, user.GetKey(), res)
 	return res, nil
 }
 
-// StringVariation return the value of the flag in boolean.
+// StringVariation return the value of the flag in string.
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.
-func StringVariation(flagKey string, user ffuser.User, defaultValue string) (string, error) {
-	flag, err := getFlagFromCache(flagKey)
+// Note: Use this function only if you are using multiple go-feature-flag instances.
+func (g *GoFeatureFlag) StringVariation(flagKey string, user ffuser.User, defaultValue string) (string, error) {
+	flag, err := g.getFlagFromCache(flagKey)
 	if err != nil {
-		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		g.notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, err
 	}
 
 	res, ok := flag.Value(flagKey, user).(string)
 	if !ok {
-		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		g.notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
-	notifyVariation(flagKey, user.GetKey(), res)
+	g.notifyVariation(flagKey, user.GetKey(), res)
 	return res, nil
 }
 
-// JSONArrayVariation return the value of the flag in boolean.
+// JSONArrayVariation return the value of the flag in []interface{}.
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.
-func JSONArrayVariation(flagKey string, user ffuser.User, defaultValue []interface{}) ([]interface{}, error) {
-	flag, err := getFlagFromCache(flagKey)
+// Note: Use this function only if you are using multiple go-feature-flag instances.
+func (g *GoFeatureFlag) JSONArrayVariation(
+	flagKey string, user ffuser.User, defaultValue []interface{}) ([]interface{}, error) {
+	flag, err := g.getFlagFromCache(flagKey)
 	if err != nil {
-		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		g.notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, err
 	}
 
 	res, ok := flag.Value(flagKey, user).([]interface{})
 	if !ok {
-		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		g.notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
-	notifyVariation(flagKey, user.GetKey(), res)
+	g.notifyVariation(flagKey, user.GetKey(), res)
 	return res, nil
 }
 
-// JSONVariation return the value of the flag in boolean.
+// JSONVariation return the value of the flag in map[string]interface{}.
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.
-func JSONVariation(
+// Note: Use this function only if you are using multiple go-feature-flag instances.
+func (g *GoFeatureFlag) JSONVariation(
 	flagKey string, user ffuser.User, defaultValue map[string]interface{}) (map[string]interface{}, error) {
-	flag, err := getFlagFromCache(flagKey)
+	flag, err := g.getFlagFromCache(flagKey)
 	if err != nil {
-		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		g.notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, err
 	}
 
 	res, ok := flag.Value(flagKey, user).(map[string]interface{})
 	if !ok {
-		notifyVariation(flagKey, user.GetKey(), defaultValue)
+		g.notifyVariation(flagKey, user.GetKey(), defaultValue)
 		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
-	notifyVariation(flagKey, user.GetKey(), res)
+	g.notifyVariation(flagKey, user.GetKey(), res)
 	return res, nil
 }
 
 // notifyVariation is logging the evaluation result for a flag
 // if no logger is provided in the configuration we are not logging anything.
-func notifyVariation(flagKey string, userKey string, value interface{}) {
-	if ff.config.Logger != nil {
-		ff.config.Logger.Printf(
+func (g *GoFeatureFlag) notifyVariation(flagKey string, userKey string, value interface{}) {
+	if g.config.Logger != nil {
+		g.config.Logger.Printf(
 			"[%v] user=\"%s\", flag=\"%s\", value=\"%v\"",
 			time.Now().Format(time.RFC3339), userKey, flagKey, value)
 	}
@@ -138,8 +188,8 @@ func notifyVariation(flagKey string, userKey string, value interface{}) {
 
 // getFlagFromCache try to get the flag from the cache.
 // It returns an error if the cache is not init or if the flag is not present or disabled.
-func getFlagFromCache(flagKey string) (flags.Flag, error) {
-	flag, err := ff.cache.GetFlag(flagKey)
+func (g *GoFeatureFlag) getFlagFromCache(flagKey string) (flags.Flag, error) {
+	flag, err := g.cache.GetFlag(flagKey)
 	if err != nil || flag.Disable {
 		return flag, fmt.Errorf(errorFlagNotAvailable, flagKey)
 	}

--- a/variation_test.go
+++ b/variation_test.go
@@ -167,7 +167,7 @@ func TestBoolVariation(t *testing.T) {
 			file, _ := ioutil.TempFile("", "log")
 			logger := log.New(file, "", 0)
 
-			ff = &goFeatureFlag{
+			ff = &GoFeatureFlag{
 				flagUpdater: *gocron.NewScheduler(time.UTC),
 				cache:       tt.args.cacheMock,
 				config: Config{
@@ -329,7 +329,7 @@ func TestFloat64Variation(t *testing.T) {
 			file, _ := ioutil.TempFile("", "log")
 			logger := log.New(file, "", 0)
 
-			ff = &goFeatureFlag{
+			ff = &GoFeatureFlag{
 				flagUpdater: *gocron.NewScheduler(time.UTC),
 				cache:       tt.args.cacheMock,
 				config: Config{
@@ -491,7 +491,7 @@ func TestJSONArrayVariation(t *testing.T) {
 			file, _ := ioutil.TempFile("", "log")
 			logger := log.New(file, "", 0)
 
-			ff = &goFeatureFlag{
+			ff = &GoFeatureFlag{
 				flagUpdater: *gocron.NewScheduler(time.UTC),
 				cache:       tt.args.cacheMock,
 				config: Config{
@@ -653,7 +653,7 @@ func TestJSONVariation(t *testing.T) {
 			file, _ := ioutil.TempFile("", "log")
 			logger := log.New(file, "", 0)
 
-			ff = &goFeatureFlag{
+			ff = &GoFeatureFlag{
 				flagUpdater: *gocron.NewScheduler(time.UTC),
 				cache:       tt.args.cacheMock,
 				config: Config{
@@ -817,7 +817,7 @@ func TestStringVariation(t *testing.T) {
 			file, _ := ioutil.TempFile("", "log")
 			logger := log.New(file, "", 0)
 
-			ff = &goFeatureFlag{
+			ff = &GoFeatureFlag{
 				flagUpdater: *gocron.NewScheduler(time.UTC),
 				cache:       tt.args.cacheMock,
 				config: Config{
@@ -979,7 +979,7 @@ func TestIntVariation(t *testing.T) {
 			file, _ := ioutil.TempFile("", "log")
 			logger := log.New(file, "", 0)
 
-			ff = &goFeatureFlag{
+			ff = &GoFeatureFlag{
 				flagUpdater: *gocron.NewScheduler(time.UTC),
 				cache:       tt.args.cacheMock,
 				config: Config{


### PR DESCRIPTION
# Description
This PR allows you to have multiple `go-feature-flag` instances in the same application.
Nothing changes if you don't need it, you can still use the built-in singleton like provided by the package.

If you need to use files from different places you can create your own instance of `go-feature-flag`:

```go
x, err := ffclient.New(Config{ Retriever: &ffclient.HTTPRetriever{{URL: "http://example.com/test.yaml",}})
defer x.Close()
y, err := ffclient.New(Config{ Retriever: &ffclient.HTTPRetriever{{URL: "http://example.com/test2.yaml",}})
defer y.Close()

user := ffuser.NewUser("user-key")
x.BoolVariation("test-flag", user, false)
y.BoolVariation("test-flag", user, false)
// ...
```

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
Resolve #56

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
