### PR TITLE
Add experimentation capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,18 +226,64 @@ test-flag:
   false: false
   default: false
   disable: false
+  trackEvents: true
+  experimentation:
+    startDate: 2021-03-20T00:00:00.10-05:00
+    endDate: 2021-03-21T00:00:00.10-05:00
 ```
 
-|   |   |   |
-|---|---|---|
-|`test-flag`   |![mandatory](https://img.shields.io/badge/-mandatory-red)   |  Name of the flag. It should be unique.  |
-|`percentage`   |![optional](https://img.shields.io/badge/-optional-green)   |  Percentage of the users affect by the flag.<br>**Default value is 0**  |
-|`rule`   |![optional](https://img.shields.io/badge/-optional-green)   |  This is the query use to select on which user the flag should apply.<br>Rule format is describe in the [rule format section](#rule-format).<br>**If no rule set, the flag apply to all users *(percentage still apply)*.** |
-|`true`   |![mandatory](https://img.shields.io/badge/-mandatory-red)   |  The value return by the flag if apply to the user *(rule is evaluated to true)* and user is in the active percentage. |
-|`false`   |![mandatory](https://img.shields.io/badge/-mandatory-red)   |  The value return by the flag if apply to the user *(rule is evaluated to true)* and user is **not** in the active percentage. |
-|`default`   |![mandatory](https://img.shields.io/badge/-mandatory-red)   |  The value return by the flag if not apply to the user *(rule is evaluated to false)*. |
-|`disable`   |![optional](https://img.shields.io/badge/-optional-green)   |  True if the flag is disabled. |
-|`trackEvents`   |![optional](https://img.shields.io/badge/-optional-green)   |   False if you don't want to export the data in your data exporter.<br>Default value is true |
+
+<table>
+<thead>
+    <tr>
+    <td><strong>Field</strong></td><td><strong>Description</strong></td>
+    </tr>
+</thead>
+<tr>
+    <td><code>test-flag</code></td>
+    <td>Name of the flag.<br>It should be unique.</td>
+</tr>
+<tr>
+    <td><code>true</code></td>
+    <td>The value return by the flag if apply to the user <i>(rule is evaluated to true)</i> and user is in the active percentage.</td>
+</tr>
+<tr>
+    <td><code>false</code></td>
+    <td>The value return by the flag if apply to the user <i>(rule is evaluated to true)</i> and user is <strong>not</strong> in the active percentage.</td>
+</tr>
+<tr>
+    <td><code>default</code></td>
+    <td>The value return by the flag if not apply to the user <i>(rule is evaluated to false).</i></td>
+</tr>
+<tr>
+    <td><code>percentage</code></td>
+    <td><i>(optional)</i> Percentage of the users affect by the flag.<br><strong>Default value is 0</strong></td>
+</tr>
+<tr>
+    <td><code>rule</code></td>
+    <td><i>(optional)</i> This is the query use to select on which user the flag should apply.<br>Rule format is describe in the <a href="#rule-format">rule format section</a>.<br><strong>If no rule set, the flag apply to all users <i>(percentage still apply)</i>.</strong></td>
+</tr>
+<tr>
+    <td><code>disable</code></td>
+    <td><i>(optional)</i> True if the flag is disabled.</i></td>
+</tr>
+<tr>
+    <td><code>trackEvents</code></td>
+    <td><i>(optional)</i> False if you don't want to export the data in your data exporter.<br>Default value is true</i></td>
+</tr>
+<tr>
+    <td><code>experimentation</code></td>
+    <td><i>(optional)</i> <code>experimentation</code> is here to configure a flag that is available for only a determined time.<br>The structure is:<br> 
+    <pre lang="yaml" >
+  experimentation:
+    startDate: 2021-03-20T00:00:00.10-05:00
+    endDate: 2021-03-21T00:00:00.10-05:00
+   </pre>
+   <i>The date is in the format supported natively by your flag file format.</i><br>
+   Check this <a href="https://github.com/thomaspoignant/go-feature-flag/blob/main/examples/experimentation/main.go">example</a> to see how it works.
+   </td>
+</tr>
+</table>
 
 ## Rule format
 The rule format is based on the [`nikunjy/rules`](https://github.com/nikunjy/rules) library.

--- a/README.md
+++ b/README.md
@@ -277,8 +277,7 @@ test-flag:
     <pre lang="yaml" >
   experimentation:
     startDate: 2021-03-20T00:00:00.10-05:00
-    endDate: 2021-03-21T00:00:00.10-05:00
-   </pre>
+    endDate: 2021-03-21T00:00:00.10-05:00</pre>
    <i>The date is in the format supported natively by your flag file format.</i><br>
    Check this <a href="https://github.com/thomaspoignant/go-feature-flag/blob/main/examples/experimentation/main.go">example</a> to see how it works.
    </td>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ No server is needed, just add a file in a central system and all your services w
 - Storing your configuration flags file on various locations ([`HTTP`](#from-an-http-endpoint), [`S3`](#from-a-s3-bucket), [`GitHub`](#from-github), [`file`](#from-a-file)).
 - Configuring your flags in various [format](#flags-file-format) (`JSON`, `TOML` and `YAML`).
 - Adding complex [rules](#rule-format) to target your users.
+- Run A/B test experimentations.
 - Getting notified when a flag has changed ([`webhook`](#webhooks) and [`slack`](#slack)).
 - Exporting your flags usage data ([`s3`](#s3-exporter), [`log`](#log-exporter) and [`file`](#file-exporter)).
 

--- a/examples/experimentation/flags.yaml
+++ b/examples/experimentation/flags.yaml
@@ -1,0 +1,8 @@
+experimentation-flag:
+  percentage: 50
+  true: "B"
+  false: "A"
+  default: "A"
+  experimentation:
+    startDate: 2021-03-20T00:00:00.10-05:00
+    endDate: 2021-03-21T00:00:00.10-05:00

--- a/examples/experimentation/main.go
+++ b/examples/experimentation/main.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	ffclient "github.com/thomaspoignant/go-feature-flag"
+	"github.com/thomaspoignant/go-feature-flag/ffexporter"
+	"github.com/thomaspoignant/go-feature-flag/ffuser"
+)
+
+func main() {
+	// Before running this example you should edit the date in the flag file (examples/experimentation/flags.yaml)
+	// The important part is the experimentation configuration
+
+	// Init ffclient with a file retriever.
+	err := ffclient.Init(ffclient.Config{
+		PollInterval: 10,
+		Logger:       log.New(os.Stdout, "", 0),
+		Context:      context.Background(),
+		Retriever: &ffclient.FileRetriever{
+			Path: "examples/experimentation/flags.yaml",
+		},
+		DataExporter: ffclient.DataExporter{
+			FlushInterval:    10,
+			MaxEventInMemory: 2,
+			Exporter: &ffexporter.Log{
+				Format: "[{{ .FormattedDate}}] user=\"{{ .UserKey}}\", flag=\"{{ .Key}}\", value=\"{{ .Value}}\", variation=\"{{ .Variation}}\"",
+			},
+		},
+	})
+
+	// Check init errors.
+	if err != nil {
+		log.Fatal(err)
+	}
+	// defer closing ffclient
+	defer ffclient.Close()
+
+	// create users
+	user1 := ffuser.NewAnonymousUser("332460b9-a8aa-4f7a-bc5d-9cc33632df9a")
+	user2 := ffuser.NewAnonymousUser("91ff5618-6cbb-4f54-a038-3e99b078f560")
+	_, _ = ffclient.StringVariation("experimentation-flag", user1, "error")
+	_, _ = ffclient.StringVariation("experimentation-flag", user2, "error")
+
+	// If the current time is in the range of the experimentation you should have an output in your log
+	// that looks like this:
+	//
+	// [2021-04-20T17:11:40+02:00] user="332460b9-a8aa-4f7a-bc5d-9cc33632df9a", flag="experimentation-flag", value="B", variation="True"
+	// [2021-04-20T17:11:40+02:00] user="91ff5618-6cbb-4f54-a038-3e99b078f560", flag="experimentation-flag", value="A", variation="False"
+	//
+	// You can see that the variation is True and False, it means that the flag has been evaluated and user1 is in cohort B
+	// while user2 is in cohort A.
+
+	// If you change the date again and the current time is not in the range anymore, your output will looks like:
+	//
+	// [2021-04-20T17:20:38+02:00] user="332460b9-a8aa-4f7a-bc5d-9cc33632df9a", flag="experimentation-flag", value="A", variation="Default"
+	// [2021-04-20T17:20:38+02:00] user="91ff5618-6cbb-4f54-a038-3e99b078f560", flag="experimentation-flag", value="A", variation="Default"
+}

--- a/internal/model/flag.go
+++ b/internal/model/flag.go
@@ -6,6 +6,7 @@ import (
 	"hash/fnv"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/ffuser"
 )
@@ -19,6 +20,22 @@ const (
 	VariationDefault    VariationType = "Default"
 	VariationSDKDefault VariationType = "SdkDefault"
 )
+
+type Experimentation struct {
+	StartDate *time.Time `json:"startDate,omitempty" yaml:"startDate,omitempty" toml:"startDate,omitempty"`
+	EndDate   *time.Time `json:"endDate,omitempty" yaml:"endDate,omitempty" toml:"endDate,omitempty"`
+}
+
+func (e Experimentation) String() string {
+	buf := make([]string, 0)
+	if e.StartDate != nil {
+		buf = append(buf, fmt.Sprintf("start:[%v]", e.StartDate.Format(time.RFC3339)))
+	}
+	if e.EndDate != nil {
+		buf = append(buf, fmt.Sprintf("end:[%v]", e.EndDate.Format(time.RFC3339)))
+	}
+	return strings.Join(buf, " ")
+}
 
 // Flag describe the fields of a flag.
 type Flag struct {
@@ -48,16 +65,23 @@ type Flag struct {
 
 	// Disable is true if the flag is disabled.
 	Disable bool `json:"disable,omitempty" yaml:"disable,omitempty" toml:"disable,omitempty"`
+
+	// Experimentation is your object to configure an experimentation, it will allow you to configure a start date and
+	// an end date for your flag.
+	// When the experimentation is not running, the flag will serve the default value.
+	Experimentation *Experimentation `json:"experimentation,omitempty" yaml:"experimentation,omitempty" toml:"experimentation,omitempty" slack_short:"false"` // nolint: lll
 }
 
 // Value is returning the Value associate to the flag (True / False / Default ) based
 // if the toggle apply to the user or not.
 func (f *Flag) Value(flagName string, user ffuser.User) (interface{}, VariationType) {
-	inRule := f.evaluateRule(user)
-	inPercentage := f.isInPercentage(flagName, user)
+	if f.isExperimentationOver() {
+		// if we have an experimentation that has not started or that is finished we use the default value.
+		return f.Default, VariationDefault
+	}
 
-	if inRule {
-		if inPercentage {
+	if f.evaluateRule(user) {
+		if f.isInPercentage(flagName, user) {
 			// Rule applied and user in the cohort.
 			return f.True, VariationTrue
 		}
@@ -67,6 +91,13 @@ func (f *Flag) Value(flagName string, user ffuser.User) (interface{}, VariationT
 
 	// Default value is used if the rule does not applied to the user.
 	return f.Default, VariationDefault
+}
+
+func (f *Flag) isExperimentationOver() bool {
+	now := time.Now()
+	return f.Experimentation != nil && (
+		(f.Experimentation.StartDate != nil && now.Before(*f.Experimentation.StartDate)) ||
+			(f.Experimentation.EndDate != nil && now.After(*f.Experimentation.EndDate)))
 }
 
 // isInPercentage check if the user is in the cohort for the toggle.

--- a/internal/model/flag.go
+++ b/internal/model/flag.go
@@ -28,11 +28,12 @@ type Experimentation struct {
 
 func (e Experimentation) String() string {
 	buf := make([]string, 0)
+	lo, _ := time.LoadLocation("UTC")
 	if e.StartDate != nil {
-		buf = append(buf, fmt.Sprintf("start:[%v]", e.StartDate.Format(time.RFC3339)))
+		buf = append(buf, fmt.Sprintf("start:[%v]", e.StartDate.In(lo).Format(time.RFC3339)))
 	}
 	if e.EndDate != nil {
-		buf = append(buf, fmt.Sprintf("end:[%v]", e.EndDate.Format(time.RFC3339)))
+		buf = append(buf, fmt.Sprintf("end:[%v]", e.EndDate.In(lo).Format(time.RFC3339)))
 	}
 	return strings.Join(buf, " ")
 }

--- a/internal/model/flag_pub_test.go
+++ b/internal/model/flag_pub_test.go
@@ -263,7 +263,7 @@ func TestFlag_value(t *testing.T) {
 				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
 			},
 			want: want{
-				value:         "Default",
+				value:         "default",
 				variationType: model.VariationDefault,
 			},
 		},

--- a/internal/model/flag_pub_test.go
+++ b/internal/model/flag_pub_test.go
@@ -3,6 +3,7 @@ package model_test
 import (
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/ffuser"
 	"github.com/thomaspoignant/go-feature-flag/internal/model"
@@ -11,12 +12,13 @@ import (
 
 func TestFlag_value(t *testing.T) {
 	type fields struct {
-		Disable    bool
-		Rule       string
-		Percentage float64
-		True       interface{}
-		False      interface{}
-		Default    interface{}
+		Disable         bool
+		Rule            string
+		Percentage      float64
+		True            interface{}
+		False           interface{}
+		Default         interface{}
+		Experimentation model.Experimentation
 	}
 	type args struct {
 		flagName string
@@ -67,16 +69,193 @@ func TestFlag_value(t *testing.T) {
 				variationType: model.VariationTrue,
 			},
 		},
+		{
+			name: "Experimentation only start date in the past",
+			fields: fields{
+				True:       "true",
+				False:      "false",
+				Default:    "default",
+				Rule:       "key == \"user66\"",
+				Percentage: 10,
+				Experimentation: model.Experimentation{
+					StartDate: testutils.Time(time.Now().Add(-1 * time.Minute)),
+					EndDate:   nil,
+				},
+			},
+			args: args{
+				flagName: "test-flag",
+				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
+			},
+			want: want{
+				value:         "true",
+				variationType: model.VariationTrue,
+			},
+		},
+		{
+			name: "Experimentation only start date in the future",
+			fields: fields{
+				True:       "true",
+				False:      "false",
+				Default:    "default",
+				Rule:       "key == \"user66\"",
+				Percentage: 10,
+				Experimentation: model.Experimentation{
+					StartDate: testutils.Time(time.Now().Add(1 * time.Minute)),
+					EndDate:   nil,
+				},
+			},
+			args: args{
+				flagName: "test-flag",
+				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
+			},
+			want: want{
+				value:         "default",
+				variationType: model.VariationDefault,
+			},
+		},
+		{
+			name: "Experimentation between start and end date",
+			fields: fields{
+				True:       "true",
+				False:      "false",
+				Default:    "default",
+				Rule:       "key == \"user66\"",
+				Percentage: 10,
+				Experimentation: model.Experimentation{
+					StartDate: testutils.Time(time.Now().Add(-1 * time.Minute)),
+					EndDate:   testutils.Time(time.Now().Add(1 * time.Minute)),
+				},
+			},
+			args: args{
+				flagName: "test-flag",
+				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
+			},
+			want: want{
+				value:         "true",
+				variationType: model.VariationTrue,
+			},
+		},
+		{
+			name: "Experimentation not started yet",
+			fields: fields{
+				True:       "true",
+				False:      "false",
+				Default:    "default",
+				Rule:       "key == \"user66\"",
+				Percentage: 10,
+				Experimentation: model.Experimentation{
+					StartDate: testutils.Time(time.Now().Add(1 * time.Minute)),
+					EndDate:   testutils.Time(time.Now().Add(2 * time.Minute)),
+				},
+			},
+			args: args{
+				flagName: "test-flag",
+				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
+			},
+			want: want{
+				value:         "default",
+				variationType: model.VariationDefault,
+			},
+		},
+		{
+			name: "Experimentation finished",
+			fields: fields{
+				True:       "true",
+				False:      "false",
+				Default:    "default",
+				Rule:       "key == \"user66\"",
+				Percentage: 10,
+				Experimentation: model.Experimentation{
+					StartDate: testutils.Time(time.Now().Add(-2 * time.Minute)),
+					EndDate:   testutils.Time(time.Now().Add(-1 * time.Minute)),
+				},
+			},
+			args: args{
+				flagName: "test-flag",
+				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
+			},
+			want: want{
+				value:         "default",
+				variationType: model.VariationDefault,
+			},
+		},
+		{
+			name: "Experimentation only end date finished",
+			fields: fields{
+				True:       "true",
+				False:      "false",
+				Default:    "default",
+				Rule:       "key == \"user66\"",
+				Percentage: 10,
+				Experimentation: model.Experimentation{
+					StartDate: nil,
+					EndDate:   testutils.Time(time.Now().Add(-1 * time.Minute)),
+				},
+			},
+			args: args{
+				flagName: "test-flag",
+				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
+			},
+			want: want{
+				value:         "default",
+				variationType: model.VariationDefault,
+			},
+		},
+		{
+			name: "Experimentation only end date not finished",
+			fields: fields{
+				True:       "true",
+				False:      "false",
+				Default:    "default",
+				Rule:       "key == \"user66\"",
+				Percentage: 10,
+				Experimentation: model.Experimentation{
+					StartDate: nil,
+					EndDate:   testutils.Time(time.Now().Add(1 * time.Minute)),
+				},
+			},
+			args: args{
+				flagName: "test-flag",
+				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
+			},
+			want: want{
+				value:         "true",
+				variationType: model.VariationTrue,
+			},
+		},
+		{
+			name: "Experimentation only end date not finished",
+			fields: fields{
+				True:       "true",
+				False:      "false",
+				Default:    "default",
+				Rule:       "key == \"user66\"",
+				Percentage: 10,
+				Experimentation: model.Experimentation{
+					StartDate: nil,
+					EndDate:   nil,
+				},
+			},
+			args: args{
+				flagName: "test-flag",
+				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
+			},
+			want: want{
+				value:         "true",
+				variationType: model.VariationTrue,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &model.Flag{
-				Disable:    tt.fields.Disable,
-				Rule:       tt.fields.Rule,
-				Percentage: tt.fields.Percentage,
-				True:       tt.fields.True,
-				False:      tt.fields.False,
-				Default:    tt.fields.Default,
+				Disable:         tt.fields.Disable,
+				Rule:            tt.fields.Rule,
+				Percentage:      tt.fields.Percentage,
+				True:            tt.fields.True,
+				False:           tt.fields.False,
+				Default:         tt.fields.Default,
+				Experimentation: &tt.fields.Experimentation,
 			}
 
 			got, variationType := f.Value(tt.args.flagName, tt.args.user)

--- a/internal/model/flag_pub_test.go
+++ b/internal/model/flag_pub_test.go
@@ -352,3 +352,48 @@ func TestFlag_String(t *testing.T) {
 		})
 	}
 }
+
+func TestExperimentation_String(t *testing.T) {
+	type fields struct {
+		StartDate *time.Time
+		EndDate   *time.Time
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "both dates",
+			fields: fields{
+				StartDate: testutils.Time(time.Unix(1095379400, 0)),
+				EndDate:   testutils.Time(time.Unix(1095379500, 0)),
+			},
+			want: "start:[2004-09-17T00:03:20Z] end:[2004-09-17T00:05:00Z]",
+		},
+		{
+			name: "only start date",
+			fields: fields{
+				StartDate: testutils.Time(time.Unix(1095379400, 0)),
+			},
+			want: "start:[2004-09-17T00:03:20Z]",
+		},
+		{
+			name: "only end date",
+			fields: fields{
+				EndDate: testutils.Time(time.Unix(1095379500, 0)),
+			},
+			want: "end:[2004-09-17T00:05:00Z]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := model.Experimentation{
+				StartDate: tt.fields.StartDate,
+				EndDate:   tt.fields.EndDate,
+			}
+			got := e.String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/model/flag_pub_test.go
+++ b/internal/model/flag_pub_test.go
@@ -245,6 +245,28 @@ func TestFlag_value(t *testing.T) {
 				variationType: model.VariationTrue,
 			},
 		},
+		{
+			name: "Invert start date and end date",
+			fields: fields{
+				True:       "true",
+				False:      "false",
+				Default:    "default",
+				Rule:       "key == \"user66\"",
+				Percentage: 10,
+				Experimentation: model.Experimentation{
+					StartDate: testutils.Time(time.Now().Add(1 * time.Minute)),
+					EndDate:   testutils.Time(time.Now().Add(-1 * time.Minute)),
+				},
+			},
+			args: args{
+				flagName: "test-flag",
+				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
+			},
+			want: want{
+				value:         "Default",
+				variationType: model.VariationDefault,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/notifier/notifier_slack_test.go
+++ b/internal/notifier/notifier_slack_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/internal/model"
 	"github.com/thomaspoignant/go-feature-flag/testutils"
@@ -67,6 +68,10 @@ func TestSlackNotifier_Notify(t *testing.T) {
 								False:       false,
 								Default:     false,
 								TrackEvents: testutils.Bool(true),
+								Experimentation: &model.Experimentation{
+									StartDate: testutils.Time(time.Unix(1095379400, 0)),
+									EndDate:   testutils.Time(time.Unix(1095371000, 0)),
+								},
 							},
 							After: model.Flag{
 								Rule:        "key eq \"not-a-ke\"",

--- a/testdata/internal/notifier/slack/should_call_webhook_and_have_valid_results.json
+++ b/testdata/internal/notifier/slack/should_call_webhook_and_have_valid_results.json
@@ -47,6 +47,11 @@
           "title": "Disable",
           "value": "false =\u003e true",
           "short": true
+        },
+        {
+          "title": "Experimentation",
+          "value": "start:[2004-09-17T02:03:20+02:00] end:[2004-09-16T23:43:20+02:00] => <nil>",
+          "short": false
         }
       ],
       "footer_icon": "https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/logo_128.png",

--- a/testdata/internal/notifier/slack/should_call_webhook_and_have_valid_results.json
+++ b/testdata/internal/notifier/slack/should_call_webhook_and_have_valid_results.json
@@ -50,7 +50,7 @@
         },
         {
           "title": "Experimentation",
-          "value": "start:[2004-09-17T02:03:20+02:00] end:[2004-09-16T23:43:20+02:00] => <nil>",
+          "value": "start:[2004-09-17T00:03:20Z] end:[2004-09-16T21:43:20Z] => <nil>",
           "short": false
         }
       ],

--- a/testutils/convert_types.go
+++ b/testutils/convert_types.go
@@ -1,6 +1,13 @@
 package testutils
 
+import "time"
+
 // Bool returns a pointer to the bool value passed in.
 func Bool(v bool) *bool {
 	return &v
+}
+
+// Time returns a pointer to the Time value passed in.
+func Time(t time.Time) *time.Time {
+	return &t
 }


### PR DESCRIPTION
# Description
To do proper A/B tests we need to be able to run the flag for a specific amount of time.
You can now in the configuration of the flag set a **start date** and an **end date** for your flags.

If you are out of the range, your flag will serve the **default** value.

example:
```yaml
experimentation-flag:
  percentage: 50
  true: "B"
  false: "A"
  default: "A"
  experimentation:
    startDate: 2021-03-20T00:00:00.10-05:00
    endDate: 2021-03-21T00:00:00.10-05:00
```

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)
Resolve #102 

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
