### PR TITLE
JSON Variation are notified twice

### DIFF
--- a/variation.go
+++ b/variation.go
@@ -186,7 +186,6 @@ func (g *GoFeatureFlag) JSONVariation(
 		return defaultValue, fmt.Errorf(errorWrongVariation, flagKey)
 	}
 	g.notifyVariation(flagKey, flag, user, res, variationType, false)
-	g.notifyVariation(flagKey, flag, user, res, variationType, false)
 	return res, nil
 }
 


### PR DESCRIPTION
# Description
`JSONVariation` are notified twice that result in an error in the data export.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (README.md and /docs)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
