### PR TITLE
Add RawVariation method for proxy calls

### DIFF
--- a/internal/model/variation_result.go
+++ b/internal/model/variation_result.go
@@ -48,3 +48,10 @@ type JSONArrayVarResult struct {
 	VariationResult
 	Value []interface{}
 }
+
+// RawVarResult is the result of the raw variation call.
+// This is used by ffclient.RawVariation functions, this should be used only by internal calls.
+type RawVarResult struct {
+	VariationResult
+	Value interface{}
+}


### PR DESCRIPTION
# Description
Adding a new function called `RawVariation`.
This method doesn't care about the type of the result and forwards it as an interface.

This is needed if you want to expose the results as `json`, this will be used by `go-feature-flag relay proxy` that is an API exposition of `go-feature-flag`.

I did not add any documentation because it is not required to use this function in normal usage of the library.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
