### PR TITLE
Remove deprecated experimentation field

### DIFF
--- a/internal/model/flag.go
+++ b/internal/model/flag.go
@@ -50,9 +50,6 @@ type Flag struct {
 	// Disable is true if the flag is disabled.
 	Disable bool `json:"disable,omitempty" yaml:"disable,omitempty" toml:"disable,omitempty"`
 
-	// Deprecated: you should use Rollout.Experimentation instead.
-	Experimentation *Experimentation `json:"experimentation,omitempty" yaml:"experimentation,omitempty" toml:"experimentation,omitempty" slack_ignore:"true"` // nolint: lll
-
 	// Rollout is the object to configure how the flag is rollout.
 	// You have different rollout strategy available but only one is used at a time.
 	Rollout *Rollout `json:"rollout,omitempty" yaml:"rollout,omitempty" toml:"rollout,omitempty" slack_short:"false"` // nolint: lll
@@ -81,25 +78,9 @@ func (f *Flag) Value(flagName string, user ffuser.User) (interface{}, VariationT
 
 func (f *Flag) isExperimentationOver() bool {
 	now := time.Now()
-	// legacy experimentation notation
-	// TO BE REMOVED when deprecated time is over
-	legacy := f.Experimentation != nil && (
-		(f.Experimentation.Start != nil && now.Before(*f.Experimentation.Start)) ||
-			(f.Experimentation.StartDate != nil && now.Before(*f.Experimentation.StartDate)) ||
-			(f.Experimentation.End != nil && now.After(*f.Experimentation.End)) ||
-			(f.Experimentation.EndDate != nil && now.After(*f.Experimentation.EndDate)))
-
-	if legacy {
-		return legacy
-	}
-	// END TO BE REMOVED
-
 	return f.Rollout != nil && f.Rollout.Experimentation != nil && (
 		(f.Rollout.Experimentation.Start != nil && now.Before(*f.Rollout.Experimentation.Start)) ||
-			(f.Rollout.Experimentation.End != nil && now.After(*f.Rollout.Experimentation.End)) ||
-			// Remove bellow when deprecated field are removed
-			(f.Rollout.Experimentation.StartDate != nil && now.Before(*f.Rollout.Experimentation.StartDate)) ||
-			(f.Rollout.Experimentation.EndDate != nil && now.After(*f.Rollout.Experimentation.EndDate)))
+			(f.Rollout.Experimentation.End != nil && now.After(*f.Rollout.Experimentation.End)))
 }
 
 // isInPercentage check if the user is in the cohort for the toggle.

--- a/internal/model/flag_pub_test.go
+++ b/internal/model/flag_pub_test.go
@@ -12,14 +12,13 @@ import (
 
 func TestFlag_value(t *testing.T) {
 	type fields struct {
-		Disable         bool
-		Rule            string
-		Percentage      float64
-		True            interface{}
-		False           interface{}
-		Default         interface{}
-		Experimentation model.Experimentation
-		Rollout         model.Rollout
+		Disable    bool
+		Rule       string
+		Percentage float64
+		True       interface{}
+		False      interface{}
+		Default    interface{}
+		Rollout    model.Rollout
 	}
 	type args struct {
 		flagName string
@@ -70,377 +69,6 @@ func TestFlag_value(t *testing.T) {
 				variationType: model.VariationTrue,
 			},
 		},
-
-		// Remove these tests when the deprecated fields are removed
-		{
-			name: "Experimentation only start date in the past",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"7e50ee61-06ad-4bb0-9034-38ad7cdea9f5\"",
-				Percentage: 10,
-				Experimentation: model.Experimentation{
-					StartDate: testutils.Time(time.Now().Add(-1 * time.Minute)),
-					EndDate:   nil,
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("7e50ee61-06ad-4bb0-9034-38ad7cdea9f5").AddCustom("name", "john").Build(),
-			},
-			want: want{
-				value:         "true",
-				variationType: model.VariationTrue,
-			},
-		},
-		{
-			name: "Experimentation only start date in the future",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"user66\"",
-				Percentage: 10,
-				Experimentation: model.Experimentation{
-					StartDate: testutils.Time(time.Now().Add(1 * time.Minute)),
-					EndDate:   nil,
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
-			},
-			want: want{
-				value:         "default",
-				variationType: model.VariationDefault,
-			},
-		},
-		{
-			name: "Experimentation between start and end date",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"7e50ee61-06ad-4bb0-9034-38ad7cdea9f5\"",
-				Percentage: 10,
-				Experimentation: model.Experimentation{
-					StartDate: testutils.Time(time.Now().Add(-1 * time.Minute)),
-					EndDate:   testutils.Time(time.Now().Add(1 * time.Minute)),
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("7e50ee61-06ad-4bb0-9034-38ad7cdea9f5").AddCustom("name", "john").Build(),
-			},
-			want: want{
-				value:         "true",
-				variationType: model.VariationTrue,
-			},
-		},
-		{
-			name: "Experimentation not started yet",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"user66\"",
-				Percentage: 10,
-				Experimentation: model.Experimentation{
-					StartDate: testutils.Time(time.Now().Add(1 * time.Minute)),
-					EndDate:   testutils.Time(time.Now().Add(2 * time.Minute)),
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
-			},
-			want: want{
-				value:         "default",
-				variationType: model.VariationDefault,
-			},
-		},
-		{
-			name: "Experimentation finished",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"user66\"",
-				Percentage: 10,
-				Experimentation: model.Experimentation{
-					StartDate: testutils.Time(time.Now().Add(-2 * time.Minute)),
-					EndDate:   testutils.Time(time.Now().Add(-1 * time.Minute)),
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
-			},
-			want: want{
-				value:         "default",
-				variationType: model.VariationDefault,
-			},
-		},
-		{
-			name: "Experimentation only end date finished",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"user66\"",
-				Percentage: 10,
-				Experimentation: model.Experimentation{
-					StartDate: nil,
-					EndDate:   testutils.Time(time.Now().Add(-1 * time.Minute)),
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
-			},
-			want: want{
-				value:         "default",
-				variationType: model.VariationDefault,
-			},
-		},
-		{
-			name: "Experimentation only end date not finished",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"7e50ee61-06ad-4bb0-9034-38ad7cdea9f5\"",
-				Percentage: 10,
-				Experimentation: model.Experimentation{
-					StartDate: nil,
-					EndDate:   testutils.Time(time.Now().Add(1 * time.Minute)),
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("7e50ee61-06ad-4bb0-9034-38ad7cdea9f5").AddCustom("name", "john").Build(),
-			},
-			want: want{
-				value:         "true",
-				variationType: model.VariationTrue,
-			},
-		},
-		{
-			name: "Experimentation only end date not finished",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"7e50ee61-06ad-4bb0-9034-38ad7cdea9f5\"",
-				Percentage: 10,
-				Experimentation: model.Experimentation{
-					StartDate: nil,
-					EndDate:   nil,
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("7e50ee61-06ad-4bb0-9034-38ad7cdea9f5").AddCustom("name", "john").Build(),
-			},
-			want: want{
-				value:         "true",
-				variationType: model.VariationTrue,
-			},
-		},
-		{
-			name: "Rollout Deprecated Experimentation only start date in the past",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"7e50ee61-06ad-4bb0-9034-38ad7cdea9f5\"",
-				Percentage: 10,
-				Rollout: model.Rollout{
-					Experimentation: &model.Experimentation{
-						StartDate: testutils.Time(time.Now().Add(-1 * time.Minute)),
-						EndDate:   nil,
-					},
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("7e50ee61-06ad-4bb0-9034-38ad7cdea9f5").AddCustom("name", "john").Build(),
-			},
-			want: want{
-				value:         "true",
-				variationType: model.VariationTrue,
-			},
-		},
-		{
-			name: "Rollout Deprecated Experimentation only start date in the future",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"user66\"",
-				Percentage: 10,
-				Rollout: model.Rollout{
-					Experimentation: &model.Experimentation{
-						StartDate: testutils.Time(time.Now().Add(1 * time.Minute)),
-						EndDate:   nil,
-					},
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
-			},
-			want: want{
-				value:         "default",
-				variationType: model.VariationDefault,
-			},
-		},
-		{
-			name: "Rollout Deprecated Experimentation between start and end date",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"7e50ee61-06ad-4bb0-9034-38ad7cdea9f5\"",
-				Percentage: 10,
-				Rollout: model.Rollout{
-					Experimentation: &model.Experimentation{
-						StartDate: testutils.Time(time.Now().Add(-1 * time.Minute)),
-						EndDate:   testutils.Time(time.Now().Add(1 * time.Minute)),
-					},
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("7e50ee61-06ad-4bb0-9034-38ad7cdea9f5").AddCustom("name", "john").Build(),
-			},
-			want: want{
-				value:         "true",
-				variationType: model.VariationTrue,
-			},
-		},
-		{
-			name: "Rollout Deprecated Experimentation not started yet",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"user66\"",
-				Percentage: 10,
-				Rollout: model.Rollout{
-					Experimentation: &model.Experimentation{
-						StartDate: testutils.Time(time.Now().Add(1 * time.Minute)),
-						EndDate:   testutils.Time(time.Now().Add(2 * time.Minute)),
-					},
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
-			},
-			want: want{
-				value:         "default",
-				variationType: model.VariationDefault,
-			},
-		},
-		{
-			name: "Rollout Deprecated Experimentation finished",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"user66\"",
-				Percentage: 10,
-				Rollout: model.Rollout{
-					Experimentation: &model.Experimentation{
-						StartDate: testutils.Time(time.Now().Add(-2 * time.Minute)),
-						EndDate:   testutils.Time(time.Now().Add(-1 * time.Minute)),
-					},
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
-			},
-			want: want{
-				value:         "default",
-				variationType: model.VariationDefault,
-			},
-		},
-		{
-			name: "Rollout Deprecated Experimentation only end date finished",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"user66\"",
-				Percentage: 10,
-				Rollout: model.Rollout{
-					Experimentation: &model.Experimentation{
-						StartDate: nil,
-						EndDate:   testutils.Time(time.Now().Add(-1 * time.Minute)),
-					},
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("user66").AddCustom("name", "john").Build(), // combined hash is 9
-			},
-			want: want{
-				value:         "default",
-				variationType: model.VariationDefault,
-			},
-		},
-		{
-			name: "Rollout Deprecated Experimentation only end date not finished",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"7e50ee61-06ad-4bb0-9034-38ad7cdea9f5\"",
-				Percentage: 10,
-				Rollout: model.Rollout{
-					Experimentation: &model.Experimentation{
-						StartDate: nil,
-						EndDate:   testutils.Time(time.Now().Add(1 * time.Minute)),
-					},
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("7e50ee61-06ad-4bb0-9034-38ad7cdea9f5").AddCustom("name", "john").Build(),
-			},
-			want: want{
-				value:         "true",
-				variationType: model.VariationTrue,
-			},
-		},
-		{
-			name: "Rollout Deprecated Experimentation only end date not finished",
-			fields: fields{
-				True:       "true",
-				False:      "false",
-				Default:    "default",
-				Rule:       "key == \"7e50ee61-06ad-4bb0-9034-38ad7cdea9f5\"",
-				Percentage: 10,
-				Rollout: model.Rollout{
-					Experimentation: &model.Experimentation{
-						StartDate: nil,
-						EndDate:   nil,
-					},
-				},
-			},
-			args: args{
-				flagName: "test-flag",
-				user:     ffuser.NewUserBuilder("7e50ee61-06ad-4bb0-9034-38ad7cdea9f5").AddCustom("name", "john").Build(),
-			},
-			want: want{
-				value:         "true",
-				variationType: model.VariationTrue,
-			},
-		},
-		// End remove when deprecated ok
 		{
 			name: "Rollout Experimentation only start date in the past",
 			fields: fields{
@@ -641,9 +269,11 @@ func TestFlag_value(t *testing.T) {
 				Default:    "default",
 				Rule:       "key == \"user66\"",
 				Percentage: 10,
-				Experimentation: model.Experimentation{
-					StartDate: testutils.Time(time.Now().Add(1 * time.Minute)),
-					EndDate:   testutils.Time(time.Now().Add(-1 * time.Minute)),
+				Rollout: model.Rollout{
+					Experimentation: &model.Experimentation{
+						Start: testutils.Time(time.Now().Add(1 * time.Minute)),
+						End:   testutils.Time(time.Now().Add(-1 * time.Minute)),
+					},
 				},
 			},
 			args: args{
@@ -695,14 +325,13 @@ func TestFlag_value(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &model.Flag{
-				Disable:         tt.fields.Disable,
-				Rule:            tt.fields.Rule,
-				Percentage:      tt.fields.Percentage,
-				True:            tt.fields.True,
-				False:           tt.fields.False,
-				Default:         tt.fields.Default,
-				Experimentation: &tt.fields.Experimentation,
-				Rollout:         &tt.fields.Rollout,
+				Disable:    tt.fields.Disable,
+				Rule:       tt.fields.Rule,
+				Percentage: tt.fields.Percentage,
+				True:       tt.fields.True,
+				False:      tt.fields.False,
+				Default:    tt.fields.Default,
+				Rollout:    &tt.fields.Rollout,
 			}
 
 			got, variationType := f.Value(tt.args.flagName, tt.args.user)

--- a/internal/model/rollout.go
+++ b/internal/model/rollout.go
@@ -21,11 +21,6 @@ func (e Rollout) String() string {
 }
 
 type Experimentation struct {
-	// Deprecated: use Start instead
-	StartDate *time.Time `json:"startDate,omitempty" yaml:"startDate,omitempty" toml:"startDate,omitempty"`
-	// Deprecated: use End instead
-	EndDate *time.Time `json:"endDate,omitempty" yaml:"endDate,omitempty" toml:"endDate,omitempty"`
-
 	// Start is the starting time of the experimentation
 	Start *time.Time `json:"start,omitempty" yaml:"start,omitempty" toml:"start,omitempty"`
 
@@ -36,15 +31,6 @@ type Experimentation struct {
 func (e Experimentation) String() string {
 	buf := make([]string, 0)
 	lo, _ := time.LoadLocation("UTC")
-
-	// Remove when deprecated fields will be removed
-	if e.StartDate != nil {
-		buf = append(buf, fmt.Sprintf("start:[%v]", e.StartDate.In(lo).Format(time.RFC3339)))
-	}
-	if e.EndDate != nil {
-		buf = append(buf, fmt.Sprintf("end:[%v]", e.EndDate.In(lo).Format(time.RFC3339)))
-	}
-	// end removed
 
 	if e.Start != nil {
 		buf = append(buf, fmt.Sprintf("start:[%v]", e.Start.In(lo).Format(time.RFC3339)))

--- a/internal/model/rollout_test.go
+++ b/internal/model/rollout_test.go
@@ -22,28 +22,6 @@ func TestExperimentation_String(t *testing.T) {
 		want   string
 	}{
 		{
-			name: "both dates - deprecated fields",
-			fields: fields{
-				StartDate: testconvert.Time(time.Unix(1095379400, 0)),
-				EndDate:   testconvert.Time(time.Unix(1095379500, 0)),
-			},
-			want: "start:[2004-09-17T00:03:20Z] end:[2004-09-17T00:05:00Z]",
-		},
-		{
-			name: "only start date - deprecated fields",
-			fields: fields{
-				StartDate: testconvert.Time(time.Unix(1095379400, 0)),
-			},
-			want: "start:[2004-09-17T00:03:20Z]",
-		},
-		{
-			name: "only end date - deprecated fields",
-			fields: fields{
-				EndDate: testconvert.Time(time.Unix(1095379500, 0)),
-			},
-			want: "end:[2004-09-17T00:05:00Z]",
-		},
-		{
 			name: "both dates",
 			fields: fields{
 				Start: testconvert.Time(time.Unix(1095379400, 0)),

--- a/internal/model/rollout_test.go
+++ b/internal/model/rollout_test.go
@@ -11,38 +11,14 @@ import (
 
 func TestExperimentation_String(t *testing.T) {
 	type fields struct {
-		StartDate *time.Time
-		EndDate   *time.Time
-		Start     *time.Time
-		End       *time.Time
+		Start *time.Time
+		End   *time.Time
 	}
 	tests := []struct {
 		name   string
 		fields fields
 		want   string
 	}{
-		{
-			name: "both dates - deprecated fields",
-			fields: fields{
-				StartDate: testutils.Time(time.Unix(1095379400, 0)),
-				EndDate:   testutils.Time(time.Unix(1095379500, 0)),
-			},
-			want: "start:[2004-09-17T00:03:20Z] end:[2004-09-17T00:05:00Z]",
-		},
-		{
-			name: "only start date - deprecated fields",
-			fields: fields{
-				StartDate: testutils.Time(time.Unix(1095379400, 0)),
-			},
-			want: "start:[2004-09-17T00:03:20Z]",
-		},
-		{
-			name: "only end date - deprecated fields",
-			fields: fields{
-				EndDate: testutils.Time(time.Unix(1095379500, 0)),
-			},
-			want: "end:[2004-09-17T00:05:00Z]",
-		},
 		{
 			name: "both dates",
 			fields: fields{
@@ -69,10 +45,8 @@ func TestExperimentation_String(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := model.Experimentation{
-				StartDate: tt.fields.StartDate,
-				EndDate:   tt.fields.EndDate,
-				End:       tt.fields.End,
-				Start:     tt.fields.Start,
+				End:   tt.fields.End,
+				Start: tt.fields.Start,
 			}
 			got := e.String()
 			assert.Equal(t, tt.want, got)


### PR DESCRIPTION
# Description
In version `v0.13.0` we introduced the configuration option `experimentation` for your flags.
The field was introduced at the wrong level because it is supposed to be under `rollout` and it was not.

The `v0.13.1` has fixed the problem but we have continued to support both configurations.
⚠️ This PR removes the support of the old configuration, so check your flag file to be sure that you've configured the good format.
Since the version `v0.13.0` and the associate documentation was here only for a quick period it should be ok, but this worth checking.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)
Resolve #114

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
