### PR TITLE
Expose FeatureEvent publicly

### DIFF
--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
+	"github.com/thomaspoignant/go-feature-flag/testutils/mock"
 	"io/ioutil"
 	"log"
 	"os"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/ffuser"
-	"github.com/thomaspoignant/go-feature-flag/testutils"
 )
 
 func TestStartWithoutRetriever(t *testing.T) {
@@ -49,7 +49,7 @@ func TestValidUseCase(t *testing.T) {
 		DataExporter: ffclient.DataExporter{
 			FlushInterval:    10 * time.Second,
 			MaxEventInMemory: 1000,
-			Exporter: &testutils.MockExporter{
+			Exporter: &mock.Exporter{
 				Bulk: true,
 			},
 		},

--- a/ffexporter/common.go
+++ b/ffexporter/common.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"text/template"
 	"time"
-
-	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
 )
 
 const DefaultCsvTemplate = "{{ .Kind}};{{ .ContextKind}};{{ .UserKey}};{{ .CreationDate}};{{ .Key}};{{ .Variation}};" +
@@ -47,13 +45,13 @@ func computeFilename(template *template.Template, format string) (string, error)
 	return buf.String(), err
 }
 
-func formatEventInCSV(csvTemplate *template.Template, event exporter.FeatureEvent) ([]byte, error) {
+func formatEventInCSV(csvTemplate *template.Template, event FeatureEvent) ([]byte, error) {
 	var buf bytes.Buffer
 	err := csvTemplate.Execute(&buf, event)
 	return buf.Bytes(), err
 }
 
-func formatEventInJSON(event exporter.FeatureEvent) ([]byte, error) {
+func formatEventInJSON(event FeatureEvent) ([]byte, error) {
 	b, err := json.Marshal(event)
 	b = append(b, []byte("\n")...)
 	return b, err

--- a/ffexporter/feature_event.go
+++ b/ffexporter/feature_event.go
@@ -1,4 +1,4 @@
-package exporter
+package ffexporter
 
 import (
 	"time"

--- a/ffexporter/file.go
+++ b/ffexporter/file.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"sync"
 	"text/template"
-
-	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
 )
 
 type File struct {
@@ -43,7 +41,7 @@ type File struct {
 }
 
 // Export is saving a collection of events in a file.
-func (f *File) Export(ctx context.Context, logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (f *File) Export(ctx context.Context, logger *log.Logger, featureEvents []FeatureEvent) error {
 	// Parse the template only once
 	f.initTemplates.Do(func() {
 		f.csvTemplate = parseTemplate("csvFormat", f.CsvTemplate, DefaultCsvTemplate)

--- a/ffexporter/file_test.go
+++ b/ffexporter/file_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/thomaspoignant/go-feature-flag/ffexporter"
-	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
 )
 
 func TestFile_Export(t *testing.T) {
@@ -23,7 +22,7 @@ func TestFile_Export(t *testing.T) {
 	}
 	type args struct {
 		logger        *log.Logger
-		featureEvents []exporter.FeatureEvent
+		featureEvents []ffexporter.FeatureEvent
 	}
 	type expected struct {
 		fileNameRegex string
@@ -41,7 +40,7 @@ func TestFile_Export(t *testing.T) {
 			wantErr: false,
 			fields:  fields{},
 			args: args{
-				featureEvents: []exporter.FeatureEvent{
+				featureEvents: []ffexporter.FeatureEvent{
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 						Variation: "Default", Value: "YO", Default: false},
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "EFGH", CreationDate: 1617970701, Key: "random-key",
@@ -60,7 +59,7 @@ func TestFile_Export(t *testing.T) {
 				Format: "csv",
 			},
 			args: args{
-				featureEvents: []exporter.FeatureEvent{
+				featureEvents: []ffexporter.FeatureEvent{
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 						Variation: "Default", Value: "YO", Default: false},
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "EFGH", CreationDate: 1617970701, Key: "random-key",
@@ -80,7 +79,7 @@ func TestFile_Export(t *testing.T) {
 				CsvTemplate: "{{ .Kind}};{{ .ContextKind}}\n",
 			},
 			args: args{
-				featureEvents: []exporter.FeatureEvent{
+				featureEvents: []ffexporter.FeatureEvent{
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 						Variation: "Default", Value: "YO", Default: false},
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "EFGH", CreationDate: 1617970701, Key: "random-key",
@@ -100,7 +99,7 @@ func TestFile_Export(t *testing.T) {
 				Filename: "{{ .Format}}-test-{{ .Timestamp}}",
 			},
 			args: args{
-				featureEvents: []exporter.FeatureEvent{
+				featureEvents: []ffexporter.FeatureEvent{
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 						Variation: "Default", Value: "YO", Default: false},
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "EFGH", CreationDate: 1617970701, Key: "random-key",
@@ -119,7 +118,7 @@ func TestFile_Export(t *testing.T) {
 				Format: "xxx",
 			},
 			args: args{
-				featureEvents: []exporter.FeatureEvent{
+				featureEvents: []ffexporter.FeatureEvent{
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 						Variation: "Default", Value: "YO", Default: false},
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "EFGH", CreationDate: 1617970701, Key: "random-key",
@@ -138,7 +137,7 @@ func TestFile_Export(t *testing.T) {
 				OutputDir: "/tmp/foo/bar/",
 			},
 			args: args{
-				featureEvents: []exporter.FeatureEvent{
+				featureEvents: []ffexporter.FeatureEvent{
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 						Variation: "Default", Value: "YO", Default: false},
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "EFGH", CreationDate: 1617970701, Key: "random-key",
@@ -153,7 +152,7 @@ func TestFile_Export(t *testing.T) {
 				Filename: "{{ .InvalidField}}",
 			},
 			args: args{
-				featureEvents: []exporter.FeatureEvent{
+				featureEvents: []ffexporter.FeatureEvent{
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 						Variation: "Default", Value: "YO", Default: false},
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "EFGH", CreationDate: 1617970701, Key: "random-key",
@@ -169,7 +168,7 @@ func TestFile_Export(t *testing.T) {
 				CsvTemplate: "{{ .Foo}}",
 			},
 			args: args{
-				featureEvents: []exporter.FeatureEvent{
+				featureEvents: []ffexporter.FeatureEvent{
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 						Variation: "Default", Value: "YO", Default: false},
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "EFGH", CreationDate: 1617970701, Key: "random-key",

--- a/ffexporter/log.go
+++ b/ffexporter/log.go
@@ -7,8 +7,6 @@ import (
 	"sync"
 	"text/template"
 	"time"
-
-	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
 )
 
 const defaultLoggerFormat = "[{{ .FormattedDate}}] user=\"{{ .UserKey}}\", flag=\"{{ .Key}}\", value=\"{{ .Value}}\""
@@ -25,7 +23,7 @@ type Log struct {
 }
 
 // Export is saving a collection of events in a file.
-func (f *Log) Export(ctx context.Context, logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (f *Log) Export(ctx context.Context, logger *log.Logger, featureEvents []FeatureEvent) error {
 	f.initTemplates.Do(func() {
 		f.logTemplate = parseTemplate("logFormat", f.Format, defaultLoggerFormat)
 	})
@@ -33,7 +31,7 @@ func (f *Log) Export(ctx context.Context, logger *log.Logger, featureEvents []ex
 	for _, event := range featureEvents {
 		var log bytes.Buffer
 		err := f.logTemplate.Execute(&log, struct {
-			exporter.FeatureEvent
+			FeatureEvent
 			FormattedDate string
 		}{FeatureEvent: event, FormattedDate: time.Unix(event.CreationDate, 0).Format(time.RFC3339)})
 

--- a/ffexporter/log_test.go
+++ b/ffexporter/log_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/thomaspoignant/go-feature-flag/ffexporter"
-	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
 	"github.com/thomaspoignant/go-feature-flag/testutils"
 )
 
@@ -17,7 +16,7 @@ func TestLog_Export(t *testing.T) {
 		Format string
 	}
 	type args struct {
-		featureEvents []exporter.FeatureEvent
+		featureEvents []ffexporter.FeatureEvent
 	}
 	tests := []struct {
 		name        string
@@ -29,7 +28,7 @@ func TestLog_Export(t *testing.T) {
 		{
 			name:   "Default format",
 			fields: fields{Format: ""},
-			args: args{featureEvents: []exporter.FeatureEvent{
+			args: args{featureEvents: []ffexporter.FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
 			}},
@@ -40,7 +39,7 @@ func TestLog_Export(t *testing.T) {
 			fields: fields{
 				Format: "key=\"{{ .Key}}\" [{{ .FormattedDate}}]",
 			},
-			args: args{featureEvents: []exporter.FeatureEvent{
+			args: args{featureEvents: []ffexporter.FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
 			}},
@@ -51,7 +50,7 @@ func TestLog_Export(t *testing.T) {
 			fields: fields{
 				Format: "key=\"{{ .Key}\" [{{ .FormattedDate}}]",
 			},
-			args: args{featureEvents: []exporter.FeatureEvent{
+			args: args{featureEvents: []ffexporter.FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
 			}},
@@ -62,7 +61,7 @@ func TestLog_Export(t *testing.T) {
 			fields: fields{
 				Format: "key=\"{{ .UnknownKey}}\" [{{ .FormattedDate}}]",
 			},
-			args: args{featureEvents: []exporter.FeatureEvent{
+			args: args{featureEvents: []ffexporter.FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
 			}},

--- a/ffexporter/s3.go
+++ b/ffexporter/s3.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
 	"github.com/thomaspoignant/go-feature-flag/internal/fflog"
 )
 
@@ -50,7 +49,7 @@ type S3 struct {
 }
 
 // Export is saving a collection of events in a file.
-func (f *S3) Export(ctx context.Context, logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (f *S3) Export(ctx context.Context, logger *log.Logger, featureEvents []FeatureEvent) error {
 	// init the s3 uploader
 	if f.s3Uploader == nil {
 		var initErr error

--- a/ffexporter/s3_test.go
+++ b/ffexporter/s3_test.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/testutils"
 	"io/ioutil"
 	"log"
 	"os"
 	"testing"
-
-	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
-	"github.com/thomaspoignant/go-feature-flag/testutils"
 )
 
 func TestS3_Export(t *testing.T) {
@@ -27,7 +25,7 @@ func TestS3_Export(t *testing.T) {
 	tests := []struct {
 		name         string
 		fields       fields
-		events       []exporter.FeatureEvent
+		events       []FeatureEvent
 		wantErr      bool
 		expectedFile string
 		expectedName string
@@ -37,7 +35,7 @@ func TestS3_Export(t *testing.T) {
 			fields: fields{
 				Bucket: "test",
 			},
-			events: []exporter.FeatureEvent{
+			events: []FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
 			},
@@ -50,7 +48,7 @@ func TestS3_Export(t *testing.T) {
 				S3Path: "random/path",
 				Bucket: "test",
 			},
-			events: []exporter.FeatureEvent{
+			events: []FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
 			},
@@ -63,7 +61,7 @@ func TestS3_Export(t *testing.T) {
 				Format: "csv",
 				Bucket: "test",
 			},
-			events: []exporter.FeatureEvent{
+			events: []FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
 			},
@@ -77,7 +75,7 @@ func TestS3_Export(t *testing.T) {
 				CsvTemplate: "{{ .Kind}};{{ .ContextKind}}\n",
 				Bucket:      "test",
 			},
-			events: []exporter.FeatureEvent{
+			events: []FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
 			},
@@ -91,7 +89,7 @@ func TestS3_Export(t *testing.T) {
 				Filename: "{{ .Format}}-test-{{ .Timestamp}}",
 				Bucket:   "test",
 			},
-			events: []exporter.FeatureEvent{
+			events: []FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
 			},
@@ -104,7 +102,7 @@ func TestS3_Export(t *testing.T) {
 				Format: "xxx",
 				Bucket: "test",
 			},
-			events: []exporter.FeatureEvent{
+			events: []FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
 			},
@@ -116,7 +114,7 @@ func TestS3_Export(t *testing.T) {
 			fields: fields{
 				Format: "xxx",
 			},
-			events: []exporter.FeatureEvent{
+			events: []FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
 			},
@@ -128,7 +126,7 @@ func TestS3_Export(t *testing.T) {
 				Filename: "{{ .InvalidField}}",
 				Bucket:   "test",
 			},
-			events: []exporter.FeatureEvent{
+			events: []FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
 			},
@@ -140,7 +138,7 @@ func TestS3_Export(t *testing.T) {
 				Format:      "csv",
 				CsvTemplate: "{{ .Foo}}",
 			},
-			events: []exporter.FeatureEvent{
+			events: []FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
 			},
@@ -181,7 +179,7 @@ func Test_errSDK(t *testing.T) {
 		Bucket:    "empty",
 		AwsConfig: &aws.Config{},
 	}
-	err := f.Export(context.Background(), log.New(os.Stdout, "", 0), []exporter.FeatureEvent{})
+	err := f.Export(context.Background(), log.New(os.Stdout, "", 0), []FeatureEvent{})
 	assert.Error(t, err, "Empty AWS config should failed")
 }
 

--- a/ffexporter/webhook.go
+++ b/ffexporter/webhook.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 
 	"github.com/thomaspoignant/go-feature-flag/internal"
-	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
 	"github.com/thomaspoignant/go-feature-flag/internal/signer"
 )
 
@@ -55,11 +54,11 @@ type webhookPayload struct {
 	Meta map[string]string `json:"meta"`
 
 	// events is the list of the event we send in the payload
-	Events []exporter.FeatureEvent `json:"events"`
+	Events []FeatureEvent `json:"events"`
 }
 
 // Export is sending a collection of events in a webhook call.
-func (f *Webhook) Export(ctx context.Context, logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (f *Webhook) Export(ctx context.Context, logger *log.Logger, featureEvents []FeatureEvent) error {
 	f.init.Do(func() {
 		if f.httpClient == nil {
 			f.httpClient = internal.DefaultHTTPClient()

--- a/ffexporter/webhook_test.go
+++ b/ffexporter/webhook_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
 	"github.com/thomaspoignant/go-feature-flag/testutils"
 )
 
@@ -27,7 +26,7 @@ func TestWebhook_Export(t *testing.T) {
 	}
 	type args struct {
 		logger        *log.Logger
-		featureEvents []exporter.FeatureEvent
+		featureEvents []FeatureEvent
 	}
 	type expected struct {
 		bodyFilePath string
@@ -56,7 +55,7 @@ func TestWebhook_Export(t *testing.T) {
 			},
 			args: args{
 				logger: logger,
-				featureEvents: []exporter.FeatureEvent{
+				featureEvents: []FeatureEvent{
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 						Variation: "Default", Value: "YO", Default: false},
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "EFGH", CreationDate: 1617970701, Key: "random-key",
@@ -79,7 +78,7 @@ func TestWebhook_Export(t *testing.T) {
 			},
 			args: args{
 				logger: logger,
-				featureEvents: []exporter.FeatureEvent{
+				featureEvents: []FeatureEvent{
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 						Variation: "Default", Value: "YO", Default: false},
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "EFGH", CreationDate: 1617970701, Key: "random-key",
@@ -102,7 +101,7 @@ func TestWebhook_Export(t *testing.T) {
 			},
 			args: args{
 				logger: logger,
-				featureEvents: []exporter.FeatureEvent{
+				featureEvents: []FeatureEvent{
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 						Variation: "Default", Value: "YO", Default: false},
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "EFGH", CreationDate: 1617970701, Key: "random-key",
@@ -121,7 +120,7 @@ func TestWebhook_Export(t *testing.T) {
 			},
 			args: args{
 				logger: logger,
-				featureEvents: []exporter.FeatureEvent{
+				featureEvents: []FeatureEvent{
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 						Variation: "Default", Value: "YO", Default: false},
 					{Kind: "feature", ContextKind: "anonymousUser", UserKey: "EFGH", CreationDate: 1617970701, Key: "random-key",
@@ -163,6 +162,6 @@ func TestWebhook_Export_impossibleToParse(t *testing.T) {
 		EndpointURL: " http://invalid.com/",
 	}
 
-	err := f.Export(context.Background(), log.New(os.Stdout, "", 0), []exporter.FeatureEvent{})
+	err := f.Export(context.Background(), log.New(os.Stdout, "", 0), []FeatureEvent{})
 	assert.EqualError(t, err, "parse \" http://invalid.com/\": first path segment in URL cannot contain colon")
 }

--- a/internal/exporter/data_exporter.go
+++ b/internal/exporter/data_exporter.go
@@ -2,6 +2,7 @@ package exporter
 
 import (
 	"context"
+	"github.com/thomaspoignant/go-feature-flag/ffexporter"
 	"log"
 	"sync"
 	"time"
@@ -28,7 +29,7 @@ func NewDataExporterScheduler(ctx context.Context, flushInterval time.Duration, 
 	}
 
 	return &DataExporterScheduler{
-		localCache:      make([]FeatureEvent, 0),
+		localCache:      make([]ffexporter.FeatureEvent, 0),
 		mutex:           sync.Mutex{},
 		maxEventInCache: maxEventInMemory,
 		exporter:        exporter,
@@ -42,7 +43,7 @@ func NewDataExporterScheduler(ctx context.Context, flushInterval time.Duration, 
 // Exporter is an interface to describe how a exporter looks like.
 type Exporter interface {
 	// Export will send the data to the exporter.
-	Export(context.Context, *log.Logger, []FeatureEvent) error
+	Export(context.Context, *log.Logger, []ffexporter.FeatureEvent) error
 
 	// IsBulk return false if we should directly send the data as soon as it is produce
 	// and true if we collect the data to send them in bulk.
@@ -51,7 +52,7 @@ type Exporter interface {
 
 // DataExporterScheduler is the struct that handle the data collection.
 type DataExporterScheduler struct {
-	localCache      []FeatureEvent
+	localCache      []ffexporter.FeatureEvent
 	mutex           sync.Mutex
 	daemonChan      chan struct{}
 	ticker          *time.Ticker
@@ -63,7 +64,7 @@ type DataExporterScheduler struct {
 
 // AddEvent allow to add an event to the local cache and to call the exporter if we reach
 // the maximum number of events that can be present in the cache.
-func (dc *DataExporterScheduler) AddEvent(event FeatureEvent) {
+func (dc *DataExporterScheduler) AddEvent(event ffexporter.FeatureEvent) {
 	dc.mutex.Lock()
 	defer dc.mutex.Unlock()
 
@@ -120,5 +121,5 @@ func (dc *DataExporterScheduler) flush() {
 		}
 	}
 	// Clear the cache
-	dc.localCache = make([]FeatureEvent, 0)
+	dc.localCache = make([]ffexporter.FeatureEvent, 0)
 }

--- a/internal/exporter/data_exporter_test.go
+++ b/internal/exporter/data_exporter_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/ffexporter"
+	"github.com/thomaspoignant/go-feature-flag/testutils/mock"
 	"io/ioutil"
 	"log"
 	"os"
@@ -17,14 +19,14 @@ import (
 )
 
 func TestDataExporterScheduler_flushWithTime(t *testing.T) {
-	mockExporter := testutils.MockExporter{Bulk: true}
+	mockExporter := mock.Exporter{Bulk: true}
 	dc := exporter.NewDataExporterScheduler(
 		context.Background(), 10*time.Millisecond, 1000, &mockExporter, log.New(os.Stdout, "", 0))
 	go dc.StartDaemon()
 	defer dc.Close()
 
-	inputEvents := []exporter.FeatureEvent{
-		exporter.NewFeatureEvent(ffuser.NewAnonymousUser("ABCD"), "random-key",
+	inputEvents := []ffexporter.FeatureEvent{
+		ffexporter.NewFeatureEvent(ffuser.NewAnonymousUser("ABCD"), "random-key",
 			"YO", model.VariationDefault, false, 0),
 	}
 
@@ -37,15 +39,15 @@ func TestDataExporterScheduler_flushWithTime(t *testing.T) {
 }
 
 func TestDataExporterScheduler_flushWithNumberOfEvents(t *testing.T) {
-	mockExporter := testutils.MockExporter{Bulk: true}
+	mockExporter := mock.Exporter{Bulk: true}
 	dc := exporter.NewDataExporterScheduler(
 		context.Background(), 10*time.Minute, 100, &mockExporter, log.New(os.Stdout, "", 0))
 	go dc.StartDaemon()
 	defer dc.Close()
 
-	var inputEvents []exporter.FeatureEvent
+	var inputEvents []ffexporter.FeatureEvent
 	for i := 0; i <= 100; i++ {
-		inputEvents = append(inputEvents, exporter.NewFeatureEvent(ffuser.NewAnonymousUser("ABCD"),
+		inputEvents = append(inputEvents, ffexporter.NewFeatureEvent(ffuser.NewAnonymousUser("ABCD"),
 			"random-key", "YO", model.VariationDefault, false, 0))
 	}
 	for _, event := range inputEvents {
@@ -55,15 +57,15 @@ func TestDataExporterScheduler_flushWithNumberOfEvents(t *testing.T) {
 }
 
 func TestDataExporterScheduler_defaultFlush(t *testing.T) {
-	mockExporter := testutils.MockExporter{Bulk: true}
+	mockExporter := mock.Exporter{Bulk: true}
 	dc := exporter.NewDataExporterScheduler(
 		context.Background(), 0, 0, &mockExporter, log.New(os.Stdout, "", 0))
 	go dc.StartDaemon()
 	defer dc.Close()
 
-	var inputEvents []exporter.FeatureEvent
+	var inputEvents []ffexporter.FeatureEvent
 	for i := 0; i <= 100000; i++ {
-		inputEvents = append(inputEvents, exporter.NewFeatureEvent(ffuser.NewAnonymousUser("ABCD"),
+		inputEvents = append(inputEvents, ffexporter.NewFeatureEvent(ffuser.NewAnonymousUser("ABCD"),
 			"random-key", "YO", model.VariationDefault, false, 0))
 	}
 	for _, event := range inputEvents {
@@ -73,7 +75,7 @@ func TestDataExporterScheduler_defaultFlush(t *testing.T) {
 }
 
 func TestDataExporterScheduler_exporterReturnError(t *testing.T) {
-	mockExporter := testutils.MockExporter{Err: errors.New("random err"), ExpectedNumberErr: 1, Bulk: true}
+	mockExporter := mock.Exporter{Err: errors.New("random err"), ExpectedNumberErr: 1, Bulk: true}
 
 	file, _ := ioutil.TempFile("", "log")
 	defer file.Close()
@@ -85,9 +87,9 @@ func TestDataExporterScheduler_exporterReturnError(t *testing.T) {
 	go dc.StartDaemon()
 	defer dc.Close()
 
-	var inputEvents []exporter.FeatureEvent
+	var inputEvents []ffexporter.FeatureEvent
 	for i := 0; i <= 200; i++ {
-		inputEvents = append(inputEvents, exporter.NewFeatureEvent(ffuser.NewAnonymousUser("ABCD"),
+		inputEvents = append(inputEvents, ffexporter.NewFeatureEvent(ffuser.NewAnonymousUser("ABCD"),
 			"random-key", "YO", model.VariationDefault, false, 0))
 	}
 	for _, event := range inputEvents {
@@ -101,14 +103,14 @@ func TestDataExporterScheduler_exporterReturnError(t *testing.T) {
 }
 
 func TestDataExporterScheduler_nonBulkExporter(t *testing.T) {
-	mockExporter := testutils.MockExporter{Bulk: false}
+	mockExporter := mock.Exporter{Bulk: false}
 	dc := exporter.NewDataExporterScheduler(
 		context.Background(), 0, 0, &mockExporter, log.New(os.Stdout, "", 0))
 	defer dc.Close()
 
-	var inputEvents []exporter.FeatureEvent
+	var inputEvents []ffexporter.FeatureEvent
 	for i := 0; i < 100; i++ {
-		inputEvents = append(inputEvents, exporter.NewFeatureEvent(ffuser.NewAnonymousUser("ABCD"),
+		inputEvents = append(inputEvents, ffexporter.NewFeatureEvent(ffuser.NewAnonymousUser("ABCD"),
 			"random-key", "YO", model.VariationDefault, false, 0))
 	}
 	for _, event := range inputEvents {

--- a/retriever_s3_test.go
+++ b/retriever_s3_test.go
@@ -5,10 +5,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/testutils"
 	"io/ioutil"
 	"testing"
-
-	"github.com/thomaspoignant/go-feature-flag/testutils"
 )
 
 func Test_s3Retriever_Retrieve(t *testing.T) {

--- a/testutils/mock/exporter.go
+++ b/testutils/mock/exporter.go
@@ -1,15 +1,14 @@
-package testutils
+package mock
 
 import (
 	"context"
+	"github.com/thomaspoignant/go-feature-flag/ffexporter"
 	"log"
 	"sync"
-
-	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
 )
 
-type MockExporter struct {
-	ExportedEvents    []exporter.FeatureEvent
+type Exporter struct {
+	ExportedEvents    []ffexporter.FeatureEvent
 	Err               error
 	ExpectedNumberErr int
 	CurrentNumberErr  int
@@ -19,7 +18,7 @@ type MockExporter struct {
 	once  sync.Once
 }
 
-func (m *MockExporter) Export(ctx context.Context, logger *log.Logger, events []exporter.FeatureEvent) error {
+func (m *Exporter) Export(ctx context.Context, logger *log.Logger, events []ffexporter.FeatureEvent) error {
 	m.once.Do(m.initMutex)
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -33,17 +32,17 @@ func (m *MockExporter) Export(ctx context.Context, logger *log.Logger, events []
 	return nil
 }
 
-func (m *MockExporter) GetExportedEvents() []exporter.FeatureEvent {
+func (m *Exporter) GetExportedEvents() []ffexporter.FeatureEvent {
 	m.once.Do(m.initMutex)
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	return m.ExportedEvents
 }
 
-func (m *MockExporter) IsBulk() bool {
+func (m *Exporter) IsBulk() bool {
 	return m.Bulk
 }
 
-func (m *MockExporter) initMutex() {
+func (m *Exporter) initMutex() {
 	m.mutex = sync.Mutex{}
 }

--- a/variation.go
+++ b/variation.go
@@ -2,9 +2,8 @@ package ffclient
 
 import (
 	"fmt"
-
+	"github.com/thomaspoignant/go-feature-flag/ffexporter"
 	"github.com/thomaspoignant/go-feature-flag/ffuser"
-	"github.com/thomaspoignant/go-feature-flag/internal/exporter"
 	"github.com/thomaspoignant/go-feature-flag/internal/flagstate"
 	"github.com/thomaspoignant/go-feature-flag/internal/model"
 )
@@ -353,7 +352,7 @@ func (g *GoFeatureFlag) notifyVariation(
 	result model.VariationResult,
 	value interface{}) {
 	if result.TrackEvents {
-		event := exporter.NewFeatureEvent(user, flagKey, value, result.VariationType, result.Failed, result.Version)
+		event := ffexporter.NewFeatureEvent(user, flagKey, value, result.VariationType, result.Failed, result.Version)
 
 		// Add event in the exporter
 		if g.dataExporter != nil {


### PR DESCRIPTION
# Description
It was not possible to implement a custom `Exporter` because `FeatureEvent` was in the internal package.
Now `FeatureEvent` is in the `ffexporter` package so we are able to create custom `Exporter`.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #224

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (README.md and /docs)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
