### PR TITLE
Add a log data exporter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,8 +439,9 @@ ffclient.Config{
 ## Export data
 If you want to export data about how your flag are used, you can use the **`DataExporter`**.  
 It collects all the variations events and can save these events on several locations:
-- [File](#file-exporter)
-
+- [File](#file-exporter) *- create local files with the variation usages.*
+- [Log](#log-exporter) *- use your logger to write the variation usages*
+ 
 Currently we are supporting only feature events.
 It represent individual flag evaluations and are considered "full fidelity" events.
 
@@ -530,6 +531,33 @@ ffclient.Config{
 |`Filename`   | Filename is the name of your output file. You can use a templated config to define the name of your exported files.<br>Available replacement are `{{ .Hostname}}`, `{{ .Timestamp}`} and `{{ .Format}}`<br>Default: `flag-variation-{{ .Hostname}}-{{ .Timestamp}}.{{ .Format}}`|
 |`CsvTemplate`   |   CsvTemplate is used if your output format is CSV. This field will be ignored if you are using another format than CSV. You can decide which fields you want in your CSV line with a go-template syntax, please check [internal/exporter/feature_event.go](internal/exporter/feature_event.go) to see what are the fields available.<br>**Default:** `{{ .Kind}};{{ .ContextKind}};{{ .UserKey}};{{ .CreationDate}};{{ .Key}};{{ .Variation}};{{ .Value}};{{ .Default}}\n` |
 
+</details>
+
+### Log Exporter
+<details>
+<summary><i>expand to see details</i></summary>
+
+The log exporter is here mostly for backward compatibility *(originaly every variations were logged, but it can be a lot of data for a default configuration)*.  
+It will use your logger `ffclient.Config.Logger` to log every variations changes.
+
+You can configure your output log with the `Format` field. It use a [go template](https://golang.org/pkg/text/template/) format.
+
+**Configuration example:**
+```go
+ffclient.Config{
+    // ...
+   DataExporter: ffclient.DataExporter{
+        Exporter: &ffexporter.Log{
+            Format: "[{{ .FormattedDate}}] user=\"{{ .UserKey}}\", flag=\"{{ .Key}}\", value=\"{{ .Value}}\"",
+        },
+    },
+    // ...
+}
+```
+
+| Field  | Description  |
+|---|---|
+|`Format`   | Format is the [template](https://golang.org/pkg/text/template/) configuration of the output format of your log. You can use all the key from the `exporter.FeatureEvent` + a key called `FormattedDate` that represent the date with the **RFC 3339** Format.<br>Default: `[{{ .FormattedDate}}] user="{{ .UserKey}}", flag="{{ .Key}}", value="{{ .Value}}"`  |
 
 </details>
 

--- a/feature_flag.go
+++ b/feature_flag.go
@@ -84,7 +84,11 @@ func New(config Config) (*GoFeatureFlag, error) {
 		// init the data exporter
 		goFF.dataExporter = exporter.NewDataExporterScheduler(goFF.config.DataExporter.FlushInterval,
 			goFF.config.DataExporter.MaxEventInMemory, goFF.config.DataExporter.Exporter, goFF.config.Logger)
-		go goFF.dataExporter.StartDaemon()
+
+		// we start the daemon only if we have a bulk exporter
+		if goFF.config.DataExporter.Exporter.IsBulk() {
+			go goFF.dataExporter.StartDaemon()
+		}
 	}
 	return goFF, nil
 }

--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -43,7 +42,7 @@ func TestValidUseCase(t *testing.T) {
 			FlushInterval:    10 * time.Second,
 			MaxEventInMemory: 1000,
 			Exporter: &testutils.MockExporter{
-				Mutex: sync.Mutex{},
+				Bulk: true,
 			},
 		},
 	})

--- a/ffexporter/common.go
+++ b/ffexporter/common.go
@@ -17,13 +17,13 @@ const DefaultCsvTemplate = "{{ .Kind}};{{ .ContextKind}};{{ .UserKey}};{{ .Creat
 const DefaultFilenameTemplate = "flag-variation-{{ .Hostname}}-{{ .Timestamp}}.{{ .Format}}"
 
 // parseTemplate is parsing the template given by the config or use the default template
-func parseTemplate(templateToParse string, defaultTemplate string) *template.Template {
+func parseTemplate(name string, templateToParse string, defaultTemplate string) *template.Template {
 	if templateToParse == "" {
 		templateToParse = defaultTemplate
 	}
-	t, err := template.New("exporter").Parse(templateToParse)
+	t, err := template.New(name).Parse(templateToParse)
 	if err != nil {
-		t, _ = template.New("exporter").Parse(defaultTemplate)
+		t, _ = template.New(name).Parse(defaultTemplate)
 	}
 	return t
 }

--- a/ffexporter/common_test.go
+++ b/ffexporter/common_test.go
@@ -38,9 +38,9 @@ func Test_parseTemplate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defaultT, _ := template.New("exporter").Parse(tt.args.defaultTemplate)
-			assert.NotPanics(t, func() { parseTemplate(tt.args.template, tt.args.defaultTemplate) })
-			got := parseTemplate(tt.args.template, tt.args.defaultTemplate)
+			defaultT, _ := template.New("random-name").Parse(tt.args.defaultTemplate)
+			assert.NotPanics(t, func() { parseTemplate("random-name", tt.args.template, tt.args.defaultTemplate) })
+			got := parseTemplate("random-name", tt.args.template, tt.args.defaultTemplate)
 
 			if tt.wantErr {
 				assert.Equal(t, defaultT, got, "If template invalid we should use default template")

--- a/ffexporter/file.go
+++ b/ffexporter/file.go
@@ -45,8 +45,8 @@ type File struct {
 func (f *File) Export(logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
 	// Parse the template only once
 	f.initTemplates.Do(func() {
-		f.csvTemplate = parseTemplate(f.CsvTemplate, DefaultCsvTemplate)
-		f.filenameTemplate = parseTemplate(f.Filename, DefaultFilenameTemplate)
+		f.csvTemplate = parseTemplate("csvFormat", f.CsvTemplate, DefaultCsvTemplate)
+		f.filenameTemplate = parseTemplate("filenameFormat", f.Filename, DefaultFilenameTemplate)
 	})
 
 	// Default format for the output
@@ -91,4 +91,10 @@ func (f *File) Export(logger *log.Logger, featureEvents []exporter.FeatureEvent)
 		}
 	}
 	return nil
+}
+
+// IsBulk return false if we should directly send the data as soon as it is produce
+// and true if we collect the data to send them in bulk.
+func (f *File) IsBulk() bool {
+	return true
 }

--- a/ffexporter/file_test.go
+++ b/ffexporter/file_test.go
@@ -208,3 +208,8 @@ func TestFile_Export(t *testing.T) {
 		})
 	}
 }
+
+func TestFile_IsBulk(t *testing.T) {
+	exporter := ffexporter.File{}
+	assert.True(t, exporter.IsBulk(), "File exporter is a bulk exporter")
+}

--- a/ffexporter/log.go
+++ b/ffexporter/log.go
@@ -1,0 +1,50 @@
+package ffexporter
+
+import (
+	"bytes"
+	"log"
+	"sync"
+	"text/template"
+	"time"
+
+	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
+	"github.com/thomaspoignant/go-feature-flag/internal/fflog"
+)
+
+const defaultLoggerFormat = "[{{ .FormattedDate}}] user=\"{{ .UserKey}}\", flag=\"{{ .Key}}\", value=\"{{ .Value}}\""
+
+type Log struct {
+	// Format is the template configuration of the output format of your log.
+	// You can use all the key from the exporter.FeatureEvent + a key called FormattedDate that represent the date with
+	// the RFC 3339 Format
+	// Default: [{{ .FormattedDate}}] user="{{ .UserKey}}", flag="{{ .Key}}", value="{{ .Value}}"
+	Format string
+
+	logTemplate   *template.Template
+	initTemplates sync.Once
+}
+
+// Export is saving a collection of events in a file.
+func (f *Log) Export(logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
+	f.initTemplates.Do(func() {
+		f.logTemplate = parseTemplate("logFormat", f.Format, defaultLoggerFormat)
+	})
+
+	for _, event := range featureEvents {
+		var log bytes.Buffer
+		err := f.logTemplate.Execute(&log, struct {
+			exporter.FeatureEvent
+			FormattedDate string
+		}{FeatureEvent: event, FormattedDate: time.Unix(event.CreationDate, 0).Format(time.RFC3339)})
+
+		fflog.Printf(logger, log.String())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f *Log) IsBulk() bool {
+	return false
+}

--- a/ffexporter/log_test.go
+++ b/ffexporter/log_test.go
@@ -1,0 +1,64 @@
+package ffexporter_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/thomaspoignant/go-feature-flag/ffexporter"
+	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
+	"github.com/thomaspoignant/go-feature-flag/testutil"
+)
+
+func TestLog_Export(t *testing.T) {
+	type fields struct {
+		Format string
+	}
+	type args struct {
+		featureEvents []exporter.FeatureEvent
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		args        args
+		expectedLog string
+	}{
+		{
+			name:   "Default format",
+			fields: fields{Format: ""},
+			args: args{featureEvents: []exporter.FeatureEvent{
+				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
+					Variation: "Default", Value: "YO", Default: false},
+			}},
+			expectedLog: "\\[" + testutil.RFC3339Regex + "\\] user=\"ABCD\", flag=\"random-key\", value=\"YO\"\n",
+		},
+		{
+			name: "Custom format",
+			fields: fields{
+				Format: "key=\"{{ .Key}}\" [{{ .FormattedDate}}]",
+			},
+			args: args{featureEvents: []exporter.FeatureEvent{
+				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
+					Variation: "Default", Value: "YO", Default: false},
+			}},
+			expectedLog: "key=\"random-key\" \\[" + testutil.RFC3339Regex + "\\]\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &ffexporter.Log{
+				Format: tt.fields.Format,
+			}
+
+			logFile, _ := ioutil.TempFile("", "")
+			logger := log.New(logFile, "", 0)
+
+			err := f.Export(logger, tt.args.featureEvents)
+			assert.NoError(t, err, "Log exporter should not throw errors")
+
+			logContent, _ := ioutil.ReadFile(logFile.Name())
+			assert.Regexp(t, tt.expectedLog, string(logContent))
+		})
+	}
+}

