### PR TITLE
Fix crash when in offline mode

### DIFF
--- a/feature_flag.go
+++ b/feature_flag.go
@@ -152,6 +152,9 @@ func retrieveFlagsAndUpdateCache(config Config, cache cache.Manager) error {
 
 // GetCacheRefreshDate gives the date of the latest refresh of the cache
 func (g *GoFeatureFlag) GetCacheRefreshDate() time.Time {
+	if g.config.Offline {
+		return time.Time{}
+	}
 	return g.cache.GetLatestUpdateDate()
 }
 


### PR DESCRIPTION
# Description
Avoid crash when calling `GetCacheRefreshDate` in offline mode.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)


# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (README.md and /docs)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
