### PR TITLE
AllFlagsSet Don't crash when flag is not correctly initialized 

### DIFF
--- a/testdata/ffclient/all_flags/config_flag/flag-config-with-error.yaml
+++ b/testdata/ffclient/all_flags/config_flag/flag-config-with-error.yaml
@@ -1,0 +1,40 @@
+test-flag0:
+  percentage: 100
+  true:
+  false: false
+  default: false
+test-flag1:
+  percentage: 100
+  true: "true"
+  false: "false"
+  default: "false"
+test-flag2:
+  percentage: 100
+  true: 1
+  false: 2
+  default: 3
+test-flag3:
+  percentage: 100
+  true:
+    - yo
+    - ya
+  false:
+    - yo
+    - ya
+  default:
+    - yo
+    - ya
+test-flag4:
+  percentage: 100
+  true:
+    test: yo
+  false:
+    test: yo
+  default:
+    test: yo
+test-flag5:
+  percentage: 100
+  true: 1.1
+  false: 1.2
+  default: 1.3
+  trackEvents: false

--- a/testdata/ffclient/all_flags/marshal_json/error_in_flag_0.json
+++ b/testdata/ffclient/all_flags/marshal_json/error_in_flag_0.json
@@ -1,0 +1,46 @@
+{
+  "flags": {
+    "test-flag0": {
+      "value": false,
+      "timestamp": 1622206239,
+      "variationType": "Default",
+      "trackEvents": true
+    },
+    "test-flag1": {
+      "value": "true",
+      "timestamp": 1622206239,
+      "variationType": "True",
+      "trackEvents": true
+    },
+    "test-flag2": {
+      "value": 1,
+      "timestamp": 1622206239,
+      "variationType": "True",
+      "trackEvents": true
+    },
+    "test-flag3": {
+      "value": [
+        "yo",
+        "ya"
+      ],
+      "timestamp": 1622206239,
+      "variationType": "True",
+      "trackEvents": true
+    },
+    "test-flag4": {
+      "value": {
+        "test": "yo"
+      },
+      "timestamp": 1622206239,
+      "variationType": "True",
+      "trackEvents": true
+    },
+    "test-flag5": {
+      "value": 1.1,
+      "timestamp": 1622206239,
+      "variationType": "True",
+      "trackEvents": false
+    }
+  },
+  "valid": false
+}

--- a/variation.go
+++ b/variation.go
@@ -132,7 +132,14 @@ func (g *GoFeatureFlag) AllFlagsState(user ffuser.User) flagstate.AllFlags {
 	}
 
 	allFlags := flagstate.NewAllFlags()
-	for key := range flags {
+	for key, flag := range flags {
+		// True is not configured the flag is not valid
+		if flags[key].True == nil {
+			allFlags.AddFlag(
+				key, flagstate.NewFlagState(flag.GetTrackEvents(), flag.GetDefault(), model.VariationDefault, true))
+			continue
+		}
+
 		switch trueValue := *flags[key].True; trueValue.(type) {
 		case int:
 			f, _ := g.intVariation(key, user, 0)
@@ -172,7 +179,7 @@ func (g *GoFeatureFlag) boolVariation(flagKey string, user ffuser.User, defaultV
 			Value: defaultValue,
 			VariationResult: model.VariationResult{
 				VariationType: model.VariationSDKDefault,
-				Failed: true,
+				Failed:        true,
 			},
 		}, err
 	}

--- a/variation_test.go
+++ b/variation_test.go
@@ -1124,6 +1124,17 @@ func TestAllFlagsState(t *testing.T) {
 			initModule: true,
 		},
 		{
+			name: "Error in flag-0",
+			config: Config{
+				Retriever: &FileRetriever{
+					Path: "./testdata/ffclient/all_flags/config_flag/flag-config-with-error.yaml",
+				},
+			},
+			valid:      false,
+			jsonOutput: "./testdata/ffclient/all_flags/marshal_json/error_in_flag_0.json",
+			initModule: true,
+		},
+		{
 			name: "module not init",
 			config: Config{
 				Retriever: &FileRetriever{


### PR DESCRIPTION
# Description
We had a problem when the **True** value was not correctly set the `AllFlagsState` function was crashing.
This fix avoids the crash and we are using the default value.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Closes issue(s)
Resolve #158

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
