### PR TITLE
Deprecate the webhook field to have the field Notifiers instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ ffclient.Init(ffclient.Config{
     Context:        context.Background(),
     Retriever:      &ffclient.FileRetriever{Path: "testdata/flag-config.yaml"},
     FileFormat:     "yaml",
-    Webhooks:       []ffclient.WebhookConfig{
-        {
+    Notifiers: []ffclient.NotifierConfig{
+        &ffclient.WebhookConfig{
             PayloadURL: " https://example.com/hook",
             Secret:     "Secret",
             Meta: map[string]string{
@@ -90,7 +90,8 @@ ffclient.Init(ffclient.Config{
 |`Context`  | The context used by the retriever.<br />The default value is `context.Background()`.|
 |`FileFormat`| Format of your configuration file. Available formats are `yaml`, `toml` and `json`, if you omit the field it will try to unmarshal the file as a `yaml` file.|
 |`Retriever`  | The configuration retriever you want to use to get your flag file *(see [Where do I store my flags file](#where-do-i-store-my-flags-file) for the configuration details)*.|
-|`Webhooks` | List of webhooks to call when your flag file has changed *(see [webhook section](#webhook) for more details)*.|
+|`Notifiers` | List of notifiers to call when your flag file has changed *(see [notifiers section](#notifiers) for more details)*.|
+
 ## Where do I store my flags file
 `go-feature-flags` support different ways of retrieving the flag file.  
 We can have only one source for the file, if you set multiple sources in your configuration, only one will be take in
@@ -280,20 +281,28 @@ The default value is return when an error is encountered _(`ffclient` not initia
 In the example, if the flag `your.feature.key` does not exists, result will be `false`.  
 Not that you will always have a usable value in the result. 
 
-## Webhook
-If you want to be informed when a flag has changed outside of your app, you can configure a webhook.
+## Notifiers
+If you want to be informed when a flag has changed outside of your app, you can configure a **notifier**.
+`go-feature-flag` can handle more than one notifier at a time *(see bellow the list of available notifiers and how to configure them)*.
+
+<details>
+<summary><span style="font-size: 1.2em;font-style: bold;">Webhooks</span></summary>
+
+> :warning: In `v0.9.0` we have changed how to configure webhooks, moving from the key `Webhooks` to `Notifiers`.  
+`Webhooks` is still supported for now but will be removed in a future version.
 
 ```go
 ffclient.Config{ 
     // ...
-    Webhooks: []ffclient.WebhookConfig{
-        {
+    Notifiers: []ffclient.NotifierConfig{
+        &ffclient.WebhookConfig{
             PayloadURL: " https://example.com/hook",
             Secret:     "Secret",
             Meta: map[string]string{
                 "app.name": "my app",
             },
         },
+        // ...
     },
 }
 ```
@@ -303,8 +312,6 @@ ffclient.Config{
 |`PayloadURL`   |![mandatory](https://img.shields.io/badge/-mandatory-red)   | The complete URL of your API *(we will send a POST request to this URL, [see format](#format))*  |
 |`Secret`   |![optional](https://img.shields.io/badge/-optional-green)   |  A secret key you can share with your webhook. We will use this key to sign the request *(see [signature section](#signature) for more details)*. |
 |`Meta`   |![optional](https://img.shields.io/badge/-optional-green)   |  A list of key value that will be add in your request, this is super usefull if you to add information on the current running instance of your app.<br/>*By default the hostname is always added in the meta informations.*|
-
-
 
 ### Format
 If you have configured a webhook, a POST request will be sent to the `PayloadURL` with a body in this format:
@@ -383,6 +390,7 @@ This header **`X-Hub-Signature-256`** is sent if the webhook is configured with 
 
 :warning: **The recommendation is to always use the `Secret` and on your API/webook always verify the signature key to be sure that you don't have a man in the middle attack.**
 
+</details>
 ---
 
 ## Multiple flag configurations

--- a/config.go
+++ b/config.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net/http"
+	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/internal/notifier"
 	"github.com/thomaspoignant/go-feature-flag/internal/retriever"
@@ -102,6 +104,9 @@ type WebhookConfig struct {
 
 // GetNotifier convert the configuration in a Notifier struct
 func (w *WebhookConfig) GetNotifier(config Config) (notifier.Notifier, error) {
-	notifier, err := notifier.NewWebhookNotifier(config.Logger, w.PayloadURL, w.Secret, w.Meta)
+	// httpClient used to call the webhook
+	httpClient := http.DefaultClient
+	httpClient.Timeout = 10 * time.Second
+	notifier, err := notifier.NewWebhookNotifier(config.Logger, httpClient, w.PayloadURL, w.Secret, w.Meta)
 	return &notifier, err
 }

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 
+	"github.com/thomaspoignant/go-feature-flag/internal/notifier"
 	"github.com/thomaspoignant/go-feature-flag/internal/retriever"
 )
 
@@ -12,12 +13,14 @@ import (
 // PollInterval is the interval in seconds where we gonna read the file to update the cache.
 // You should also have a retriever to specify where to read the flags file.
 type Config struct {
-	PollInterval int // Poll every X seconds
-	Logger       *log.Logger
-	Context      context.Context // default is context.Background()
-	Retriever    Retriever
-	Webhooks     []WebhookConfig // webhooks we should call when a flag create/update/delete
-	FileFormat   string
+	PollInterval int              // Poll every X seconds
+	Logger       *log.Logger      // Logger use by the library
+	Context      context.Context  // default is context.Background()
+	Retriever    Retriever        // Retriever is the component in charge to retrieve your flag file
+	Notifiers    []NotifierConfig // Notifiers is the list of notifiers called when a flag change
+	FileFormat   string           // FileFormat is the format of the file to retrieve (available YAML, TOML and JSON)
+	// Deprecated: Use Notifiers instead, webhooks will be delete in a future version
+	Webhooks []WebhookConfig // webhooks we should call when a flag create/update/delete
 }
 
 // GetRetriever returns a retriever.FlagRetriever configure with the retriever available in the config.
@@ -26,6 +29,23 @@ func (c *Config) GetRetriever() (retriever.FlagRetriever, error) {
 		return nil, errors.New("no retriever in the configuration, impossible to get the flags")
 	}
 	return c.Retriever.getFlagRetriever()
+}
+
+// NotifierConfig is the interface for your notifiers.
+// You can use as notifier a WebhookConfig
+//
+// Notifiers: []ffclient.NotifierConfig{
+//        &ffclient.WebhookConfig{
+//            PayloadURL: " https://example.com/hook",
+//            Secret:     "Secret",
+//            Meta: map[string]string{
+//                "app.name": "my app",
+//            },
+//        },
+//        // ...
+//    }
+type NotifierConfig interface {
+	GetNotifier(config Config) (notifier.Notifier, error)
 }
 
 // WebhookConfig is the configuration of your webhook.
@@ -73,9 +93,15 @@ func (c *Config) GetRetriever() (retriever.FlagRetriever, error) {
 //            }
 //        }
 //    }
-//   }
+//  }
 type WebhookConfig struct {
 	PayloadURL string            // PayloadURL of your webhook
 	Secret     string            // Secret used to sign your request body.
 	Meta       map[string]string // Meta information that you want to send to your webhook (not mandatory)
+}
+
+// GetNotifier convert the configuration in a Notifier struct
+func (w *WebhookConfig) GetNotifier(config Config) (notifier.Notifier, error) {
+	notifier, err := notifier.NewWebhookNotifier(config.Logger, w.PayloadURL, w.Secret, w.Meta)
+	return &notifier, err
 }

--- a/config.go
+++ b/config.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"errors"
 	"log"
-	"net/http"
-	"time"
 
+	"github.com/thomaspoignant/go-feature-flag/internal"
 	"github.com/thomaspoignant/go-feature-flag/internal/notifier"
 	"github.com/thomaspoignant/go-feature-flag/internal/retriever"
 )
@@ -104,9 +103,9 @@ type WebhookConfig struct {
 
 // GetNotifier convert the configuration in a Notifier struct
 func (w *WebhookConfig) GetNotifier(config Config) (notifier.Notifier, error) {
-	// httpClient used to call the webhook
-	httpClient := http.DefaultClient
-	httpClient.Timeout = 10 * time.Second
-	notifier, err := notifier.NewWebhookNotifier(config.Logger, httpClient, w.PayloadURL, w.Secret, w.Meta)
+	notifier, err := notifier.NewWebhookNotifier(
+		config.Logger,
+		internal.DefaultHTTPClient(),
+		w.PayloadURL, w.Secret, w.Meta)
 	return &notifier, err
 }

--- a/internal/HTTPClient.go
+++ b/internal/HTTPClient.go
@@ -1,8 +1,21 @@
 package internal
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 // HTTPClient is an interface over http.Client to make mock easier.
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
+}
+
+func DefaultHTTPClient() HTTPClient {
+	return HTTPClientWithTimeout(10 * time.Second)
+}
+
+func HTTPClientWithTimeout(timeout time.Duration) HTTPClient {
+	httpClient := http.DefaultClient
+	httpClient.Timeout = timeout
+	return httpClient
 }

--- a/internal/notifier/notifier_webhook.go
+++ b/internal/notifier/notifier_webhook.go
@@ -19,21 +19,21 @@ import (
 )
 
 func NewWebhookNotifier(logger *log.Logger,
+	httpClient internal.HTTPClient,
 	payloadURL string,
 	secret string,
 	meta map[string]string,
 ) (WebhookNotifier, error) {
-	// httpClient used to call the webhook
-	httpClient := http.Client{
-		Timeout: 10 * time.Second,
-	}
-
 	// Deal with meta information
 	if meta == nil {
 		meta = make(map[string]string)
 	}
-	hostname, _ := os.Hostname()
-	meta["hostname"] = hostname
+
+	// if no hostname provided we return the hostname of the current machine
+	if _, ok := meta["hostname"]; !ok {
+		hostname, _ := os.Hostname()
+		meta["hostname"] = hostname
+	}
 
 	parsedURL, err := url.Parse(payloadURL)
 	if err != nil {
@@ -45,7 +45,7 @@ func NewWebhookNotifier(logger *log.Logger,
 		PayloadURL: *parsedURL,
 		Secret:     secret,
 		Meta:       meta,
-		HTTPClient: &httpClient,
+		HTTPClient: httpClient,
 	}
 	return w, nil
 }

--- a/internal/notifier/notifier_webhook_test.go
+++ b/internal/notifier/notifier_webhook_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"sync"
 	"testing"
@@ -163,16 +162,15 @@ func Test_webhookNotifier_Notify(t *testing.T) {
 			defer logFile.Close()
 			defer os.Remove(logFile.Name())
 
-			webhookURL, _ := url.Parse("http://webhook.example/hook")
 			mockHTTPClient := &httpClientMock{statusCode: tt.args.statusCode, forceError: tt.args.forceError}
 
-			c := WebhookNotifier{
-				Logger:     log.New(logFile, "", 0),
-				HTTPClient: mockHTTPClient,
-				PayloadURL: *webhookURL,
-				Secret:     tt.fields.Secret,
-				Meta:       map[string]string{"hostname": "toto"},
-			}
+			c, _ := NewWebhookNotifier(
+				log.New(logFile, "", 0),
+				mockHTTPClient,
+				"http://webhook.example/hook",
+				tt.fields.Secret,
+				map[string]string{"hostname": "toto"},
+			)
 
 			w := sync.WaitGroup{}
 			w.Add(1)

--- a/notifier.go
+++ b/notifier.go
@@ -11,20 +11,32 @@ import (
 
 // getNotifiers is creating Notifier from the config
 func getNotifiers(config Config) ([]notifier.Notifier, error) {
-	var notifiers []notifier.Notifier
+	notifiers := make([]notifier.Notifier, 0)
 	if config.Logger != nil {
 		notifiers = append(notifiers, &notifier.LogNotifier{Logger: config.Logger})
 	}
 
+	// add all the notifiers
+	for _, whConf := range config.Notifiers {
+		notifier, err := whConf.GetNotifier(config)
+		if err != nil {
+			return nil, err
+		}
+		notifiers = append(notifiers, notifier)
+	}
+
+	// Deprecated: we will have to remove that block when webhook will be un-supported
 	wh, err := getWebhooks(config)
 	if err != nil {
 		return nil, err
 	}
-
 	notifiers = append(notifiers, wh...)
+	// end deprecated
+
 	return notifiers, nil
 }
 
+// Deprecated: use getNotifiers instead
 func getWebhooks(config Config) ([]notifier.Notifier, error) {
 	res := make([]notifier.Notifier, len(config.Webhooks))
 	for index, whConf := range config.Webhooks {

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -31,6 +31,39 @@ func TestGoFeatureFlag_getNotifiers(t *testing.T) {
 			fields: fields{
 				config: Config{
 					Logger: log.New(os.Stdout, "", 0),
+					Notifiers: []NotifierConfig{
+						&WebhookConfig{
+							PayloadURL: urlStr,
+							Secret:     "Secret",
+							Meta: map[string]string{
+								"my-app":   "go-ff-test",
+								"hostname": hostname,
+							},
+						},
+					},
+				},
+			},
+			want: []notifier.Notifier{
+				&notifier.LogNotifier{Logger: log.New(os.Stdout, "", 0)},
+				&notifier.WebhookNotifier{
+					Logger: log.New(os.Stdout, "", 0),
+					HTTPClient: &http.Client{
+						Timeout: 10 * time.Second,
+					},
+					PayloadURL: *parsedURL,
+					Secret:     "Secret",
+					Meta: map[string]string{
+						"my-app":   "go-ff-test",
+						"hostname": hostname,
+					},
+				},
+			},
+		},
+		{
+			name: "log + webhook notifier - deprecated webhook",
+			fields: fields{
+				config: Config{
+					Logger: log.New(os.Stdout, "", 0),
 					Webhooks: []WebhookConfig{
 						{
 							PayloadURL: urlStr,
@@ -64,8 +97,8 @@ func TestGoFeatureFlag_getNotifiers(t *testing.T) {
 			fields: fields{
 				config: Config{
 					Logger: log.New(os.Stdout, "", 0),
-					Webhooks: []WebhookConfig{
-						{
+					Notifiers: []NotifierConfig{
+						&WebhookConfig{
 							PayloadURL: " https://example.com/hook",
 							Secret:     "Secret",
 							Meta: map[string]string{

--- a/retriever.go
+++ b/retriever.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/thomaspoignant/go-feature-flag/internal"
 	"github.com/thomaspoignant/go-feature-flag/internal/retriever"
 )
 
@@ -42,9 +43,7 @@ func (r *HTTPRetriever) getFlagRetriever() (retriever.FlagRetriever, error) {
 	}
 
 	return retriever.NewHTTPRetriever(
-		&http.Client{
-			Timeout: timeout,
-		},
+		internal.HTTPClientWithTimeout(timeout),
 		r.URL,
 		r.Method,
 		r.Body,


### PR DESCRIPTION
# Description

- The config field `Webhooks` used to notify an API when a flag has changed is too restrictive because we need to have other types of service to call when a flag has changed.

  This PR introduces a new field called `Notifiers` in place of the `Webhooks` field to be able to have different types of notifiers when a flag has changed _(slack can be a great example)_.

  Based on that the field **`Webhooks`** is deprecated and will continue to be supported in the next versions.
It will be removed in a future release. (Check **migration** section bellow to see how to re-configure your webhooks).

- This PR contains also a small change around the `HTTPClient` used at different place to have a central place where we can configure it.


## Migration
If you were using `Webhooks` before, you should have a configuration like this:
```go
ffclient.Init(ffclient.Config{ 
    Retriever:      &ffclient.FileRetriever{Path: "testdata/flag-config.yaml"},
    FileFormat:     "yaml",
    Webhooks:       []ffclient.WebhookConfig{
        {
            PayloadURL: " https://example.com/hook",
            Secret:     "Secret",
            Meta: map[string]string{
                "app.name": "my app",
            },
        },
    },
}
```
With `Notifiers`, your configuration should looks like this now:
```go
ffclient.Init(ffclient.Config{ 
    Retriever:      &ffclient.FileRetriever{Path: "testdata/flag-config.yaml"},
    FileFormat:     "yaml",
    Notifiers: []ffclient.NotifierConfig{
        &ffclient.WebhookConfig{
            PayloadURL: " https://example.com/hook",
            Secret:     "Secret",
            Meta: map[string]string{
                "app.name": "my app",
            },
        },
    },
}
```


# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
