### PR TITLE
Documentation to link go-feature-flag-editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ Available retriever are:
 
 Your file should be a `YAML`, `JSON` or `TOML` file with a list of flags *(examples: [`YAML`](testdata/flag-config.yaml), [`JSON`](testdata/flag-config.json), [`TOML`](testdata/flag-config.toml))*.
 
+The easiest way to create your configuration file is to used **GO Feature Flag Editor** available at https://thomaspoignant.github.io/go-feature-flag-editor/.  
+If you prefer to do it manually please follow instruction bellow.
+
 **A flag configuration looks like:**
 
 <details open>

--- a/docs/flag_format.md
+++ b/docs/flag_format.md
@@ -3,6 +3,12 @@
 
 Your file must be a valid `YAML`, `JSON` or `TOML` file with a list of flags *(examples: [`YAML`](https://github.com/thomaspoignant/go-feature-flag/tree/main/testdata/flag-config.yaml), [`JSON`](https://github.com/thomaspoignant/go-feature-flag/tree/main/testdata/flag-config.json), [`TOML`](https://github.com/thomaspoignant/go-feature-flag/tree/main/testdata/flag-config.toml))*.
 
+The easiest way to create your configuration file is to used **GO Feature Flag Editor** available at https://thomaspoignant.github.io/go-feature-flag-editor/.  
+If you prefer to do it manually please follow instruction bellow.
+
+## Editor
+Creating the first version of the flag is not always pleasant, that's why we have created [**GO Feature Flag Editor**](https://thomaspoignant.github.io/go-feature-flag-editor/) a simple editor to create your files.  
+
 ## Example
 A flag configuration looks like:
 


### PR DESCRIPTION
# Description
[**GO Feature Flag Editor**](https://thomaspoignant.github.io/go-feature-flag-editor/) is a simple editor to create your flag files.

# Changes include
- [x] Documentation 

# Closes issue(s)
Resolve #177

# Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [x] I have updated the documentation (README.md and /docs)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
