### PR TITLE
Deprecate Format and use LogFormat instead

### DIFF
--- a/docs/data_collection/log.md
+++ b/docs/data_collection/log.md
@@ -11,7 +11,7 @@ ffclient.Config{
     // ...
    DataExporter: ffclient.DataExporter{
         Exporter: &ffexporter.Log{
-            Format: "[{{ .FormattedDate}}] user=\"{{ .UserKey}}\", flag=\"{{ .Key}}\", value=\"{{ .Value}}\"",
+            LogFormat: "[{{ .FormattedDate}}] user=\"{{ .UserKey}}\", flag=\"{{ .Key}}\", value=\"{{ .Value}}\"",
         },
     },
     // ...
@@ -19,8 +19,8 @@ ffclient.Config{
 ```
 
 ## Configuration fields
-| Field  | Description  |
-|---|---|
-|`Format`   | *(optional)*<br>Format is the [template](https://golang.org/pkg/text/template/) configuration of the output format of your log.<br>You can use all the key from the `exporter.FeatureEvent` + a key called `FormattedDate` that represent the date with the **RFC 3339** Format.<br><br>**Default: `[{{ .FormattedDate}}] user="{{ .UserKey}}", flag="{{ .Key}}", value="{{ .Value}}"`**  |
+| Field       | Description                                                                                                                                                                                                                                                                                                                                                                                 |
+|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `LogFormat` | *(optional)*<br>LogFormat is the [template](https://golang.org/pkg/text/template/) configuration of the output format of your log.<br>You can use all the key from the `exporter.FeatureEvent` + a key called `FormattedDate` that represent the date with the **RFC 3339** Format.<br><br>**Default: `[{{ .FormattedDate}}] user="{{ .UserKey}}", flag="{{ .Key}}", value="{{ .Value}}"`** |
 
 Check the [godoc for full details](https://pkg.go.dev/github.com/thomaspoignant/go-feature-flag@v0.11.0/ffexporter#Log).

--- a/ffexporter/log.go
+++ b/ffexporter/log.go
@@ -16,7 +16,13 @@ type Log struct {
 	// You can use all the key from the exporter.FeatureEvent + a key called FormattedDate that represent the date with
 	// the RFC 3339 Format
 	// Default: [{{ .FormattedDate}}] user="{{ .UserKey}}", flag="{{ .Key}}", value="{{ .Value}}"
-	Format string
+	Format string // Deprecated: use LogFormat instead.
+
+	// Format is the template configuration of the output format of your log.
+	// You can use all the key from the exporter.FeatureEvent + a key called FormattedDate that represent the date with
+	// the RFC 3339 Format
+	// Default: [{{ .FormattedDate}}] user="{{ .UserKey}}", flag="{{ .Key}}", value="{{ .Value}}"
+	LogFormat string
 
 	logTemplate   *template.Template
 	initTemplates sync.Once
@@ -25,7 +31,12 @@ type Log struct {
 // Export is saving a collection of events in a file.
 func (f *Log) Export(ctx context.Context, logger *log.Logger, featureEvents []FeatureEvent) error {
 	f.initTemplates.Do(func() {
-		f.logTemplate = parseTemplate("logFormat", f.Format, defaultLoggerFormat)
+		// Remove bellow after deprecation of Format
+		if f.LogFormat == "" && f.Format != "" {
+			f.LogFormat = f.Format
+		}
+
+		f.logTemplate = parseTemplate("logFormat", f.LogFormat, defaultLoggerFormat)
 	})
 
 	for _, event := range featureEvents {

--- a/ffexporter/log_test.go
+++ b/ffexporter/log_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestLog_Export(t *testing.T) {
 	type fields struct {
-		Format string
+		LogFormat string
 	}
 	type args struct {
 		featureEvents []ffexporter.FeatureEvent
@@ -27,7 +27,7 @@ func TestLog_Export(t *testing.T) {
 	}{
 		{
 			name:   "Default format",
-			fields: fields{Format: ""},
+			fields: fields{LogFormat: ""},
 			args: args{featureEvents: []ffexporter.FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
 					Variation: "Default", Value: "YO", Default: false},
@@ -37,7 +37,7 @@ func TestLog_Export(t *testing.T) {
 		{
 			name: "Custom format",
 			fields: fields{
-				Format: "key=\"{{ .Key}}\" [{{ .FormattedDate}}]",
+				LogFormat: "key=\"{{ .Key}}\" [{{ .FormattedDate}}]",
 			},
 			args: args{featureEvents: []ffexporter.FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
@@ -46,9 +46,9 @@ func TestLog_Export(t *testing.T) {
 			expectedLog: "key=\"random-key\" \\[" + testutils.RFC3339Regex + "\\]\n",
 		},
 		{
-			name: "Format error",
+			name: "LogFormat error",
 			fields: fields{
-				Format: "key=\"{{ .Key}\" [{{ .FormattedDate}}]",
+				LogFormat: "key=\"{{ .Key}\" [{{ .FormattedDate}}]",
 			},
 			args: args{featureEvents: []ffexporter.FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
@@ -59,7 +59,7 @@ func TestLog_Export(t *testing.T) {
 		{
 			name: "Field does not exist",
 			fields: fields{
-				Format: "key=\"{{ .UnknownKey}}\" [{{ .FormattedDate}}]",
+				LogFormat: "key=\"{{ .UnknownKey}}\" [{{ .FormattedDate}}]",
 			},
 			args: args{featureEvents: []ffexporter.FeatureEvent{
 				{Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
@@ -72,7 +72,7 @@ func TestLog_Export(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &ffexporter.Log{
-				Format: tt.fields.Format,
+				LogFormat: tt.fields.LogFormat,
 			}
 
 			logFile, _ := ioutil.TempFile("", "")


### PR DESCRIPTION
# Description
Deprecate field `Format` and use `LogFormat` instead to avoid confusion in field name with other `exporter`.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (README.md and /docs)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
