### PR TITLE
Add method to get the last time the cache was updated

### DIFF
--- a/feature_flag.go
+++ b/feature_flag.go
@@ -149,3 +149,13 @@ func retrieveFlagsAndUpdateCache(config Config, cache cache.Manager) error {
 	}
 	return nil
 }
+
+// GetCacheRefreshDate gives the date of the latest refresh of the cache
+func (g *GoFeatureFlag) GetCacheRefreshDate() time.Time {
+	return g.cache.GetLatestUpdateDate()
+}
+
+// GetCacheRefreshDate gives the date of the latest refresh of the cache
+func GetCacheRefreshDate() time.Time {
+	return ff.GetCacheRefreshDate()
+}

--- a/internal/cache/cache_manager.go
+++ b/internal/cache/cache_manager.go
@@ -36,10 +36,6 @@ func New(notificationService Service) Manager {
 	}
 }
 
-func (c *cacheManagerImpl) GetLatestUpdateDate() time.Time {
-	return c.latestUpdate
-}
-
 func (c *cacheManagerImpl) UpdateCache(loadedFlags []byte, fileFormat string) error {
 	var newFlags map[string]flagv1.FlagData
 	var err error
@@ -101,4 +97,10 @@ func (c *cacheManagerImpl) AllFlags() (map[string]flag.Flag, error) {
 		return nil, errors.New("impossible to read the flag before the initialisation")
 	}
 	return c.inMemoryCache.All(), nil
+}
+
+func (c *cacheManagerImpl) GetLatestUpdateDate() time.Time {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.latestUpdate
 }

--- a/internal/cache/cache_manager_test.go
+++ b/internal/cache/cache_manager_test.go
@@ -292,3 +292,21 @@ test-flag2:
 		})
 	}
 }
+
+func Test_cacheManagerImpl_GetLatestUpdateDate(t *testing.T) {
+	loadedFlags := []byte(`test-flag:
+  rule: key eq "random-key"
+  percentage: 100
+  true: true
+  false: false
+  default: false
+  trackEvents: false
+`)
+
+	fCache := cache.New(cache.NewNotificationService([]ffnotifier.Notifier{}))
+	timeBefore := fCache.GetLatestUpdateDate()
+	_ = fCache.UpdateCache(loadedFlags, "yaml")
+	timeAfter := fCache.GetLatestUpdateDate()
+
+	assert.True(t, timeBefore.Before(timeAfter))
+}

--- a/variation_test.go
+++ b/variation_test.go
@@ -32,6 +32,11 @@ func NewCacheMock(flag flag.Flag, err error) cache.Manager {
 		err:  err,
 	}
 }
+
+func (c *cacheMock) GetLatestUpdateDate() time.Time {
+	return time.Now()
+}
+
 func (c *cacheMock) UpdateCache(loadedFlags []byte, fileFormat string) error {
 	return nil
 }


### PR DESCRIPTION
# Description
Add a new function `GetCacheRefreshDate()` that allows getting the last time the cache was refreshed.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)
Resolve #238

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (README.md and /docs)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
