### PR TITLE
Create a notification system when flags changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ lint:
 	./bin/golangci-lint run --deadline=65s ./...
 
 test:
-	GO111MODULE=off go get -u github.com/jstemmer/go-junit-report
 ifeq ($(CI), true)
+	GO111MODULE=off go get -u github.com/jstemmer/go-junit-report
 	$(GOTEST) -v -race ./... | tee /dev/tty | go-junit-report -set-exit-code > /tmp/test-results/junit-report.xml
 else
 	$(GOTEST) -v -race ./...

--- a/feature_flag.go
+++ b/feature_flag.go
@@ -57,10 +57,10 @@ func New(config Config) (*GoFeatureFlag, error) {
 	}
 
 	goFF := &GoFeatureFlag{
-		cache:     cache.New(config.Logger),
 		config:    config,
 		bgUpdater: newBackgroundUpdater(config.PollInterval),
 	}
+	goFF.cache = cache.New(cache.NewService(goFF.getNotifiers()))
 
 	// fail if we cannot retrieve the flags the 1st time
 	err := retrieveFlagsAndUpdateCache(goFF.config, goFF.cache)
@@ -95,6 +95,15 @@ func (g *GoFeatureFlag) startFlagUpdaterDaemon() {
 			return
 		}
 	}
+}
+
+// getNotifiers is creating Notifier from the config
+func (g *GoFeatureFlag) getNotifiers() []cache.Notifier {
+	var notifiers []cache.Notifier
+	if g.config.Logger != nil {
+		notifiers = append(notifiers, &cache.LogNotifier{Logger: g.config.Logger})
+	}
+	return notifiers
 }
 
 // retrieveFlagsAndUpdateCache is called every X seconds to refresh the cache flag.

