### PR TITLE
Rename PayloadURL -> EndpointURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ ffclient.Init(ffclient.Config{
     FileFormat:     "yaml",
     Notifiers: []ffclient.NotifierConfig{
         &ffclient.WebhookConfig{
-            PayloadURL: " https://example.com/hook",
+            EndpointURL: " https://example.com/hook",
             Secret:     "Secret",
             Meta: map[string]string{
                 "app.name": "my app",
@@ -320,7 +320,7 @@ ffclient.Config{
     // ...
     Notifiers: []ffclient.NotifierConfig{
         &ffclient.WebhookConfig{
-            PayloadURL: " https://example.com/hook",
+            EndpointURL: " https://example.com/hook",
             Secret:     "Secret",
             Meta: map[string]string{
                 "app.name": "my app",
@@ -333,12 +333,12 @@ ffclient.Config{
 
 |   |   |   |
 |---|---|---|
-|`PayloadURL`   |![mandatory](https://img.shields.io/badge/-mandatory-red)   | The complete URL of your API *(we will send a POST request to this URL, [see format](#format))*  |
+|`EndpointURL`   |![mandatory](https://img.shields.io/badge/-mandatory-red)   | The complete URL of your API *(we will send a POST request to this URL, [see format](#format))*  |
 |`Secret`   |![optional](https://img.shields.io/badge/-optional-green)   |  A secret key you can share with your webhook. We will use this key to sign the request *(see [signature section](#signature) for more details)*. |
 |`Meta`   |![optional](https://img.shields.io/badge/-optional-green)   |  A list of key value that will be add in your request, this is super usefull if you to add information on the current running instance of your app.<br/>*By default the hostname is always added in the meta informations.*|
 
 #### Format
-If you have configured a webhook, a POST request will be sent to the `PayloadURL` with a body in this format:
+If you have configured a webhook, a POST request will be sent to the `EndpointURL` with a body in this format:
 
 ```json
 {

--- a/config.go
+++ b/config.go
@@ -62,7 +62,7 @@ func (c *Config) GetRetriever() (retriever.FlagRetriever, error) {
 //
 // Notifiers: []ffclient.NotifierConfig{
 //        &ffclient.WebhookConfig{
-//            PayloadURL: " https://example.com/hook",
+//            EndpointURL: " https://example.com/hook",
 //            Secret:     "Secret",
 //            Meta: map[string]string{
 //                "app.name": "my app",
@@ -121,17 +121,28 @@ type NotifierConfig interface {
 //    }
 //  }
 type WebhookConfig struct {
-	PayloadURL string            // PayloadURL of your webhook
-	Secret     string            // Secret used to sign your request body.
-	Meta       map[string]string // Meta information that you want to send to your webhook (not mandatory)
+	// Deprecated: use EndpointURL instead
+	PayloadURL string
+
+	// EndpointURL is the URL where we gonna do the POST Request.
+	EndpointURL string
+	Secret      string            // Secret used to sign your request body.
+	Meta        map[string]string // Meta information that you want to send to your webhook (not mandatory)
 }
 
 // GetNotifier convert the configuration in a Notifier struct
 func (w *WebhookConfig) GetNotifier(config Config) (notifier.Notifier, error) {
+	url := w.EndpointURL
+
+	// remove this if when EndpointURL will be removed
+	if url == "" {
+		url = w.PayloadURL
+	}
+
 	notifier, err := notifier.NewWebhookNotifier(
 		config.Logger,
 		internal.DefaultHTTPClient(),
-		w.PayloadURL, w.Secret, w.Meta)
+		url, w.Secret, w.Meta)
 	return &notifier, err
 }
 

--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -212,8 +212,8 @@ func TestWrongWebhookConfig(t *testing.T) {
 		Retriever:    &FileRetriever{Path: "testdata/flag-config.yaml"},
 		Webhooks: []WebhookConfig{
 			{
-				PayloadURL: " https://example.com/hook",
-				Secret:     "Secret",
+				EndpointURL: " https://example.com/hook",
+				Secret:      "Secret",
 				Meta: map[string]string{
 					"my-app": "go-ff-test",
 				},

--- a/internal/notifier/notifier_webhook.go
+++ b/internal/notifier/notifier_webhook.go
@@ -20,7 +20,7 @@ import (
 
 func NewWebhookNotifier(logger *log.Logger,
 	httpClient internal.HTTPClient,
-	payloadURL string,
+	endpointURL string,
 	secret string,
 	meta map[string]string,
 ) (WebhookNotifier, error) {
@@ -35,17 +35,17 @@ func NewWebhookNotifier(logger *log.Logger,
 		meta["hostname"] = hostname
 	}
 
-	parsedURL, err := url.Parse(payloadURL)
+	parsedURL, err := url.Parse(endpointURL)
 	if err != nil {
 		return WebhookNotifier{}, err
 	}
 
 	w := WebhookNotifier{
-		Logger:     logger,
-		PayloadURL: *parsedURL,
-		Secret:     secret,
-		Meta:       meta,
-		HTTPClient: httpClient,
+		Logger:      logger,
+		EndpointURL: *parsedURL,
+		Secret:      secret,
+		Meta:        meta,
+		HTTPClient:  httpClient,
 	}
 	return w, nil
 }
@@ -56,11 +56,11 @@ type webhookReqBody struct {
 }
 
 type WebhookNotifier struct {
-	Logger     *log.Logger
-	HTTPClient internal.HTTPClient
-	PayloadURL url.URL
-	Secret     string
-	Meta       map[string]string
+	Logger      *log.Logger
+	HTTPClient  internal.HTTPClient
+	EndpointURL url.URL
+	Secret      string
+	Meta        map[string]string
 }
 
 func (c *WebhookNotifier) Notify(diff model.DiffCache, wg *sync.WaitGroup) {
@@ -89,7 +89,7 @@ func (c *WebhookNotifier) Notify(diff model.DiffCache, wg *sync.WaitGroup) {
 
 	request := http.Request{
 		Method: "POST",
-		URL:    &c.PayloadURL,
+		URL:    &c.EndpointURL,
 		Header: headers,
 		Body:   ioutil.NopCloser(bytes.NewReader(payload)),
 	}

--- a/internal/notifier/notifier_webhook_test.go
+++ b/internal/notifier/notifier_webhook_test.go
@@ -193,9 +193,9 @@ func TestNewWebhookNotifier(t *testing.T) {
 	hostname, _ := os.Hostname()
 
 	type args struct {
-		payloadURL string
-		secret     string
-		meta       map[string]string
+		endpointURL string
+		secret      string
+		meta        map[string]string
 	}
 	tests := []struct {
 		name    string
@@ -206,27 +206,27 @@ func TestNewWebhookNotifier(t *testing.T) {
 		{
 			name: "Invalid URL",
 			args: args{
-				payloadURL: " http://example.com",
+				endpointURL: " http://example.com",
 			},
 			wantErr: true,
 		},
 		{
 			name: "No meta",
 			args: args{
-				payloadURL: "http://example.com",
+				endpointURL: "http://example.com",
 			},
 			wantErr: false,
 			want: WebhookNotifier{
-				HTTPClient: mockHTTPClient,
-				PayloadURL: url.URL{Host: "example.com", Scheme: "http"},
-				Secret:     "",
-				Meta:       map[string]string{"hostname": hostname},
+				HTTPClient:  mockHTTPClient,
+				EndpointURL: url.URL{Host: "example.com", Scheme: "http"},
+				Secret:      "",
+				Meta:        map[string]string{"hostname": hostname},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewWebhookNotifier(nil, mockHTTPClient, tt.args.payloadURL, tt.args.secret, tt.args.meta)
+			got, err := NewWebhookNotifier(nil, mockHTTPClient, tt.args.endpointURL, tt.args.secret, tt.args.meta)
 
 			if tt.wantErr {
 				assert.Error(t, err, "NewWebhookNotifier should return an error")

--- a/notifier.go
+++ b/notifier.go
@@ -52,17 +52,17 @@ func getWebhooks(config Config) ([]notifier.Notifier, error) {
 		hostname, _ := os.Hostname()
 		whConf.Meta["hostname"] = hostname
 
-		payloadURL, err := url.Parse(whConf.PayloadURL)
+		endpointURL, err := url.Parse(whConf.EndpointURL)
 		if err != nil {
 			return nil, err
 		}
 
 		w := notifier.WebhookNotifier{
-			Logger:     config.Logger,
-			PayloadURL: *payloadURL,
-			Secret:     whConf.Secret,
-			Meta:       whConf.Meta,
-			HTTPClient: &httpClient,
+			Logger:      config.Logger,
+			EndpointURL: *endpointURL,
+			Secret:      whConf.Secret,
+			Meta:        whConf.Meta,
+			HTTPClient:  &httpClient,
 		}
 		res[index] = &w
 	}

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -33,8 +33,8 @@ func TestGoFeatureFlag_getNotifiers(t *testing.T) {
 					Logger: log.New(os.Stdout, "", 0),
 					Notifiers: []NotifierConfig{
 						&WebhookConfig{
-							PayloadURL: parsedURL.String(),
-							Secret:     "Secret",
+							EndpointURL: parsedURL.String(),
+							Secret:      "Secret",
 							Meta: map[string]string{
 								"my-app":   "go-ff-test",
 								"hostname": hostname,
@@ -53,8 +53,8 @@ func TestGoFeatureFlag_getNotifiers(t *testing.T) {
 					HTTPClient: &http.Client{
 						Timeout: 10 * time.Second,
 					},
-					PayloadURL: *parsedURL,
-					Secret:     "Secret",
+					EndpointURL: *parsedURL,
+					Secret:      "Secret",
 					Meta: map[string]string{
 						"my-app":   "go-ff-test",
 						"hostname": hostname,
@@ -74,8 +74,8 @@ func TestGoFeatureFlag_getNotifiers(t *testing.T) {
 					Logger: log.New(os.Stdout, "", 0),
 					Webhooks: []WebhookConfig{
 						{
-							PayloadURL: parsedURL.String(),
-							Secret:     "Secret",
+							EndpointURL: parsedURL.String(),
+							Secret:      "Secret",
 							Meta: map[string]string{
 								"my-app":   "go-ff-test",
 								"hostname": hostname,
@@ -92,8 +92,8 @@ func TestGoFeatureFlag_getNotifiers(t *testing.T) {
 					HTTPClient: &http.Client{
 						Timeout: 10 * time.Second,
 					},
-					PayloadURL: *parsedURL,
-					Secret:     "Secret",
+					EndpointURL: *parsedURL,
+					Secret:      "Secret",
 					Meta: map[string]string{
 						"my-app":   "go-ff-test",
 						"hostname": hostname,
@@ -108,8 +108,8 @@ func TestGoFeatureFlag_getNotifiers(t *testing.T) {
 					Logger: log.New(os.Stdout, "", 0),
 					Notifiers: []NotifierConfig{
 						&WebhookConfig{
-							PayloadURL: " https://example.com/hook",
-							Secret:     "Secret",
+							EndpointURL: " https://example.com/hook",
+							Secret:      "Secret",
 							Meta: map[string]string{
 								"my-app":   "go-ff-test",
 								"hostname": hostname,


### PR DESCRIPTION
# Description
As explaining in #107 this was a bad naming.
With this PR `PayloadURL` is deprecated and `EndpointURL` is used instead.


# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)
Resolve #107

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
