### PR TITLE
(bug) Fix a problem in the exported data for the variation type

### DIFF
--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -62,6 +62,9 @@ func TestValidUseCase(t *testing.T) {
 	assert.True(t, hasTestFlag, "User should have test flag")
 	hasUnknownFlag, _ := ffclient.BoolVariation("unknown-flag", user, false)
 	assert.False(t, hasUnknownFlag, "User should use default value if flag does not exists")
+
+	allFlags := ffclient.AllFlagsState(user)
+	assert.Equal(t, 2, len(allFlags.GetFlags()))
 }
 
 func TestValidUseCaseToml(t *testing.T) {

--- a/variation.go
+++ b/variation.go
@@ -171,16 +171,13 @@ func (g *GoFeatureFlag) AllFlagsState(user ffuser.User) flagstate.AllFlags {
 
 // boolVariation is the internal func that handle the logic of a variation with a bool value
 // the result will always contains a valid model.BoolVarResult
-func (g *GoFeatureFlag) boolVariation(flagKey string, user ffuser.User, defaultValue bool,
+func (g *GoFeatureFlag) boolVariation(flagKey string, user ffuser.User, sdkDefaultValue bool,
 ) (model.BoolVarResult, error) {
 	flag, err := g.getFlagFromCache(flagKey)
 	if err != nil {
 		return model.BoolVarResult{
-			Value: defaultValue,
-			VariationResult: model.VariationResult{
-				VariationType: model.VariationSDKDefault,
-				Failed:        true,
-			},
+			Value:           sdkDefaultValue,
+			VariationResult: computeVariationResult(flag, model.VariationSDKDefault, true),
 		}, err
 	}
 
@@ -188,27 +185,23 @@ func (g *GoFeatureFlag) boolVariation(flagKey string, user ffuser.User, defaultV
 	res, ok := flagValue.(bool)
 	if !ok {
 		return model.BoolVarResult{
-			Value: defaultValue,
-			VariationResult: model.VariationResult{
-				TrackEvents:   flag.GetTrackEvents(),
-				VariationType: model.VariationSDKDefault,
-				Failed:        true,
-			},
+			Value:           sdkDefaultValue,
+			VariationResult: computeVariationResult(flag, model.VariationSDKDefault, true),
 		}, fmt.Errorf(errorWrongVariation, flagKey)
 	}
 	return model.BoolVarResult{Value: res,
-		VariationResult: model.VariationResult{TrackEvents: flag.GetTrackEvents(), VariationType: variationType},
+		VariationResult: computeVariationResult(flag, variationType, false),
 	}, nil
 }
 
 // intVariation is the internal func that handle the logic of a variation with an int value
 // the result will always contains a valid model.IntVarResult
-func (g *GoFeatureFlag) intVariation(flagKey string, user ffuser.User, defaultValue int,
+func (g *GoFeatureFlag) intVariation(flagKey string, user ffuser.User, sdkDefaultValue int,
 ) (model.IntVarResult, error) {
 	flag, err := g.getFlagFromCache(flagKey)
 	if err != nil {
-		return model.IntVarResult{Value: defaultValue,
-			VariationResult: model.VariationResult{VariationType: model.VariationSDKDefault, Failed: true},
+		return model.IntVarResult{Value: sdkDefaultValue,
+			VariationResult: computeVariationResult(flag, model.VariationSDKDefault, true),
 		}, err
 	}
 
@@ -218,41 +211,30 @@ func (g *GoFeatureFlag) intVariation(flagKey string, user ffuser.User, defaultVa
 		// if this is a float64 we convert it to int
 		if resFloat, okFloat := flagValue.(float64); okFloat {
 			return model.IntVarResult{
-				Value: int(resFloat),
-				VariationResult: model.VariationResult{
-					TrackEvents:   flag.GetTrackEvents(),
-					VariationType: model.VariationSDKDefault,
-					Failed:        true,
-				},
-			}, fmt.Errorf(errorWrongVariation, flagKey)
+				Value:           int(resFloat),
+				VariationResult: computeVariationResult(flag, variationType, false),
+			}, nil
 		}
 
 		return model.IntVarResult{
-			Value: defaultValue,
-			VariationResult: model.VariationResult{
-				TrackEvents:   flag.GetTrackEvents(),
-				VariationType: model.VariationSDKDefault,
-				Failed:        true,
-			},
+			Value:           sdkDefaultValue,
+			VariationResult: computeVariationResult(flag, model.VariationSDKDefault, true),
 		}, fmt.Errorf(errorWrongVariation, flagKey)
 	}
 	return model.IntVarResult{Value: res,
-		VariationResult: model.VariationResult{TrackEvents: flag.GetTrackEvents(), VariationType: variationType},
+		VariationResult: computeVariationResult(flag, variationType, false),
 	}, nil
 }
 
 // float64Variation is the internal func that handle the logic of a variation with a float64 value
 // the result will always contains a valid model.Float64VarResult
-func (g *GoFeatureFlag) float64Variation(flagKey string, user ffuser.User, defaultValue float64,
+func (g *GoFeatureFlag) float64Variation(flagKey string, user ffuser.User, sdkDefaultValue float64,
 ) (model.Float64VarResult, error) {
 	flag, err := g.getFlagFromCache(flagKey)
 	if err != nil {
 		return model.Float64VarResult{
-			Value: defaultValue,
-			VariationResult: model.VariationResult{
-				VariationType: model.VariationSDKDefault,
-				Failed:        true,
-			},
+			Value:           sdkDefaultValue,
+			VariationResult: computeVariationResult(flag, model.VariationSDKDefault, true),
 		}, err
 	}
 
@@ -260,31 +242,25 @@ func (g *GoFeatureFlag) float64Variation(flagKey string, user ffuser.User, defau
 	res, ok := flagValue.(float64)
 	if !ok {
 		return model.Float64VarResult{
-			Value: defaultValue,
-			VariationResult: model.VariationResult{
-				TrackEvents:   flag.GetTrackEvents(),
-				VariationType: model.VariationSDKDefault,
-				Failed:        true,
-			},
+			Value:           sdkDefaultValue,
+			VariationResult: computeVariationResult(flag, model.VariationSDKDefault, true),
 		}, fmt.Errorf(errorWrongVariation, flagKey)
 	}
-	return model.Float64VarResult{Value: res,
-		VariationResult: model.VariationResult{TrackEvents: flag.GetTrackEvents(), VariationType: variationType},
+	return model.Float64VarResult{
+		Value:           res,
+		VariationResult: computeVariationResult(flag, variationType, false),
 	}, nil
 }
 
 // stringVariation is the internal func that handle the logic of a variation with a string value
 // the result will always contains a valid model.StringVarResult
-func (g *GoFeatureFlag) stringVariation(flagKey string, user ffuser.User, defaultValue string,
+func (g *GoFeatureFlag) stringVariation(flagKey string, user ffuser.User, sdkDefaultValue string,
 ) (model.StringVarResult, error) {
 	flag, err := g.getFlagFromCache(flagKey)
 	if err != nil {
 		return model.StringVarResult{
-			Value: defaultValue,
-			VariationResult: model.VariationResult{
-				VariationType: model.VariationSDKDefault,
-				Failed:        true,
-			},
+			Value:           sdkDefaultValue,
+			VariationResult: computeVariationResult(flag, model.VariationSDKDefault, true),
 		}, err
 	}
 
@@ -292,31 +268,25 @@ func (g *GoFeatureFlag) stringVariation(flagKey string, user ffuser.User, defaul
 	res, ok := flagValue.(string)
 	if !ok {
 		return model.StringVarResult{
-			Value: defaultValue,
-			VariationResult: model.VariationResult{
-				TrackEvents:   flag.GetTrackEvents(),
-				VariationType: model.VariationSDKDefault,
-				Failed:        true,
-			},
+			Value:           sdkDefaultValue,
+			VariationResult: computeVariationResult(flag, model.VariationSDKDefault, true),
 		}, fmt.Errorf(errorWrongVariation, flagKey)
 	}
-	return model.StringVarResult{Value: res,
-		VariationResult: model.VariationResult{TrackEvents: flag.GetTrackEvents(), VariationType: variationType},
+	return model.StringVarResult{
+		Value:           res,
+		VariationResult: computeVariationResult(flag, variationType, false),
 	}, nil
 }
 
 // jsonArrayVariation is the internal func that handle the logic of a variation with a json value
 // the result will always contains a valid model.JSONArrayVarResult
-func (g *GoFeatureFlag) jsonArrayVariation(flagKey string, user ffuser.User, defaultValue []interface{},
+func (g *GoFeatureFlag) jsonArrayVariation(flagKey string, user ffuser.User, sdkDefaultValue []interface{},
 ) (model.JSONArrayVarResult, error) {
 	flag, err := g.getFlagFromCache(flagKey)
 	if err != nil {
 		return model.JSONArrayVarResult{
-			Value: defaultValue,
-			VariationResult: model.VariationResult{
-				VariationType: model.VariationSDKDefault,
-				Failed:        true,
-			},
+			Value:           sdkDefaultValue,
+			VariationResult: computeVariationResult(flag, model.VariationSDKDefault, true),
 		}, err
 	}
 
@@ -324,31 +294,25 @@ func (g *GoFeatureFlag) jsonArrayVariation(flagKey string, user ffuser.User, def
 	res, ok := flagValue.([]interface{})
 	if !ok {
 		return model.JSONArrayVarResult{
-			Value: defaultValue,
-			VariationResult: model.VariationResult{
-				TrackEvents:   flag.GetTrackEvents(),
-				VariationType: model.VariationSDKDefault,
-				Failed:        true,
-			},
+			Value:           sdkDefaultValue,
+			VariationResult: computeVariationResult(flag, model.VariationSDKDefault, true),
 		}, fmt.Errorf(errorWrongVariation, flagKey)
 	}
-	return model.JSONArrayVarResult{Value: res,
-		VariationResult: model.VariationResult{TrackEvents: flag.GetTrackEvents(), VariationType: variationType},
+	return model.JSONArrayVarResult{
+		Value:           res,
+		VariationResult: computeVariationResult(flag, variationType, false),
 	}, nil
 }
 
 // jsonVariation is the internal func that handle the logic of a variation with a json value
 // the result will always contains a valid model.JSONVarResult
-func (g *GoFeatureFlag) jsonVariation(flagKey string, user ffuser.User, defaultValue map[string]interface{},
+func (g *GoFeatureFlag) jsonVariation(flagKey string, user ffuser.User, sdkDefaultValue map[string]interface{},
 ) (model.JSONVarResult, error) {
 	flag, err := g.getFlagFromCache(flagKey)
 	if err != nil {
 		return model.JSONVarResult{
-			Value: defaultValue,
-			VariationResult: model.VariationResult{
-				VariationType: model.VariationSDKDefault,
-				Failed:        true,
-			},
+			Value:           sdkDefaultValue,
+			VariationResult: computeVariationResult(flag, model.VariationSDKDefault, true),
 		}, err
 	}
 
@@ -356,17 +320,28 @@ func (g *GoFeatureFlag) jsonVariation(flagKey string, user ffuser.User, defaultV
 	res, ok := flagValue.(map[string]interface{})
 	if !ok {
 		return model.JSONVarResult{
-			Value: defaultValue,
-			VariationResult: model.VariationResult{
-				TrackEvents:   flag.GetTrackEvents(),
-				VariationType: model.VariationSDKDefault,
-				Failed:        true,
-			},
+			Value:           sdkDefaultValue,
+			VariationResult: computeVariationResult(flag, model.VariationSDKDefault, true),
 		}, fmt.Errorf(errorWrongVariation, flagKey)
 	}
-	return model.JSONVarResult{Value: res,
-		VariationResult: model.VariationResult{TrackEvents: flag.GetTrackEvents(), VariationType: variationType},
+	return model.JSONVarResult{
+		Value:           res,
+		VariationResult: computeVariationResult(flag, variationType, false),
 	}, nil
+}
+
+// computeVariationResult is creating a model.VariationResult
+func computeVariationResult(flag model.Flag, variationType model.VariationType, failed bool) model.VariationResult {
+	varResult := model.VariationResult{
+		VariationType: variationType,
+		Failed:        failed,
+	}
+
+	if flag != nil {
+		varResult.TrackEvents = flag.GetTrackEvents()
+	}
+
+	return varResult
 }
 
 // notifyVariation is logging the evaluation result for a flag

--- a/variation_test.go
+++ b/variation_test.go
@@ -66,7 +66,7 @@ func TestBoolVariation(t *testing.T) {
 			},
 			want:        true,
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"disable-flag\", value=\"true\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"disable-flag\", value=\"true\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get error when not init",
@@ -80,7 +80,7 @@ func TestBoolVariation(t *testing.T) {
 			},
 			want:        true,
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"true\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"true\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get default value with key not exist",
@@ -92,7 +92,7 @@ func TestBoolVariation(t *testing.T) {
 			},
 			want:        true,
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"true\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"true\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get default value, rule not apply",
@@ -110,7 +110,7 @@ func TestBoolVariation(t *testing.T) {
 			},
 			want:        true,
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"true\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"true\", variation=\"Default\"\n",
 		},
 		{
 			name: "Get true value, rule apply",
@@ -128,7 +128,7 @@ func TestBoolVariation(t *testing.T) {
 			},
 			want:        true,
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"true\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"true\", variation=\"True\"\n",
 		},
 		{
 			name: "Get false value, rule apply",
@@ -146,7 +146,7 @@ func TestBoolVariation(t *testing.T) {
 			},
 			want:        false,
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"false\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"false\", variation=\"False\"\n",
 		},
 		{
 			name: "Get default value, when rule apply and not right type",
@@ -163,7 +163,7 @@ func TestBoolVariation(t *testing.T) {
 			},
 			want:        true,
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"true\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"true\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "No exported log",
@@ -199,10 +199,18 @@ func TestBoolVariation(t *testing.T) {
 					Logger:          logger,
 				},
 				dataExporter: exporter.NewDataExporterScheduler(context.Background(), 0, 0,
-					&ffexporter.Log{}, logger),
+					&ffexporter.Log{
+						Format: "[{{ .FormattedDate}}] user=\"{{ .UserKey}}\", flag=\"{{ .Key}}\", " +
+							"value=\"{{ .Value}}\", variation=\"{{ .Variation}}\"",
+					}, logger),
 			}
 
 			got, err := BoolVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
+
+			if tt.expectedLog != "" {
+				content, _ := ioutil.ReadFile(file.Name())
+				assert.Regexp(t, tt.expectedLog, string(content))
+			}
 
 			if tt.wantErr {
 				assert.Error(t, err, "BoolVariation() error = %v, wantErr %v", err, tt.wantErr)
@@ -210,10 +218,6 @@ func TestBoolVariation(t *testing.T) {
 			}
 			assert.Equal(t, tt.want, got, "BoolVariation() got = %v, want %v", got, tt.want)
 
-			if tt.expectedLog != "" {
-				content, _ := ioutil.ReadFile(file.Name())
-				assert.Regexp(t, tt.expectedLog, string(content))
-			}
 			// clean logger
 			ff = nil
 			_ = file.Close()
@@ -247,7 +251,7 @@ func TestFloat64Variation(t *testing.T) {
 			},
 			want:        120.12,
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"disable-flag\", value=\"120.12\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"disable-flag\", value=\"120.12\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get error when not init",
@@ -261,7 +265,7 @@ func TestFloat64Variation(t *testing.T) {
 			},
 			want:        118.12,
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"118.12\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"118.12\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get default value with key not exist",
@@ -273,7 +277,7 @@ func TestFloat64Variation(t *testing.T) {
 			},
 			want:        118.12,
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"118.12\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"118.12\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get default value, rule not apply",
@@ -291,7 +295,7 @@ func TestFloat64Variation(t *testing.T) {
 			},
 			want:        119.12,
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"119.12\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"119.12\", variation=\"Default\"\n",
 		},
 		{
 			name: "Get true value, rule apply",
@@ -309,7 +313,7 @@ func TestFloat64Variation(t *testing.T) {
 			},
 			want:        120.12,
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"120.12\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"120.12\", variation=\"True\"\n",
 		},
 		{
 			name: "Get false value, rule apply",
@@ -327,7 +331,7 @@ func TestFloat64Variation(t *testing.T) {
 			},
 			want:        121.12,
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"121.12\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"121.12\", variation=\"False\"\n",
 		},
 		{
 			name: "Get default value, when rule apply and not right type",
@@ -344,7 +348,7 @@ func TestFloat64Variation(t *testing.T) {
 			},
 			want:        118.12,
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"118.12\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"118.12\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "No exported log",
@@ -380,20 +384,24 @@ func TestFloat64Variation(t *testing.T) {
 					Logger:          logger,
 				},
 				dataExporter: exporter.NewDataExporterScheduler(context.Background(), 0, 0,
-					&ffexporter.Log{}, logger),
+					&ffexporter.Log{
+						Format: "[{{ .FormattedDate}}] user=\"{{ .UserKey}}\", flag=\"{{ .Key}}\", " +
+							"value=\"{{ .Value}}\", variation=\"{{ .Variation}}\"",
+					}, logger),
 			}
 
 			got, err := Float64Variation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
 
+			if tt.expectedLog != "" {
+				content, _ := ioutil.ReadFile(file.Name())
+				assert.Regexp(t, tt.expectedLog, string(content))
+			}
 			if tt.wantErr {
 				assert.Error(t, err, "Float64Variation() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			assert.Equal(t, tt.want, got, "Float64Variation() got = %v, want %v", got, tt.want)
-			if tt.expectedLog != "" {
-				content, _ := ioutil.ReadFile(file.Name())
-				assert.Regexp(t, tt.expectedLog, string(content))
-			}
+
 			// clean logger
 			ff = nil
 			_ = file.Close()
@@ -625,7 +633,7 @@ func TestJSONVariation(t *testing.T) {
 			},
 			want:        map[string]interface{}{"default-notkey": true},
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"disable-flag\", value=\"map\\[default-notkey:true\\]\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"disable-flag\", value=\"map\\[default-notkey:true\\]\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get error when not init",
@@ -639,7 +647,7 @@ func TestJSONVariation(t *testing.T) {
 			},
 			want:        map[string]interface{}{"default-notkey": true},
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"map\\[default-notkey:true\\]\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"map\\[default-notkey:true\\]\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get default value with key not exist",
@@ -651,7 +659,7 @@ func TestJSONVariation(t *testing.T) {
 			},
 			want:        map[string]interface{}{"default-notkey": true},
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"map\\[default-notkey:true\\]\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"map\\[default-notkey:true\\]\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get default value, rule not apply",
@@ -669,7 +677,7 @@ func TestJSONVariation(t *testing.T) {
 			},
 			want:        map[string]interface{}{"default": true},
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"map\\[default:true\\]\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"map\\[default:true\\]\", variation=\"Default\"\n",
 		},
 		{
 			name: "Get true value, rule apply",
@@ -687,7 +695,7 @@ func TestJSONVariation(t *testing.T) {
 			},
 			want:        map[string]interface{}{"true": true},
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"map\\[true:true\\]\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"map\\[true:true\\]\", variation=\"True\"\n",
 		},
 		{
 			name: "Get false value, rule apply",
@@ -705,7 +713,7 @@ func TestJSONVariation(t *testing.T) {
 			},
 			want:        map[string]interface{}{"false": true},
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"map\\[false:true\\]\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"map\\[false:true\\]\", variation=\"False\"\n",
 		},
 		{
 			name: "Get default value, when rule apply and not right type",
@@ -722,7 +730,7 @@ func TestJSONVariation(t *testing.T) {
 			},
 			want:        map[string]interface{}{"default-notkey": true},
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"map\\[default-notkey:true\\]\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"map\\[default-notkey:true\\]\", variation=\"SdkDefault\"\n",
 		},
 	}
 	for _, tt := range tests {
@@ -739,10 +747,18 @@ func TestJSONVariation(t *testing.T) {
 					Logger:          logger,
 				},
 				dataExporter: exporter.NewDataExporterScheduler(context.Background(), 0, 0,
-					&ffexporter.Log{}, logger),
+					&ffexporter.Log{
+						Format: "[{{ .FormattedDate}}] user=\"{{ .UserKey}}\", flag=\"{{ .Key}}\", " +
+							"value=\"{{ .Value}}\", variation=\"{{ .Variation}}\"",
+					}, logger),
 			}
 
 			got, err := JSONVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
+
+			if tt.expectedLog != "" {
+				content, _ := ioutil.ReadFile(file.Name())
+				assert.Regexp(t, tt.expectedLog, string(content))
+			}
 
 			if tt.wantErr {
 				assert.Error(t, err, "JSONVariation() error = %v, wantErr %v", err, tt.wantErr)
@@ -750,10 +766,6 @@ func TestJSONVariation(t *testing.T) {
 			}
 			assert.Equal(t, tt.want, got, "JSONVariation() got = %v, want %v", got, tt.want)
 
-			if tt.expectedLog != "" {
-				content, _ := ioutil.ReadFile(file.Name())
-				assert.Regexp(t, tt.expectedLog, string(content))
-			}
 			// clean logger
 			ff = nil
 			_ = file.Close()
@@ -787,7 +799,7 @@ func TestStringVariation(t *testing.T) {
 			},
 			want:        "default-notkey",
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"disable-flag\", value=\"default-notkey\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"disable-flag\", value=\"default-notkey\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get error when not init",
@@ -801,7 +813,7 @@ func TestStringVariation(t *testing.T) {
 			},
 			want:        "default-notkey",
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"default-notkey\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"default-notkey\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get default value with key not exist",
@@ -813,7 +825,7 @@ func TestStringVariation(t *testing.T) {
 			},
 			want:        "default-notkey",
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"default-notkey\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"default-notkey\", variation=\"SdkDefault\"\n",
 		},
 
 		{
@@ -832,7 +844,7 @@ func TestStringVariation(t *testing.T) {
 			},
 			want:        "default",
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"default\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"default\", variation=\"Default\"\n",
 		},
 		{
 			name: "Get true value, rule apply",
@@ -850,7 +862,7 @@ func TestStringVariation(t *testing.T) {
 			},
 			want:        "true",
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"true\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"true\", variation=\"True\"\n",
 		},
 		{
 			name: "Get false value, rule apply",
@@ -868,7 +880,7 @@ func TestStringVariation(t *testing.T) {
 			},
 			want:        "false",
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"false\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"false\", variation=\"False\"\n",
 		},
 		{
 			name: "Get default value, when rule apply and not right type",
@@ -886,7 +898,7 @@ func TestStringVariation(t *testing.T) {
 			},
 			want:        "default-notkey",
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"default-notkey\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"default-notkey\", variation=\"SdkDefault\"\n",
 		},
 	}
 	for _, tt := range tests {
@@ -903,9 +915,17 @@ func TestStringVariation(t *testing.T) {
 					Logger:          logger,
 				},
 				dataExporter: exporter.NewDataExporterScheduler(context.Background(), 0, 0,
-					&ffexporter.Log{}, logger),
+					&ffexporter.Log{
+						Format: "[{{ .FormattedDate}}] user=\"{{ .UserKey}}\", flag=\"{{ .Key}}\", " +
+							"value=\"{{ .Value}}\", variation=\"{{ .Variation}}\"",
+					}, logger),
 			}
 			got, err := StringVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
+
+			if tt.expectedLog != "" {
+				content, _ := ioutil.ReadFile(file.Name())
+				assert.Regexp(t, tt.expectedLog, string(content))
+			}
 
 			if tt.wantErr {
 				assert.Error(t, err, "StringVariation() error = %v, wantErr %v", err, tt.wantErr)
@@ -913,10 +933,6 @@ func TestStringVariation(t *testing.T) {
 			}
 			assert.Equal(t, tt.want, got, "StringVariation() got = %v, want %v", got, tt.want)
 
-			if tt.expectedLog != "" {
-				content, _ := ioutil.ReadFile(file.Name())
-				assert.Regexp(t, tt.expectedLog, string(content))
-			}
 			// clean logger
 			ff = nil
 			_ = file.Close()
@@ -950,7 +966,7 @@ func TestIntVariation(t *testing.T) {
 			},
 			want:        125,
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"disable-flag\", value=\"125\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"disable-flag\", value=\"125\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get error when not init",
@@ -964,7 +980,7 @@ func TestIntVariation(t *testing.T) {
 			},
 			want:        118,
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"118\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"118\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get default value with key not exist",
@@ -976,7 +992,7 @@ func TestIntVariation(t *testing.T) {
 			},
 			want:        118,
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"118\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"key-not-exist\", value=\"118\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Get default value rule not apply",
@@ -994,7 +1010,7 @@ func TestIntVariation(t *testing.T) {
 			},
 			want:        119,
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"119\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"119\", variation=\"Default\"\n",
 		},
 		{
 			name: "Get true value, rule apply",
@@ -1012,7 +1028,7 @@ func TestIntVariation(t *testing.T) {
 			},
 			want:        120,
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"120\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"120\", variation=\"True\"\n",
 		},
 		{
 			name: "Get false value, rule apply",
@@ -1030,7 +1046,7 @@ func TestIntVariation(t *testing.T) {
 			},
 			want:        121,
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"121\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"121\", variation=\"False\"\n",
 		},
 		{
 			name: "Get default value, when rule apply and not right type",
@@ -1048,7 +1064,7 @@ func TestIntVariation(t *testing.T) {
 			},
 			want:        118,
 			wantErr:     true,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"118\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"118\", variation=\"SdkDefault\"\n",
 		},
 		{
 			name: "Convert float to Int",
@@ -1066,7 +1082,7 @@ func TestIntVariation(t *testing.T) {
 			},
 			want:        120,
 			wantErr:     false,
-			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"120\"\n",
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"120\", variation=\"True\"\n",
 		},
 	}
 	for _, tt := range tests {
@@ -1083,9 +1099,17 @@ func TestIntVariation(t *testing.T) {
 					Logger:          logger,
 				},
 				dataExporter: exporter.NewDataExporterScheduler(context.Background(), 0, 0,
-					&ffexporter.Log{}, logger),
+					&ffexporter.Log{
+						Format: "[{{ .FormattedDate}}] user=\"{{ .UserKey}}\", flag=\"{{ .Key}}\", " +
+							"value=\"{{ .Value}}\", variation=\"{{ .Variation}}\"",
+					}, logger),
 			}
 			got, err := IntVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
+
+			if tt.expectedLog != "" {
+				content, _ := ioutil.ReadFile(file.Name())
+				assert.Regexp(t, tt.expectedLog, string(content))
+			}
 
 			if tt.wantErr {
 				assert.Error(t, err, "IntVariation() error = %v, wantErr %v", err, tt.wantErr)
@@ -1093,10 +1117,6 @@ func TestIntVariation(t *testing.T) {
 			}
 			assert.Equal(t, tt.want, got, "IntVariation() got = %v, want %v", got, tt.want)
 
-			if tt.expectedLog != "" {
-				content, _ := ioutil.ReadFile(file.Name())
-				assert.Regexp(t, tt.expectedLog, string(content))
-			}
 			// clean logger
 			ff = nil
 			_ = file.Close()


### PR DESCRIPTION
# Description
There is a problem when exporting the variation type in the `dataExporter`, we had the wrong `VariationType` when we were requesting the wrong type.

The PR fixed the issue and add more tests to prevent that in the future.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)


# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
