### PR TITLE
CI: Upgrade CI to go 1.16 + Scope coveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.15
+      - image: circleci/golang:1.16
     working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,12 @@ endif
 coverage:
 	# Create cover profile
 	$(GOTEST) -cover -covermode=count -coverprofile=coverage.out ./...
+ifeq ($(CI), true)
 	# Print code coverage details
 	GO111MODULE=off go get github.com/mattn/goveralls
 	GO111MODULE=off go get golang.org/x/tools/cmd/cover
 	goveralls -service=circle-ci -coverprofile=coverage.out -v -package ./... -repotoken=${COVERALLS_TOKEN}
+endif
 
 vendor:
 	$(GOCMD) mod vendor


### PR DESCRIPTION
# Description
- CircleCI will use go 1.16
- Change in the `Makefile` to send data to **coveralls** only in the CI.

# Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