--- a/testutils/MockExporter.go
+++ b/testutils/MockExporter.go
@@ -12,14 +12,17 @@ type MockExporter struct {
 	Err               error
 	ExpectedNumberErr int
 	CurrentNumberErr  int
-	Mutex             sync.Mutex
+	Bulk              bool
+
+	mutex sync.Mutex
+	once  sync.Once
 }
 
 func (m *MockExporter) Export(logger *log.Logger, events []exporter.FeatureEvent) error {
-	m.Mutex.Lock()
+	m.once.Do(m.initMutex)
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	m.ExportedEvents = append(m.ExportedEvents, events...)
-	m.Mutex.Unlock()
-
 	if m.Err != nil {
 		if m.ExpectedNumberErr > m.CurrentNumberErr {
 			m.CurrentNumberErr++
@@ -30,11 +33,16 @@ func (m *MockExporter) Export(logger *log.Logger, events []exporter.FeatureEvent
 }
 
 func (m *MockExporter) GetExportedEvents() []exporter.FeatureEvent {
-	m.Mutex.Lock()
-	defer m.Mutex.Unlock()
+	m.once.Do(m.initMutex)
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	return m.ExportedEvents
 }
 
 func (m *MockExporter) IsBulk() bool {
-	return true
+	return m.Bulk
+}
+
+func (m *MockExporter) initMutex() {
+	m.mutex = sync.Mutex{}
 }

--- a/testutils/MockExporter.go
+++ b/testutils/MockExporter.go
@@ -34,3 +34,7 @@ func (m *MockExporter) GetExportedEvents() []exporter.FeatureEvent {
 	defer m.Mutex.Unlock()
 	return m.ExportedEvents
 }
+
+func (m *MockExporter) IsBulk() bool {
+	return true
+}

--- a/variation.go
+++ b/variation.go
@@ -2,11 +2,9 @@ package ffclient
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/ffuser"
 	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
-	"github.com/thomaspoignant/go-feature-flag/internal/fflog"
 	"github.com/thomaspoignant/go-feature-flag/internal/model"
 )
 
@@ -195,9 +193,6 @@ func (g *GoFeatureFlag) notifyVariation(
 	if g.dataExporter != nil {
 		g.dataExporter.AddEvent(event)
 	}
-
-	fflog.Printf(g.config.Logger, "[%v] user=\"%s\", flag=\"%s\", value=\"%v\"",
-		time.Unix(event.CreationDate, 0).Format(time.RFC3339), event.UserKey, event.Key, event.Value)
 }
 
 // getFlagFromCache try to get the flag from the cache.

--- a/variation_test.go
+++ b/variation_test.go
@@ -5,15 +5,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"log"
-	"sync"
 	"testing"
 
+	"github.com/thomaspoignant/go-feature-flag/ffexporter"
 	"github.com/thomaspoignant/go-feature-flag/ffuser"
 	"github.com/thomaspoignant/go-feature-flag/internal/cache"
 	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
 	"github.com/thomaspoignant/go-feature-flag/internal/model"
 	"github.com/thomaspoignant/go-feature-flag/testutil"
-	"github.com/thomaspoignant/go-feature-flag/testutils"
 )
 
 type cacheMock struct {
@@ -175,7 +174,7 @@ func TestBoolVariation(t *testing.T) {
 					Logger:       logger,
 				},
 				dataExporter: exporter.NewDataExporterScheduler(0, 0,
-					&testutils.MockExporter{Mutex: sync.Mutex{}}, logger),
+					&ffexporter.Log{}, logger),
 			}
 
 			got, err := BoolVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
