### PR TITLE
Bump to v1.39.0 version of golangci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+run:
+  skip-dirs:
+    - (^|/)bin($|/)
 linters:
   enable:
     - asciicheck
@@ -13,25 +16,20 @@ linters:
     - golint
     - gosec
     - lll
-    - maligned
     - misspell
     - nakedret
     - noctx
     - prealloc
     - rowserrcheck
-    - scopelint
+    - exportloopref
     - stylecheck
     - unconvert
     - unparam
     - whitespace
-skip-dirs:
-  - docs
 linters-settings:
   funlen:
     lines: 90
     statements: 50
-  maligned:
-    suggest-new: true
   gocritic:
     disabled-checks:
       - singleCaseSwitch

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.31.0
+    rev: v1.39.0
     hooks:
       - id: golangci-lint


### PR DESCRIPTION
# Description
Bump version of `golangci-lint` to `v1.39.0` for `pre-commit`.

# Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