--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -15,6 +15,7 @@ import (
 func TestStartWithoutRetriever(t *testing.T) {
 	_, err := New(Config{
 		PollInterval: 60,
+		Logger:       log.New(os.Stdout, "", 0),
 	})
 	assert.Error(t, err)
 	ff = nil
@@ -24,6 +25,7 @@ func TestStartWithNegativeInterval(t *testing.T) {
 	_, err := New(Config{
 		PollInterval: -60,
 		Retriever:    &FileRetriever{Path: "testdata/test.yaml"},
+		Logger:       log.New(os.Stdout, "", 0),
 	})
 	assert.Error(t, err)
 	ff = nil
@@ -53,6 +55,7 @@ func TestS3RetrieverReturnError(t *testing.T) {
 			Item:      "unknown-item",
 			AwsConfig: aws.Config{},
 		},
+		Logger: log.New(os.Stdout, "", 0),
 	})
 
 	assert.Error(t, err)
@@ -102,6 +105,7 @@ func TestUpdateFlag(t *testing.T) {
 	gffClient1, _ := New(Config{
 		PollInterval: 1,
 		Retriever:    &FileRetriever{Path: flagFile.Name()},
+		Logger:       log.New(os.Stdout, "", 0),
 	})
 	defer gffClient1.Close()
 
@@ -124,4 +128,12 @@ func TestUpdateFlag(t *testing.T) {
 
 	flagValue, _ = gffClient1.BoolVariation("test-flag", ffuser.NewUser("random-key"), false)
 	assert.False(t, flagValue)
+
+	// remove file we should still take the last version in consideration
+	os.Remove(flagFile.Name())
+	time.Sleep(2 * time.Second)
+
+	flagValue, _ = gffClient1.BoolVariation("test-flag", ffuser.NewUser("random-key"), false)
+	assert.False(t, flagValue)
 }
+

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -45,7 +45,7 @@ func (c *cacheImpl) UpdateCache(loadedFlags []byte) error {
 		// copy cache for difference checks async
 		cacheCopy := c.getCacheCopy()
 		c.waitGroup.Add(1)
-		go c.logFlagChangesRoutine(cacheCopy, newCache)
+		go c.notifyFlagsChanges(cacheCopy, newCache)
 	}
 
 	c.mutex.Lock()
@@ -87,9 +87,9 @@ func (c *cacheImpl) GetFlag(key string) (flags.Flag, error) {
 	return flag, nil
 }
 
-func (c *cacheImpl) logFlagChangesRoutine(oldCache map[string]flags.Flag, newCache map[string]flags.Flag) {
+func (c *cacheImpl) notifyFlagsChanges(oldCache map[string]flags.Flag, newCache map[string]flags.Flag) {
+	defer c.waitGroup.Done()
 	c.logFlagChanges(oldCache, newCache)
-	c.waitGroup.Done()
 }
 
 // logFlagChanges is logging if something has changed in your flag config file

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -3,11 +3,8 @@ package cache
 import (
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
 	"gopkg.in/yaml.v3"
-	"log"
 	"sync"
-	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/internal/flags"
 )
@@ -17,59 +14,46 @@ type Cache interface {
 	Close()
 	GetFlag(key string) (flags.Flag, error)
 }
+
 type cacheImpl struct {
-	Logger     *log.Logger
-	flagsCache map[string]flags.Flag
-	mutex      sync.RWMutex
-	waitGroup  sync.WaitGroup
+	flagsCache          FlagsCache
+	mutex               sync.RWMutex
+	notificationService Service
 }
 
-func New(logger *log.Logger) Cache {
+func New(notificationService Service) Cache {
 	return &cacheImpl{
-		flagsCache: make(map[string]flags.Flag),
-		mutex:      sync.RWMutex{},
-		Logger:     logger,
-		waitGroup:  sync.WaitGroup{},
+		flagsCache:          make(map[string]flags.Flag),
+		mutex:               sync.RWMutex{},
+		notificationService: notificationService,
 	}
 }
 
 func (c *cacheImpl) UpdateCache(loadedFlags []byte) error {
-	var newCache map[string]flags.Flag
+	var newCache FlagsCache
 	err := yaml.Unmarshal(loadedFlags, &newCache)
 	if err != nil {
 		return err
 	}
 
-	// launching a go routine to log the differences
-	if c.Logger != nil {
-		// copy cache for difference checks async
-		cacheCopy := c.getCacheCopy()
-		c.waitGroup.Add(1)
-		go c.notifyFlagsChanges(cacheCopy, newCache)
-	}
+	// copy cache for difference checks async
+	cacheCopy := c.flagsCache.Copy()
 
 	c.mutex.Lock()
 	c.flagsCache = newCache
 	c.mutex.Unlock()
+
+	// notify the changes
+	c.notificationService.Notify(cacheCopy, newCache)
 	return nil
 }
 
 func (c *cacheImpl) Close() {
-	// Wait for the logs to finish
-	c.waitGroup.Wait()
-
 	// Clear the cache
 	c.mutex.Lock()
 	c.flagsCache = nil
 	c.mutex.Unlock()
-}
-
-func (c *cacheImpl) getCacheCopy() map[string]flags.Flag {
-	copyCache := make(map[string]flags.Flag)
-	for k, v := range c.flagsCache {
-		copyCache[k] = v
-	}
-	return copyCache
+	c.notificationService.Close()
 }
 
 func (c *cacheImpl) GetFlag(key string) (flags.Flag, error) {
@@ -85,40 +69,4 @@ func (c *cacheImpl) GetFlag(key string) (flags.Flag, error) {
 		return flags.Flag{}, fmt.Errorf("flag [%v] does not exists", key)
 	}
 	return flag, nil
-}
-
-func (c *cacheImpl) notifyFlagsChanges(oldCache map[string]flags.Flag, newCache map[string]flags.Flag) {
-	defer c.waitGroup.Done()
-	c.logFlagChanges(oldCache, newCache)
-}
-
-// logFlagChanges is logging if something has changed in your flag config file
-func (c *cacheImpl) logFlagChanges(oldCache map[string]flags.Flag, newCache map[string]flags.Flag) {
-	date := time.Now().Format(time.RFC3339)
-	for key := range oldCache {
-		_, inNewCache := newCache[key]
-		if !inNewCache {
-			c.Logger.Printf("[%v] flag %v removed\n", date, key)
-			continue
-		}
-
-		if oldCache[key].Disable != newCache[key].Disable {
-			if newCache[key].Disable {
-				// Flag is disabled
-				c.Logger.Printf("[%v] flag %v is turned OFF\n", date, key)
-			} else {
-				c.Logger.Printf("[%v] flag %v is turned ON (flag=[%v])  \n", date, key, newCache[key])
-			}
-		} else if !cmp.Equal(oldCache[key], newCache[key]) {
-			// key has changed in cache
-			c.Logger.Printf("[%v] flag %s updated, old=[%v], new=[%v]\n", date, key, oldCache[key], newCache[key])
-		}
-	}
-
-	for key := range newCache {
-		_, inOldCache := oldCache[key]
-		if !inOldCache && !newCache[key].Disable {
-			c.Logger.Printf("[%v] flag %v added\n", date, key)
-		}
-	}
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -2,15 +2,9 @@ package cache
 
 import (
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
-	"io/ioutil"
-	"log"
-	"os"
-	"sync"
 	"testing"
 
 	"github.com/thomaspoignant/go-feature-flag/internal/flags"
-	"github.com/thomaspoignant/go-feature-flag/testutil"
 )
 
 func Test_FlagCacheNotInit(t *testing.T) {
@@ -95,127 +89,4 @@ func Test_FlagCache(t *testing.T) {
 	}
 }
 
-func Test_LogFlagChanges(t *testing.T) {
-	exampleFile := []byte(`test-flag:
-  rule: key eq "random-key"
-  percentage: 100
-  true: true
-  false: false
-  default: false
-`)
 
-	type args struct {
-		oldFlag     []byte
-		loadedFlags []byte
-	}
-	tests := []struct {
-		name     string
-		args     args
-		expected string
-	}{
-		{
-			name: "Update flag",
-			args: args{
-				oldFlag: exampleFile,
-				loadedFlags: []byte(`test-flag:
-  percentage: 100
-  true: true
-  false: false
-  default: false`),
-			},
-			expected: "\\[" + testutil.RFC3339Regex + "\\] flag test-flag updated, old=\\[percentage=100%, rule=\"key eq \"random-key\"\", true=\"true\", false=\"false\", true=\"false\", disable=\"false\"\\], new=\\[percentage=100%, true=\"true\", false=\"false\", true=\"false\", disable=\"false\"\\]",
-		},
-		{
-			name: "Remove flag",
-			args: args{
-				oldFlag:     exampleFile,
-				loadedFlags: []byte(``),
-			},
-			expected: "\\[" + testutil.RFC3339Regex + "\\] flag test-flag removed",
-		},
-		{
-			name: "Disable flag",
-			args: args{
-				oldFlag: exampleFile,
-				loadedFlags: []byte(`test-flag:
-  rule: key eq "random-key"
-  disable: true
-  percentage: 100
-  true: true
-  false: false
-  default: false
-`),
-			},
-			expected: "\\[" + testutil.RFC3339Regex + "\\] flag test-flag is turned OFF",
-		},
-		{
-			name: "Add flag",
-			args: args{
-				oldFlag: exampleFile,
-				loadedFlags: []byte(`test-flag:
-  rule: key eq "random-key"
-  percentage: 100
-  true: true
-  false: false
-  default: false
-add-test-flag:
-  rule: key eq "random-key"
-  percentage: 100
-  true: true
-  false: false
-  default: false`),
-			},
-			expected: "\\[" + testutil.RFC3339Regex + "\\] flag add-test-flag added",
-		},
-		{
-			name: "Enable flag",
-			args: args{
-				oldFlag: []byte(`test-flag:
-  rule: key eq "random-key"
-  disable: true
-  percentage: 100
-  true: true
-  false: false
-  default: false
-`),
-				loadedFlags: []byte(`test-flag:
-  rule: key eq "random-key"
-  disable: false
-  percentage: 100
-  true: true
-  false: false
-  default: false
-`),
-			},
-			expected: "\\[" + testutil.RFC3339Regex + "\\] flag test-flag is turned ON \\(flag=\\[percentage=100%, rule=\"key eq \"random-key\"\", true=\"true\", false=\"false\", true=\"false\", disable=\"false\"\\]\\)",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var oldValue map[string]flags.Flag
-			_ = yaml.Unmarshal(tt.args.oldFlag, &oldValue)
-
-			// create temp log file
-			logOutput, _ := ioutil.TempFile("", "")
-
-			fCache := cacheImpl{
-				flagsCache: oldValue,
-				mutex:      sync.RWMutex{},
-				notificationService: NewService([]Notifier{
-					&LogNotifier{Logger: log.New(logOutput, "", 0)},
-				}),
-			}
-
-			// log cache differences
-			_ = fCache.UpdateCache(tt.args.loadedFlags)
-
-			// get the logs
-			log, _ := ioutil.ReadFile(logOutput.Name())
-			assert.Regexp(t, tt.expected, string(log))
-
-			// Remove temp log file
-			os.Remove(logOutput.Name())
-			fCache.Close()
-		})
-	}
-}

--- a/internal/cache/diff_cache.go
+++ b/internal/cache/diff_cache.go
@@ -1,0 +1,21 @@
+package cache
+
+import "github.com/thomaspoignant/go-feature-flag/internal/flags"
+
+// diffCache contains the changes made in the cache, to be able
+// to notify the user that something has changed (logs, webhook ...)
+type diffCache struct {
+	Deleted map[string]flags.Flag
+	Added   map[string]flags.Flag
+	Updated map[string]diffUpdated
+}
+
+// hasDiff check if we have differences
+func (d diffCache) hasDiff() bool {
+	return len(d.Deleted) > 0 || len(d.Added) > 0 || len(d.Updated) > 0
+}
+
+type diffUpdated struct {
+	Before flags.Flag
+	After  flags.Flag
+}

--- a/internal/cache/flag_cache.go
+++ b/internal/cache/flag_cache.go
@@ -1,0 +1,13 @@
+package cache
+
+import "github.com/thomaspoignant/go-feature-flag/internal/flags"
+
+type FlagsCache map[string]flags.Flag
+
+func (fc FlagsCache) Copy() FlagsCache {
+	copyCache := make(FlagsCache)
+	for k, v := range fc {
+		copyCache[k] = v
+	}
+	return copyCache
+}

--- a/internal/cache/flag_cache_test.go
+++ b/internal/cache/flag_cache_test.go
@@ -1,0 +1,37 @@
+package cache
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFlagsCache_Copy(t *testing.T) {
+	tests := []struct {
+		name string
+		fc   FlagsCache
+	}{
+		{
+			name: "Copy with values",
+			fc: FlagsCache{
+				"test": {
+					Disable:    false,
+					Rule:       "key eq \"toto\"",
+					Percentage: 20,
+					True:       true,
+					False:      false,
+					Default:    true,
+				},
+			},
+		},
+		{
+			name: "Copy without value",
+			fc:   FlagsCache{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.fc.Copy()
+			assert.Equal(t, tt.fc, got)
+		})
+	}
+}

--- a/internal/cache/notification_service.go
+++ b/internal/cache/notification_service.go
@@ -63,7 +63,7 @@ func (c *notificationService) getDifferences(
 
 	for key := range newCache {
 		if _, inOldCache := oldCache[key]; !inOldCache {
-			diff.Added[key] = oldCache[key]
+			diff.Added[key] = newCache[key]
 		}
 	}
 	return diff

--- a/internal/cache/notification_service.go
+++ b/internal/cache/notification_service.go
@@ -1,0 +1,70 @@
+package cache
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"sync"
+
+	"github.com/thomaspoignant/go-feature-flag/internal/flags"
+)
+
+type Service interface {
+	Close()
+	Notify(oldCache FlagsCache, newCache FlagsCache)
+}
+
+func NewService(notifiers []Notifier) Service {
+	return &notificationService{
+		Notifiers: notifiers,
+		waitGroup: &sync.WaitGroup{},
+	}
+}
+
+type notificationService struct {
+	Notifiers []Notifier
+	waitGroup *sync.WaitGroup
+}
+
+func (c *notificationService) Notify(oldCache FlagsCache, newCache FlagsCache) {
+	diff := c.getDifferences(oldCache, newCache)
+	if diff.hasDiff() {
+		for _, notifier := range c.Notifiers {
+			c.waitGroup.Add(1)
+			go notifier.Notify(diff, c.waitGroup)
+		}
+	}
+}
+
+func (c *notificationService) Close() {
+	c.waitGroup.Wait()
+}
+
+// getDifferences is checking what are the difference in the updated cache.
+func (c *notificationService) getDifferences(
+	oldCache FlagsCache, newCache FlagsCache) diffCache {
+	diff := diffCache{
+		Deleted: map[string]flags.Flag{},
+		Added:   map[string]flags.Flag{},
+		Updated: map[string]diffUpdated{},
+	}
+	for key := range oldCache {
+		_, inNewCache := newCache[key]
+		if !inNewCache {
+			diff.Deleted[key] = oldCache[key]
+			continue
+		}
+
+		if !cmp.Equal(oldCache[key], newCache[key]) {
+			diff.Updated[key] = diffUpdated{
+				Before: oldCache[key],
+				After:  newCache[key],
+			}
+		}
+	}
+
+	for key := range newCache {
+		if _, inOldCache := oldCache[key]; !inOldCache {
+			diff.Added[key] = oldCache[key]
+		}
+	}
+	return diff
+}

--- a/internal/cache/notification_service_test.go
+++ b/internal/cache/notification_service_test.go
@@ -1,0 +1,155 @@
+package cache
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+
+	"github.com/thomaspoignant/go-feature-flag/internal/flags"
+)
+
+func Test_notificationService_getDifferences(t *testing.T) {
+	type fields struct {
+		Notifiers []Notifier
+	}
+	type args struct {
+		oldCache FlagsCache
+		newCache FlagsCache
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   diffCache
+	}{
+		{
+			name: "Delete flag",
+			args: args{
+				oldCache: FlagsCache{
+					"test-flag": flags.Flag{
+						Percentage: 100,
+						True:       true,
+						False:      false,
+						Default:    false,
+					},
+					"test-flag2": flags.Flag{
+						Percentage: 100,
+						True:       true,
+						False:      false,
+						Default:    false,
+					},
+				},
+				newCache: FlagsCache{
+					"test-flag": flags.Flag{
+						Percentage: 100,
+						True:       true,
+						False:      false,
+						Default:    false,
+					},
+				},
+			},
+			want: diffCache{
+				Deleted: map[string]flags.Flag{
+					"test-flag2": {
+						Percentage: 100,
+						True:       true,
+						False:      false,
+						Default:    false,
+					},
+				},
+				Added:   map[string]flags.Flag{},
+				Updated: map[string]diffUpdated{},
+			},
+		},
+		{
+			name: "Added flag",
+			args: args{
+				oldCache: FlagsCache{
+					"test-flag": flags.Flag{
+						Percentage: 100,
+						True:       true,
+						False:      false,
+						Default:    false,
+					},
+				},
+				newCache: FlagsCache{
+					"test-flag": flags.Flag{
+						Percentage: 100,
+						True:       true,
+						False:      false,
+						Default:    false,
+					},
+					"test-flag2": flags.Flag{
+						Percentage: 100,
+						True:       true,
+						False:      false,
+						Default:    false,
+					},
+				},
+			},
+			want: diffCache{
+				Added: map[string]flags.Flag{
+					"test-flag2": {
+						Percentage: 100,
+						True:       true,
+						False:      false,
+						Default:    false,
+					},
+				},
+				Deleted: map[string]flags.Flag{},
+				Updated: map[string]diffUpdated{},
+			},
+		},
+		{
+			name: "Updated flag",
+			args: args{
+				oldCache: FlagsCache{
+					"test-flag": flags.Flag{
+						Percentage: 100,
+						True:       true,
+						False:      false,
+						Default:    false,
+					},
+				},
+				newCache: FlagsCache{
+					"test-flag": flags.Flag{
+						Percentage: 100,
+						True:       true,
+						False:      false,
+						Default:    true,
+					},
+				},
+			},
+			want: diffCache{
+				Added:   map[string]flags.Flag{},
+				Deleted: map[string]flags.Flag{},
+				Updated: map[string]diffUpdated{
+					"test-flag": {
+						Before: flags.Flag{
+							Percentage: 100,
+							True:       true,
+							False:      false,
+							Default:    false,
+						},
+						After: flags.Flag{
+							Percentage: 100,
+							True:       true,
+							False:      false,
+							Default:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &notificationService{
+				Notifiers: tt.fields.Notifiers,
+				waitGroup: &sync.WaitGroup{},
+			}
+			got := c.getDifferences(tt.args.oldCache, tt.args.newCache)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/cache/notifier.go
+++ b/internal/cache/notifier.go
@@ -1,0 +1,7 @@
+package cache
+
+import "sync"
+
+type Notifier interface {
+	Notify(cache diffCache, waitGroup *sync.WaitGroup)
+}

--- a/internal/cache/notifier_log.go
+++ b/internal/cache/notifier_log.go
@@ -1,0 +1,37 @@
+package cache
+
+import (
+	"log"
+	"sync"
+	"time"
+)
+
+type LogNotifier struct {
+	Logger *log.Logger
+}
+
+func (c *LogNotifier) Notify(diff diffCache, wg *sync.WaitGroup) {
+	defer wg.Done()
+	date := time.Now().Format(time.RFC3339)
+	for key := range diff.Deleted {
+		c.Logger.Printf("[%v] flag %v removed\n", date, key)
+	}
+
+	for key := range diff.Added {
+		c.Logger.Printf("[%v] flag %v added\n", date, key)
+	}
+
+	for key, flagDiff := range diff.Updated {
+		if flagDiff.After.Disable != flagDiff.Before.Disable {
+			if flagDiff.After.Disable {
+				// Flag is disabled
+				c.Logger.Printf("[%v] flag %v is turned OFF\n", date, key)
+				continue
+			}
+			c.Logger.Printf("[%v] flag %v is turned ON (flag=[%v])  \n", date, key, flagDiff.After)
+			continue
+		}
+		// key has changed in cache
+		c.Logger.Printf("[%v] flag %s updated, old=[%v], new=[%v]\n", date, key, flagDiff.Before, flagDiff.After)
+	}
+}

--- a/internal/cache/notifier_log_test.go
+++ b/internal/cache/notifier_log_test.go
@@ -1,0 +1,169 @@
+package cache
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"log"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/thomaspoignant/go-feature-flag/internal/flags"
+	"github.com/thomaspoignant/go-feature-flag/testutil"
+)
+
+func TestLogNotifier_Notify(t *testing.T) {
+	type args struct {
+		diff diffCache
+		wg   *sync.WaitGroup
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected string
+	}{
+		{
+			name: "Flag deleted",
+			args: args{
+				diff: diffCache{
+					Deleted: map[string]flags.Flag{
+						"test-flag": {
+							Percentage: 100,
+							True:       true,
+							False:      false,
+							Default:    false,
+						},
+					},
+					Updated: map[string]diffUpdated{},
+					Added:   map[string]flags.Flag{},
+				},
+				wg: &sync.WaitGroup{},
+			},
+			expected: "\\[" + testutil.RFC3339Regex + "\\] flag test-flag removed",
+		},
+		{
+			name: "Update flag",
+			args: args{
+				diff: diffCache{
+					Deleted: map[string]flags.Flag{},
+					Updated: map[string]diffUpdated{
+						"test-flag": {
+							Before: flags.Flag{
+								Rule:       "key eq \"random-key\"",
+								Percentage: 100,
+								True:       true,
+								False:      false,
+								Default:    false,
+							},
+							After: flags.Flag{
+								Percentage: 100,
+								True:       true,
+								False:      false,
+								Default:    false,
+							},
+						},
+					},
+					Added: map[string]flags.Flag{},
+				},
+				wg: &sync.WaitGroup{},
+			},
+			expected: "\\[" + testutil.RFC3339Regex + "\\] flag test-flag updated, old=\\[percentage=100%, rule=\"key eq \"random-key\"\", true=\"true\", false=\"false\", true=\"false\", disable=\"false\"\\], new=\\[percentage=100%, true=\"true\", false=\"false\", true=\"false\", disable=\"false\"\\]",
+		},
+		{
+			name: "Disable flag",
+			args: args{
+				diff: diffCache{
+					Deleted: map[string]flags.Flag{},
+					Updated: map[string]diffUpdated{
+						"test-flag": {
+							Before: flags.Flag{
+								Rule:       "key eq \"random-key\"",
+								Percentage: 100,
+								True:       true,
+								False:      false,
+								Default:    false,
+							},
+							After: flags.Flag{
+								Rule:       "key eq \"random-key\"",
+								Disable:    true,
+								Percentage: 100,
+								True:       true,
+								False:      false,
+								Default:    false,
+							},
+						},
+					},
+					Added: map[string]flags.Flag{},
+				},
+				wg: &sync.WaitGroup{},
+			},
+			expected: "\\[" + testutil.RFC3339Regex + "\\] flag test-flag is turned OFF",
+		},
+		{
+			name: "Add flag",
+			args: args{
+				diff: diffCache{
+					Deleted: map[string]flags.Flag{},
+					Updated: map[string]diffUpdated{},
+					Added: map[string]flags.Flag{
+						"add-test-flag": {
+							Rule:       "key eq \"random-key\"",
+							Percentage: 100,
+							True:       true,
+							False:      false,
+							Default:    false,
+						},
+					},
+				},
+				wg: &sync.WaitGroup{},
+			},
+			expected: "\\[" + testutil.RFC3339Regex + "\\] flag add-test-flag added",
+		},
+		{
+			name: "Enable flag",
+			args: args{
+				diff: diffCache{
+					Deleted: map[string]flags.Flag{},
+					Updated: map[string]diffUpdated{
+						"test-flag": {
+							After: flags.Flag{
+								Rule:       "key eq \"random-key\"",
+								Percentage: 100,
+								True:       true,
+								False:      false,
+								Default:    false,
+							},
+							Before: flags.Flag{
+								Rule:       "key eq \"random-key\"",
+								Disable:    true,
+								Percentage: 100,
+								True:       true,
+								False:      false,
+								Default:    false,
+							},
+						},
+					},
+					Added: map[string]flags.Flag{},
+				},
+				wg: &sync.WaitGroup{},
+			},
+			expected: "\\[" + testutil.RFC3339Regex + "\\] flag test-flag is turned ON \\(flag=\\[percentage=100%, rule=\"key eq \"random-key\"\", true=\"true\", false=\"false\", true=\"false\", disable=\"false\"\\]\\)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logOutput, _ := ioutil.TempFile("", "")
+			defer os.Remove(logOutput.Name())
+
+			c := &LogNotifier{
+				Logger: log.New(logOutput, "", 0),
+			}
+			tt.args.wg.Add(1)
+			c.Notify(tt.args.diff, tt.args.wg)
+			log, _ := ioutil.ReadFile(logOutput.Name())
+			fmt.Println(string(log))
+			assert.Regexp(t, tt.expected, string(log))
+		})
+	}
+}


### PR DESCRIPTION
# Description
This PR is the first element to implement #16 to be notified when a flag change.
Expect no change on how `go-feature-flag` is working, this only refactors how we log the flag changes and makes it easy to had more system for notifications.

The logs are now used as one type of notifications.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
None

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
