### PR TITLE
Add new GetFlagsFromCache public method

### DIFF
--- a/feature_flag.go
+++ b/feature_flag.go
@@ -98,6 +98,7 @@ func New(config Config) (*GoFeatureFlag, error) {
 
 // Close wait until thread are done
 func (g *GoFeatureFlag) Close() {
+	onceFF = sync.Once{}
 	if g != nil {
 		if g.cache != nil {
 			// clear the cache

--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -1,15 +1,16 @@
 package ffclient_test
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/stretchr/testify/assert"
-	ffclient "github.com/thomaspoignant/go-feature-flag"
-	"github.com/thomaspoignant/go-feature-flag/testutils/mock"
 	"io/ioutil"
 	"log"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+	ffclient "github.com/thomaspoignant/go-feature-flag"
+	"github.com/thomaspoignant/go-feature-flag/testutils/mock"
 
 	"github.com/thomaspoignant/go-feature-flag/ffuser"
 )
@@ -66,6 +67,20 @@ func TestValidUseCase(t *testing.T) {
 
 	allFlags := ffclient.AllFlagsState(user)
 	assert.Equal(t, 2, len(allFlags.GetFlags()))
+}
+
+func TestAllFlagsFromCache(t *testing.T) {
+	err := ffclient.Init(ffclient.Config{
+		Retriever:       &ffclient.FileRetriever{Path: "testdata/flag-config.yaml"},
+		PollingInterval: 5 * time.Second,
+	})
+	defer ffclient.Close()
+
+	assert.NoError(t, err)
+	flags, err := ffclient.GetFlagsFromCache()
+
+	assert.NoError(t, err)
+	assert.Len(t, flags, 2)
 }
 
 func TestValidUseCaseToml(t *testing.T) {
@@ -157,7 +172,7 @@ func TestUpdateFlag(t *testing.T) {
   default: false`
 
 	flagFile, _ := ioutil.TempFile("", "")
-	_ = ioutil.WriteFile(flagFile.Name(), []byte(initialFileContent), 0600)
+	_ = ioutil.WriteFile(flagFile.Name(), []byte(initialFileContent), 0o600)
 
 	gffClient1, _ := ffclient.New(ffclient.Config{
 		PollingInterval: 1 * time.Second,
@@ -176,7 +191,7 @@ func TestUpdateFlag(t *testing.T) {
   false: false
   default: false`
 
-	_ = ioutil.WriteFile(flagFile.Name(), []byte(updatedFileContent), 0600)
+	_ = ioutil.WriteFile(flagFile.Name(), []byte(updatedFileContent), 0o600)
 
 	flagValue, _ = gffClient1.BoolVariation("test-flag", ffuser.NewUser("random-key"), false)
 	assert.True(t, flagValue)
@@ -196,7 +211,7 @@ func TestImpossibleToLoadfile(t *testing.T) {
   default: false`
 
 	flagFile, _ := ioutil.TempFile("", "impossible")
-	_ = ioutil.WriteFile(flagFile.Name(), []byte(initialFileContent), 0600)
+	_ = ioutil.WriteFile(flagFile.Name(), []byte(initialFileContent), 0o600)
 
 	gffClient1, _ := ffclient.New(ffclient.Config{
 		PollingInterval: 1 * time.Second,
@@ -264,7 +279,7 @@ func TestFlagFileUnreachable(t *testing.T) {
 	flagValue, _ := gff.StringVariation("test-flag", ffuser.NewUser("random-key"), "SDKdefault")
 	assert.Equal(t, "SDKdefault", flagValue, "should use the SDK default value")
 
-	_ = ioutil.WriteFile(flagFilePath, []byte(initialFileContent), 0600)
+	_ = ioutil.WriteFile(flagFilePath, []byte(initialFileContent), 0o600)
 	time.Sleep(2 * time.Second)
 
 	flagValue, _ = gff.StringVariation("test-flag", ffuser.NewUser("random-key"), "SDKdefault")

--- a/variation.go
+++ b/variation.go
@@ -2,6 +2,7 @@ package ffclient
 
 import (
 	"fmt"
+
 	"github.com/thomaspoignant/go-feature-flag/ffexporter"
 	"github.com/thomaspoignant/go-feature-flag/ffuser"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
@@ -9,8 +10,10 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/internal/model"
 )
 
-const errorFlagNotAvailable = "flag %v is not present or disabled"
-const errorWrongVariation = "wrong variation used for flag %v"
+const (
+	errorFlagNotAvailable = "flag %v is not present or disabled"
+	errorWrongVariation   = "wrong variation used for flag %v"
+)
 
 var offlineVariationResult = model.VariationResult{VariationType: flag.VariationSDKDefault, Failed: true}
 
@@ -53,7 +56,8 @@ func JSONArrayVariation(flagKey string, user ffuser.User, defaultValue []interfa
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.
 func JSONVariation(
-	flagKey string, user ffuser.User, defaultValue map[string]interface{}) (map[string]interface{}, error) {
+	flagKey string, user ffuser.User, defaultValue map[string]interface{},
+) (map[string]interface{}, error) {
 	return ff.JSONVariation(flagKey, user, defaultValue)
 }
 
@@ -108,7 +112,8 @@ func (g *GoFeatureFlag) StringVariation(flagKey string, user ffuser.User, defaul
 // If the key does not exist we return the default value.
 // Note: Use this function only if you are using multiple go-feature-flag instances.
 func (g *GoFeatureFlag) JSONArrayVariation(
-	flagKey string, user ffuser.User, defaultValue []interface{}) ([]interface{}, error) {
+	flagKey string, user ffuser.User, defaultValue []interface{},
+) ([]interface{}, error) {
 	res, err := g.jsonArrayVariation(flagKey, user, defaultValue)
 	g.notifyVariation(flagKey, user, res.VariationResult, res.Value)
 	return res.Value, err
@@ -119,7 +124,8 @@ func (g *GoFeatureFlag) JSONArrayVariation(
 // If the key does not exist we return the default value.
 // Note: Use this function only if you are using multiple go-feature-flag instances.
 func (g *GoFeatureFlag) JSONVariation(
-	flagKey string, user ffuser.User, defaultValue map[string]interface{}) (map[string]interface{}, error) {
+	flagKey string, user ffuser.User, defaultValue map[string]interface{},
+) (map[string]interface{}, error) {
 	res, err := g.jsonVariation(flagKey, user, defaultValue)
 	g.notifyVariation(flagKey, user, res.VariationResult, res.Value)
 	return res.Value, err
@@ -155,6 +161,13 @@ func (g *GoFeatureFlag) AllFlagsState(user ffuser.User) flagstate.AllFlags {
 	return allFlags
 }
 
+// GetFlagsFromCache returns all the flags present in the cache with their
+// current state when calling this method. If cache hasn't been initialized, an
+// error reporting this is returned.
+func (g *GoFeatureFlag) GetFlagsFromCache() (map[string]flag.Flag, error) {
+	return g.cache.AllFlags()
+}
+
 // boolVariation is the internal func that handle the logic of a variation with a bool value
 // the result will always contains a valid model.BoolVarResult
 func (g *GoFeatureFlag) boolVariation(flagKey string, user ffuser.User, sdkDefaultValue bool,
@@ -179,7 +192,8 @@ func (g *GoFeatureFlag) boolVariation(flagKey string, user ffuser.User, sdkDefau
 			VariationResult: computeVariationResult(f, flag.VariationSDKDefault, true),
 		}, fmt.Errorf(errorWrongVariation, flagKey)
 	}
-	return model.BoolVarResult{Value: res,
+	return model.BoolVarResult{
+		Value:           res,
 		VariationResult: computeVariationResult(f, variationType, false),
 	}, nil
 }
@@ -194,7 +208,8 @@ func (g *GoFeatureFlag) intVariation(flagKey string, user ffuser.User, sdkDefaul
 
 	f, err := g.getFlagFromCache(flagKey)
 	if err != nil {
-		return model.IntVarResult{Value: sdkDefaultValue,
+		return model.IntVarResult{
+			Value:           sdkDefaultValue,
 			VariationResult: computeVariationResult(f, flag.VariationSDKDefault, true),
 		}, err
 	}
@@ -215,7 +230,8 @@ func (g *GoFeatureFlag) intVariation(flagKey string, user ffuser.User, sdkDefaul
 			VariationResult: computeVariationResult(f, flag.VariationSDKDefault, true),
 		}, fmt.Errorf(errorWrongVariation, flagKey)
 	}
-	return model.IntVarResult{Value: res,
+	return model.IntVarResult{
+		Value:           res,
 		VariationResult: computeVariationResult(f, variationType, false),
 	}, nil
 }
@@ -391,7 +407,8 @@ func (g *GoFeatureFlag) notifyVariation(
 	flagKey string,
 	user ffuser.User,
 	result model.VariationResult,
-	value interface{}) {
+	value interface{},
+) {
 	if result.TrackEvents {
 		event := ffexporter.NewFeatureEvent(user, flagKey, value, result.VariationType, result.Failed, result.Version)
 

--- a/variation.go
+++ b/variation.go
@@ -67,6 +67,13 @@ func AllFlagsState(user ffuser.User) flagstate.AllFlags {
 	return ff.AllFlagsState(user)
 }
 
+// GetFlagsFromCache returns all the flags present in the cache with their
+// current state when calling this method. If cache hasn't been initialized, an
+// error reporting this is returned.
+func GetFlagsFromCache() (map[string]flag.Flag, error) {
+	return ff.GetFlagsFromCache()
+}
+
 // BoolVariation return the value of the flag in boolean.
 // An error is return if you don't have init the library before calling the function.
 // If the key does not exist we return the default value.

--- a/variation_test.go
+++ b/variation_test.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/thomaspoignant/go-feature-flag/internal/flag"
-	flagv1 "github.com/thomaspoignant/go-feature-flag/internal/flagv1"
-	"github.com/thomaspoignant/go-feature-flag/internal/model"
 	"io/ioutil"
 	"log"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/internal/flag"
+	flagv1 "github.com/thomaspoignant/go-feature-flag/internal/flagv1"
+	"github.com/thomaspoignant/go-feature-flag/internal/model"
 
 	"github.com/thomaspoignant/go-feature-flag/ffexporter"
 	"github.com/thomaspoignant/go-feature-flag/ffuser"
@@ -1253,17 +1254,6 @@ func TestAllFlagsState(t *testing.T) {
 			initModule: true,
 		},
 		{
-			name: "Error in flag-0",
-			config: Config{
-				Retriever: &FileRetriever{
-					Path: "./testdata/ffclient/all_flags/config_flag/flag-config-with-error.yaml",
-				},
-			},
-			valid:      false,
-			jsonOutput: "./testdata/ffclient/all_flags/marshal_json/error_in_flag_0.json",
-			initModule: true,
-		},
-		{
 			name: "module not init",
 			config: Config{
 				Retriever: &FileRetriever{
@@ -1334,6 +1324,57 @@ func TestAllFlagsState(t *testing.T) {
 			// no data exported
 			files, _ := os.ReadDir(exportDir)
 			assert.Equal(t, 0, len(files))
+		})
+	}
+}
+
+func TestAllFlagsFromCache(t *testing.T) {
+	tests := []struct {
+		name       string
+		config     Config
+		initModule bool
+	}{
+		{
+			name: "Valid multiple types",
+			config: Config{
+				Retriever: &FileRetriever{
+					Path: "./testdata/ffclient/all_flags/config_flag/flag-config-all-flags.yaml",
+				},
+			},
+			initModule: true,
+		},
+		{
+			name: "module not init",
+			config: Config{
+				Retriever: &FileRetriever{
+					Path: "./testdata/ffclient/all_flags/config_flag/flag-config-all-flags.yaml",
+				},
+			},
+			initModule: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var goff *GoFeatureFlag
+			var err error
+			if tt.initModule {
+				goff, err = New(tt.config)
+				assert.NoError(t, err)
+				defer goff.Close()
+
+				flags, err := goff.GetFlagsFromCache()
+				assert.NoError(t, err)
+
+				cf, _ := goff.cache.AllFlags()
+				assert.Equal(t, flags, cf)
+			} else {
+				// we close directly so we can test with module not init
+				goff, _ = New(tt.config)
+				goff.Close()
+
+				_, err := goff.GetFlagsFromCache()
+				assert.Error(t, err)
+			}
 		})
 	}
 }

--- a/variation_test.go
+++ b/variation_test.go
@@ -1254,6 +1254,17 @@ func TestAllFlagsState(t *testing.T) {
 			initModule: true,
 		},
 		{
+			name: "Error in flag-0",
+			config: Config{
+				Retriever: &FileRetriever{
+					Path: "./testdata/ffclient/all_flags/config_flag/flag-config-with-error.yaml",
+				},
+			},
+			valid:      false,
+			jsonOutput: "./testdata/ffclient/all_flags/marshal_json/error_in_flag_0.json",
+			initModule: true,
+		},
+		{
 			name: "module not init",
 			config: Config{
 				Retriever: &FileRetriever{


### PR DESCRIPTION
This allows retrieving flag cache metadata like version, rule etc
so the application can use it for visibility purposes. i.e: you want to
know what version of a specific flag your `ffclient` is currently using

resolves #251 