@@ -336,6 +335,8 @@ func TestFloat64Variation(t *testing.T) {
 					PollInterval: 0,
 					Logger:       logger,
 				},
+				dataExporter: exporter.NewDataExporterScheduler(0, 0,
+					&ffexporter.Log{}, logger),
 			}
 
 			got, err := Float64Variation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
@@ -495,6 +496,8 @@ func TestJSONArrayVariation(t *testing.T) {
 					PollInterval: 0,
 					Logger:       logger,
 				},
+				dataExporter: exporter.NewDataExporterScheduler(0, 0,
+					&ffexporter.Log{}, logger),
 			}
 
 			got, err := JSONArrayVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
@@ -654,6 +657,8 @@ func TestJSONVariation(t *testing.T) {
 					PollInterval: 0,
 					Logger:       logger,
 				},
+				dataExporter: exporter.NewDataExporterScheduler(0, 0,
+					&ffexporter.Log{}, logger),
 			}
 
 			got, err := JSONVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
@@ -816,6 +821,8 @@ func TestStringVariation(t *testing.T) {
 					PollInterval: 0,
 					Logger:       logger,
 				},
+				dataExporter: exporter.NewDataExporterScheduler(0, 0,
+					&ffexporter.Log{}, logger),
 			}
 			got, err := StringVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
 
@@ -976,6 +983,8 @@ func TestIntVariation(t *testing.T) {
 					PollInterval: 0,
 					Logger:       logger,
 				},
+				dataExporter: exporter.NewDataExporterScheduler(0, 0,
+					&ffexporter.Log{}, logger),
 			}
 			got, err := IntVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
 


### PR DESCRIPTION
# Description
Before this PR if we had a logger in the configuration we were logging all variations.
Since it can be a lot of logs we don't want to automatically log like it was before.

This PR removes the automatic logging strategy and replaces it with a **log data exporter**.

## Migration pattern
⚠️ Breaking changes
If you were using these logs, you need to add the **log data exporter** to your configuration.

```golang
err := Init(Config{
	// ...
	DataExporter: DataExporter{
		Exporter: &ffexporter.Log{},
	},
})
```

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)
Resolve #90

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
