### PR TITLE
Don't panic when defer a cache that has failed to init

### DIFF
--- a/feature_flag.go
+++ b/feature_flag.go
@@ -82,11 +82,15 @@ func New(config Config) (*GoFeatureFlag, error) {
 
 // Close wait until thread are done
 func (g *GoFeatureFlag) Close() {
-	// clear the cache
-	g.cache.Close()
 
-	// stop the background updater
-	g.bgUpdater.close()
+	if g != nil {
+		if g.cache != nil {
+			// clear the cache
+			g.cache.Close()
+		}
+
+		g.bgUpdater.close()
+	}
 }
 
 // startFlagUpdaterDaemon is the daemon that refresh the cache every X seconds.

--- a/feature_flag.go
+++ b/feature_flag.go
@@ -82,7 +82,6 @@ func New(config Config) (*GoFeatureFlag, error) {
 
 // Close wait until thread are done
 func (g *GoFeatureFlag) Close() {
-
 	if g != nil {
 		if g.cache != nil {
 			// clear the cache


### PR DESCRIPTION
# Description
If you the `ffclient.Init` method return an error and you don't exit at that moment, the `ffclient.Close` function can panic.

Example:
```go
	err := ffclient.Init(ffclient.Config{
		PollInterval: 3,
		Retriever: &ffclient.FileRetriever{
			Path: "testdata/flag-config2.toml",
		},
		FileFormat: "toml",
	})
	defer ffclient.Close()
```

This PR avoids panic while calling the `Close` method if no cache initialized.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
