### PR TITLE
Use context when calling the exporter

### DIFF
--- a/feature_flag.go
+++ b/feature_flag.go
@@ -81,7 +81,7 @@ func New(config Config) (*GoFeatureFlag, error) {
 
 	if goFF.config.DataExporter.Exporter != nil {
 		// init the data exporter
-		goFF.dataExporter = exporter.NewDataExporterScheduler(goFF.config.DataExporter.FlushInterval,
+		goFF.dataExporter = exporter.NewDataExporterScheduler(goFF.config.Context, goFF.config.DataExporter.FlushInterval,
 			goFF.config.DataExporter.MaxEventInMemory, goFF.config.DataExporter.Exporter, goFF.config.Logger)
 
 		// we start the daemon only if we have a bulk exporter

--- a/ffexporter/file.go
+++ b/ffexporter/file.go
@@ -1,6 +1,7 @@
 package ffexporter
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -42,7 +43,7 @@ type File struct {
 }
 
 // Export is saving a collection of events in a file.
-func (f *File) Export(logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (f *File) Export(ctx context.Context, logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
 	// Parse the template only once
 	f.initTemplates.Do(func() {
 		f.csvTemplate = parseTemplate("csvFormat", f.CsvTemplate, DefaultCsvTemplate)

--- a/ffexporter/file_test.go
+++ b/ffexporter/file_test.go
@@ -1,6 +1,7 @@
 package ffexporter_test
 
 import (
+	"context"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
@@ -191,7 +192,7 @@ func TestFile_Export(t *testing.T) {
 				Filename:    tt.fields.Filename,
 				CsvTemplate: tt.fields.CsvTemplate,
 			}
-			err := f.Export(tt.args.logger, tt.args.featureEvents)
+			err := f.Export(context.Background(), tt.args.logger, tt.args.featureEvents)
 			if tt.wantErr {
 				assert.Error(t, err, "export method should error")
 				return

--- a/ffexporter/log.go
+++ b/ffexporter/log.go
@@ -2,6 +2,7 @@ package ffexporter
 
 import (
 	"bytes"
+	"context"
 	"log"
 	"sync"
 	"text/template"
@@ -24,7 +25,7 @@ type Log struct {
 }
 
 // Export is saving a collection of events in a file.
-func (f *Log) Export(logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (f *Log) Export(ctx context.Context, logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
 	f.initTemplates.Do(func() {
 		f.logTemplate = parseTemplate("logFormat", f.Format, defaultLoggerFormat)
 	})

--- a/ffexporter/log_test.go
+++ b/ffexporter/log_test.go
@@ -1,6 +1,7 @@
 package ffexporter_test
 
 import (
+	"context"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"log"
@@ -78,7 +79,7 @@ func TestLog_Export(t *testing.T) {
 			logFile, _ := ioutil.TempFile("", "")
 			logger := log.New(logFile, "", 0)
 
-			err := f.Export(logger, tt.args.featureEvents)
+			err := f.Export(context.Background(), logger, tt.args.featureEvents)
 
 			if tt.wantErr {
 				assert.Error(t, err, "It should return an error")

--- a/ffexporter/s3.go
+++ b/ffexporter/s3.go
@@ -1,6 +1,7 @@
 package ffexporter
 
 import (
+	"context"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -49,7 +50,7 @@ type S3 struct {
 }
 
 // Export is saving a collection of events in a file.
-func (f *S3) Export(logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (f *S3) Export(ctx context.Context, logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
 	// init the s3 uploader
 	if f.s3Uploader == nil {
 		var initErr error
@@ -79,7 +80,7 @@ func (f *S3) Export(logger *log.Logger, featureEvents []exporter.FeatureEvent) e
 		Filename:    f.Filename,
 		CsvTemplate: f.CsvTemplate,
 	}
-	err = fileExporter.Export(logger, featureEvents)
+	err = fileExporter.Export(ctx, logger, featureEvents)
 	if err != nil {
 		return err
 	}
@@ -97,7 +98,8 @@ func (f *S3) Export(logger *log.Logger, featureEvents []exporter.FeatureEvent) e
 			continue
 		}
 
-		result, err := f.s3Uploader.Upload(
+		result, err := f.s3Uploader.UploadWithContext(
+			ctx,
 			&s3manager.UploadInput{
 				Bucket: aws.String(f.Bucket),
 				Key:    aws.String(f.S3Path + "/" + file.Name()),

--- a/ffexporter/s3_test.go
+++ b/ffexporter/s3_test.go
@@ -1,6 +1,7 @@
 package ffexporter
 
 import (
+	"context"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
@@ -158,7 +159,7 @@ func TestS3_Export(t *testing.T) {
 				CsvTemplate: tt.fields.CsvTemplate,
 				s3Uploader:  &s3ManagerMock,
 			}
-			err := f.Export(log.New(os.Stdout, "", 0), tt.events)
+			err := f.Export(context.Background(), log.New(os.Stdout, "", 0), tt.events)
 			if tt.wantErr {
 				assert.Error(t, err, "Export should error")
 				return
@@ -180,7 +181,7 @@ func Test_errSDK(t *testing.T) {
 		Bucket:    "empty",
 		AwsConfig: &aws.Config{},
 	}
-	err := f.Export(log.New(os.Stdout, "", 0), []exporter.FeatureEvent{})
+	err := f.Export(context.Background(), log.New(os.Stdout, "", 0), []exporter.FeatureEvent{})
 	assert.Error(t, err, "Empty AWS config should failed")
 }
 

--- a/ffexporter/webhook_test.go
+++ b/ffexporter/webhook_test.go
@@ -1,6 +1,7 @@
 package ffexporter
 
 import (
+	"context"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"log"
@@ -138,7 +139,7 @@ func TestWebhook_Export(t *testing.T) {
 				Meta:        tt.fields.Meta,
 				httpClient:  &tt.fields.httpClient,
 			}
-			err := f.Export(tt.args.logger, tt.args.featureEvents)
+			err := f.Export(context.Background(), tt.args.logger, tt.args.featureEvents)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -162,10 +163,6 @@ func TestWebhook_Export_impossibleToParse(t *testing.T) {
 		EndpointURL: " http://invalid.com/",
 	}
 
-	err := f.Export(log.New(os.Stdout, "", 0), []exporter.FeatureEvent{})
+	err := f.Export(context.Background(), log.New(os.Stdout, "", 0), []exporter.FeatureEvent{})
 	assert.EqualError(t, err, "parse \" http://invalid.com/\": first path segment in URL cannot contain colon")
-
-	// We should parse the URL only once
-	err = f.Export(log.New(os.Stdout, "", 0), []exporter.FeatureEvent{})
-	assert.EqualError(t, err, "no URL available for the webhook")
 }

--- a/internal/exporter/data_exporter_test.go
+++ b/internal/exporter/data_exporter_test.go
@@ -1,6 +1,7 @@
 package exporter_test
 
 import (
+	"context"
 	"errors"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
@@ -18,7 +19,7 @@ import (
 func TestDataExporterScheduler_flushWithTime(t *testing.T) {
 	mockExporter := testutils.MockExporter{Bulk: true}
 	dc := exporter.NewDataExporterScheduler(
-		10*time.Millisecond, 1000, &mockExporter, log.New(os.Stdout, "", 0))
+		context.Background(), 10*time.Millisecond, 1000, &mockExporter, log.New(os.Stdout, "", 0))
 	go dc.StartDaemon()
 	defer dc.Close()
 
@@ -38,7 +39,7 @@ func TestDataExporterScheduler_flushWithTime(t *testing.T) {
 func TestDataExporterScheduler_flushWithNumberOfEvents(t *testing.T) {
 	mockExporter := testutils.MockExporter{Bulk: true}
 	dc := exporter.NewDataExporterScheduler(
-		10*time.Minute, 100, &mockExporter, log.New(os.Stdout, "", 0))
+		context.Background(), 10*time.Minute, 100, &mockExporter, log.New(os.Stdout, "", 0))
 	go dc.StartDaemon()
 	defer dc.Close()
 
@@ -56,7 +57,7 @@ func TestDataExporterScheduler_flushWithNumberOfEvents(t *testing.T) {
 func TestDataExporterScheduler_defaultFlush(t *testing.T) {
 	mockExporter := testutils.MockExporter{Bulk: true}
 	dc := exporter.NewDataExporterScheduler(
-		0, 0, &mockExporter, log.New(os.Stdout, "", 0))
+		context.Background(), 0, 0, &mockExporter, log.New(os.Stdout, "", 0))
 	go dc.StartDaemon()
 	defer dc.Close()
 
@@ -80,7 +81,7 @@ func TestDataExporterScheduler_exporterReturnError(t *testing.T) {
 	logger := log.New(file, "", 0)
 
 	dc := exporter.NewDataExporterScheduler(
-		0, 100, &mockExporter, logger)
+		context.Background(), 0, 100, &mockExporter, logger)
 	go dc.StartDaemon()
 	defer dc.Close()
 
@@ -102,7 +103,7 @@ func TestDataExporterScheduler_exporterReturnError(t *testing.T) {
 func TestDataExporterScheduler_nonBulkExporter(t *testing.T) {
 	mockExporter := testutils.MockExporter{Bulk: false}
 	dc := exporter.NewDataExporterScheduler(
-		0, 0, &mockExporter, log.New(os.Stdout, "", 0))
+		context.Background(), 0, 0, &mockExporter, log.New(os.Stdout, "", 0))
 	defer dc.Close()
 
 	var inputEvents []exporter.FeatureEvent

--- a/testutils/mock_exporter.go
+++ b/testutils/mock_exporter.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"context"
 	"log"
 	"sync"
 
@@ -18,7 +19,7 @@ type MockExporter struct {
 	once  sync.Once
 }
 
-func (m *MockExporter) Export(logger *log.Logger, events []exporter.FeatureEvent) error {
+func (m *MockExporter) Export(ctx context.Context, logger *log.Logger, events []exporter.FeatureEvent) error {
 	m.once.Do(m.initMutex)
 	m.mutex.Lock()
 	defer m.mutex.Unlock()

--- a/variation_test.go
+++ b/variation_test.go
@@ -1,6 +1,7 @@
 package ffclient
 
 import (
+	"context"
 	"errors"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
@@ -192,7 +193,7 @@ func TestBoolVariation(t *testing.T) {
 					PollInterval: 0,
 					Logger:       logger,
 				},
-				dataExporter: exporter.NewDataExporterScheduler(0, 0,
+				dataExporter: exporter.NewDataExporterScheduler(context.Background(), 0, 0,
 					&ffexporter.Log{}, logger),
 			}
 
@@ -210,7 +211,7 @@ func TestBoolVariation(t *testing.T) {
 			}
 			// clean logger
 			ff = nil
-			file.Close()
+			_ = file.Close()
 		})
 	}
 }
@@ -373,7 +374,7 @@ func TestFloat64Variation(t *testing.T) {
 					PollInterval: 0,
 					Logger:       logger,
 				},
-				dataExporter: exporter.NewDataExporterScheduler(0, 0,
+				dataExporter: exporter.NewDataExporterScheduler(context.Background(), 0, 0,
 					&ffexporter.Log{}, logger),
 			}
 
@@ -390,7 +391,7 @@ func TestFloat64Variation(t *testing.T) {
 			}
 			// clean logger
 			ff = nil
-			file.Close()
+			_ = file.Close()
 		})
 	}
 }
@@ -571,7 +572,7 @@ func TestJSONArrayVariation(t *testing.T) {
 					PollInterval: 0,
 					Logger:       logger,
 				},
-				dataExporter: exporter.NewDataExporterScheduler(0, 0,
+				dataExporter: exporter.NewDataExporterScheduler(context.Background(), 0, 0,
 					&ffexporter.Log{}, logger),
 			}
 
@@ -588,7 +589,7 @@ func TestJSONArrayVariation(t *testing.T) {
 			}
 			// clean logger
 			ff = nil
-			file.Close()
+			_ = file.Close()
 		})
 	}
 }
@@ -732,7 +733,7 @@ func TestJSONVariation(t *testing.T) {
 					PollInterval: 0,
 					Logger:       logger,
 				},
-				dataExporter: exporter.NewDataExporterScheduler(0, 0,
+				dataExporter: exporter.NewDataExporterScheduler(context.Background(), 0, 0,
 					&ffexporter.Log{}, logger),
 			}
 
@@ -750,7 +751,7 @@ func TestJSONVariation(t *testing.T) {
 			}
 			// clean logger
 			ff = nil
-			file.Close()
+			_ = file.Close()
 		})
 	}
 }
@@ -896,7 +897,7 @@ func TestStringVariation(t *testing.T) {
 					PollInterval: 0,
 					Logger:       logger,
 				},
-				dataExporter: exporter.NewDataExporterScheduler(0, 0,
+				dataExporter: exporter.NewDataExporterScheduler(context.Background(), 0, 0,
 					&ffexporter.Log{}, logger),
 			}
 			got, err := StringVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
@@ -913,7 +914,7 @@ func TestStringVariation(t *testing.T) {
 			}
 			// clean logger
 			ff = nil
-			file.Close()
+			_ = file.Close()
 		})
 	}
 }
@@ -1058,7 +1059,7 @@ func TestIntVariation(t *testing.T) {
 					PollInterval: 0,
 					Logger:       logger,
 				},
-				dataExporter: exporter.NewDataExporterScheduler(0, 0,
+				dataExporter: exporter.NewDataExporterScheduler(context.Background(), 0, 0,
 					&ffexporter.Log{}, logger),
 			}
 			got, err := IntVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
@@ -1075,7 +1076,7 @@ func TestIntVariation(t *testing.T) {
 			}
 			// clean logger
 			ff = nil
-			file.Close()
+			_ = file.Close()
 		})
 	}
 }


### PR DESCRIPTION
# Description
This PR use the context we pass in the configuration when we call the data exporter.

# Closes issue(s)
Resolve #116

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
