### PR TITLE
Add an option to start even when retriever is unreachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 # 🎛️ go-feature-flag [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=I%27ve%20discovered%20go-feature-flag%20a%20great%20solution%20to%20easily%20managed%20feature%20flag%20in%20golang&url=https%3A%2F%2Fgithub.com%2Fthomaspoignant%2Fgo-feature-flag&via=thomaspoignant&hashtags=golang,featureflags,featuretoggle,go)
 
-
 <p align="center">
     <a href="https://app.circleci.com/pipelines/github/thomaspoignant/go-feature-flag"><img src="https://img.shields.io/circleci/build/github/thomaspoignant/go-feature-flag" alt="Build Status" /></a>
     <a href="https://coveralls.io/github/thomaspoignant/go-feature-flag"><img src="https://coveralls.io/repos/github/thomaspoignant/go-feature-flag/badge.svg" alt="Coverage Status" /></a>
@@ -87,18 +86,20 @@ ffclient.Init(ffclient.Config{
             OutputDir: "/output-data/",
         },
     },
+    StartWithRetrieverError: false,
 })
 ```
 
-|  | Descriptions |
+| Field | Description |
 |---|---|
 |`PollInterval`   | Number of seconds to wait before refreshing the flags.<br />The default value is 60 seconds.|
-|`Logger`   | Logger used to log what `go-feature-flag` is doing.<br />If no logger is provided the module will not log anything.|
-|`Context`  | The context used by the retriever.<br />The default value is `context.Background()`.|
-|`FileFormat`| Format of your configuration file. Available formats are `yaml`, `toml` and `json`, if you omit the field it will try to unmarshal the file as a `yaml` file.|
-|`Retriever`  | The configuration retriever you want to use to get your flag file *(see [Where do I store my flags file](#where-do-i-store-my-flags-file) for the configuration details)*.|
-|`Notifiers` | List of notifiers to call when your flag file has changed *(see [notifiers section](#notifiers) for more details)*.|
-|`DataExporter` | DataExporter defines how to export data on how your flags are used. *(see [export data section](#export-data) for more details)*.|
+|`Retriever`  | The configuration retriever you want to use to get your flag file<br> *see [Where do I store my flags file](#where-do-i-store-my-flags-file) for the configuration details*.|
+|`Context`  | *(optional)* The context used by the retriever.<br />The default value is `context.Background()`.|
+|`DataExporter` | *(optional)* DataExporter defines how to export data on how your flags are used.<br> *see [export data section](#export-data) for more details*.|
+|`FileFormat`| *(optional)* Format of your configuration file. Available formats are `yaml`, `toml` and `json`, if you omit the field it will try to unmarshal the file as a `yaml` file.|
+|`Logger`   | *(optional)* Logger used to log what `go-feature-flag` is doing.<br />If no logger is provided the module will not log anything.|
+|`Notifiers` | *(optional)* List of notifiers to call when your flag file has changed.<br> *see [notifiers section](#notifiers) for more details*.|
+|`StartWithRetrieverError` | *(optional)* If **true**, the SDK will start even if we did not get any flags from the retriever. It will serve only default values until the retriever return the flags.<br>The init method will not return any error if the flag file is unreachable.<br>Default: **false**|
 
 ## Where do I store my flags file
 `go-feature-flags` support different ways of retrieving the flag file.  

--- a/README.md
+++ b/README.md
@@ -92,14 +92,14 @@ ffclient.Init(ffclient.Config{
 
 | Field | Description |
 |---|---|
-|`PollInterval`   | Number of seconds to wait before refreshing the flags.<br />The default value is 60 seconds.|
 |`Retriever`  | The configuration retriever you want to use to get your flag file<br> *see [Where do I store my flags file](#where-do-i-store-my-flags-file) for the configuration details*.|
-|`Context`  | *(optional)* The context used by the retriever.<br />The default value is `context.Background()`.|
+|`Context`  | *(optional)* The context used by the retriever.<br />Default: `context.Background()`|
 |`DataExporter` | *(optional)* DataExporter defines how to export data on how your flags are used.<br> *see [export data section](#export-data) for more details*.|
-|`FileFormat`| *(optional)* Format of your configuration file. Available formats are `yaml`, `toml` and `json`, if you omit the field it will try to unmarshal the file as a `yaml` file.|
-|`Logger`   | *(optional)* Logger used to log what `go-feature-flag` is doing.<br />If no logger is provided the module will not log anything.|
+|`FileFormat`| *(optional)* Format of your configuration file. Available formats are `yaml`, `toml` and `json`, if you omit the field it will try to unmarshal the file as a `yaml` file.<br>Default: `YAML`|
+|`Logger`   | *(optional)* Logger used to log what `go-feature-flag` is doing.<br />If no logger is provided the module will not log anything.<br>Default: No log|
 |`Notifiers` | *(optional)* List of notifiers to call when your flag file has changed.<br> *see [notifiers section](#notifiers) for more details*.|
-|`StartWithRetrieverError` | *(optional)* If **true**, the SDK will start even if we did not get any flags from the retriever. It will serve only default values until the retriever return the flags.<br>The init method will not return any error if the flag file is unreachable.<br>Default: **false**|
+|`PollInterval`   | (optional) Number of seconds to wait before refreshing the flags.<br />Default: 60|
+|`StartWithRetrieverError` | *(optional)* If **true**, the SDK will start even if we did not get any flags from the retriever. It will serve only default values until the retriever returns the flags.<br>The init method will not return any error if the flag file is unreachable.<br>Default: **false**|
 
 ## Where do I store my flags file
 `go-feature-flags` support different ways of retrieving the flag file.  

--- a/config.go
+++ b/config.go
@@ -14,16 +14,34 @@ import (
 // PollInterval is the interval in seconds where we gonna read the file to update the cache.
 // You should also have a retriever to specify where to read the flags file.
 type Config struct {
-	PollInterval int              // Poll every X seconds
-	Logger       *log.Logger      // Logger use by the library
-	Context      context.Context  // default is context.Background()
-	Retriever    Retriever        // Retriever is the component in charge to retrieve your flag file
-	Notifiers    []NotifierConfig // Notifiers is the list of notifiers called when a flag change
-	FileFormat   string           // FileFormat is the format of the file to retrieve (available YAML, TOML and JSON)
+	// Poll every X seconds
+	PollInterval int
+
+	// Logger use by the library
+	Logger *log.Logger
+
+	// default is context.Background()
+	Context context.Context
+
+	// Retriever is the component in charge to retrieve your flag file
+	Retriever Retriever
+
+	// Notifiers is the list of notifiers called when a flag change
+	Notifiers []NotifierConfig
+
+	// FileFormat is the format of the file to retrieve (available YAML, TOML and JSON)
+	FileFormat string
+
 	// Deprecated: Use Notifiers instead, webhooks will be delete in a future version
 	Webhooks []WebhookConfig // Webhooks we should call when a flag create/update/delete
+
 	// DataExporter is the configuration where we store how we should output the flags variations results
 	DataExporter DataExporter
+
+	// StartWithRetrieverError if true the SDK will start even if the flag file is unreachable and will
+	// server default values. If the flag is reachable again it will works as expected.
+	// The init method will not return any error if the flag file is unreachable.
+	StartWithRetrieverError bool
 }
 
 // GetRetriever returns a retriever.FlagRetriever configure with the retriever available in the config.

--- a/config.go
+++ b/config.go
@@ -14,33 +14,38 @@ import (
 // PollInterval is the interval in seconds where we gonna read the file to update the cache.
 // You should also have a retriever to specify where to read the flags file.
 type Config struct {
-	// Poll every X seconds
+	// PollInterval (optional) Poll every X seconds
+	// Default: 60 seconds
 	PollInterval int
 
-	// Logger use by the library
+	// Logger (optional) logger use by the library
+	// Default: No log
 	Logger *log.Logger
 
-	// default is context.Background()
+	// Context (optional) used to call other services (HTTP, S3 ...)
+	// Default: context.Background()
 	Context context.Context
 
 	// Retriever is the component in charge to retrieve your flag file
 	Retriever Retriever
 
-	// Notifiers is the list of notifiers called when a flag change
+	// Notifiers (optional) is the list of notifiers called when a flag change
 	Notifiers []NotifierConfig
 
-	// FileFormat is the format of the file to retrieve (available YAML, TOML and JSON)
+	// FileFormat (optional) is the format of the file to retrieve (available YAML, TOML and JSON)
+	// Default: YAML
 	FileFormat string
 
 	// Deprecated: Use Notifiers instead, webhooks will be delete in a future version
 	Webhooks []WebhookConfig // Webhooks we should call when a flag create/update/delete
 
-	// DataExporter is the configuration where we store how we should output the flags variations results
+	// DataExporter (optional) is the configuration where we store how we should output the flags variations results
 	DataExporter DataExporter
 
-	// StartWithRetrieverError if true the SDK will start even if the flag file is unreachable and will
-	// server default values. If the flag is reachable again it will works as expected.
+	// StartWithRetrieverError (optional) If true, the SDK will start even if we did not get any flags from the retriever.
+	// It will serve only default values until the retriever returns the flags.
 	// The init method will not return any error if the flag file is unreachable.
+	// Default: false
 	StartWithRetrieverError bool
 }
 

--- a/feature_flag.go
+++ b/feature_flag.go
@@ -73,7 +73,7 @@ func New(config Config) (*GoFeatureFlag, error) {
 
 	// fail if we cannot retrieve the flags the 1st time
 	err = retrieveFlagsAndUpdateCache(goFF.config, goFF.cache)
-	if err != nil {
+	if err != nil && !config.StartWithRetrieverError {
 		return nil, fmt.Errorf("impossible to retrieve the flags, please check your configuration: %v", err)
 	}
 

--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -226,3 +226,35 @@ func TestWrongWebhookConfig(t *testing.T) {
 	assert.Equal(t, err.Error(), "wrong configuration in your webhook: parse \" https://example.com/hook\": "+
 		"first path segment in URL cannot contain colon")
 }
+
+func TestFlagFileUnreachable(t *testing.T) {
+	initialFileContent := `test-flag:
+  rule: key eq "random-key"
+  percentage: 100
+  true: "true"
+  false: "false"
+  default: "false"`
+
+	tempDir, _ := ioutil.TempDir("", "")
+	defer os.Remove(tempDir)
+
+	flagFilePath := tempDir + "_FlagFileUnreachable.yaml"
+	gff, err := New(Config{
+		PollInterval:            1,
+		Retriever:               &FileRetriever{Path: flagFilePath},
+		Logger:                  log.New(os.Stdout, "", 0),
+		StartWithRetrieverError: true,
+	})
+	defer gff.Close()
+
+	assert.NoError(t, err, "should not return any error even if we can't retrieve the file")
+
+	flagValue, _ := gff.StringVariation("test-flag", ffuser.NewUser("random-key"), "SDKdefault")
+	assert.Equal(t, "SDKdefault", flagValue, "should use the SDK default value")
+
+	_ = ioutil.WriteFile(flagFilePath, []byte(initialFileContent), 0600)
+	time.Sleep(2 * time.Second)
+
+	flagValue, _ = gff.StringVariation("test-flag", ffuser.NewUser("random-key"), "SDKdefault")
+	assert.Equal(t, "true", flagValue, "should use the true value")
+}


### PR DESCRIPTION
# Description
The default behavior is to return an error if the flag file we want to retrieve is not available.
We don't change this behavior but we add a new configuration param `StartWithRetrieverError` to accept to start the SDK if the retriever failed to get the flags.

If `StartWithRetrieverError` is **true**, the SDK will start even if we did not get any flags from the retriever. It will serve only default values until the retriever returns the flags.  
The init method will not return any error if the flag file is unreachable.  
Default: **false**

# Changes include
- [x] New feature (non-breaking change that adds functionality)

# Closes issue(s)
Resolve #83

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
