### PR TITLE
Adding section in the documentation to explain environments

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@ During the initialization you must give a [`ffclient.Config{}`](https://pkg.go.d
 |---|---|
 |`Retriever`  | The configuration retriever you want to use to get your flag file<br> *See [Store your flag file](flag_file/index.md) for the configuration details*.|
 |`Context`  | *(optional)*<br>The context used by the retriever.<br />Default: `context.Background()`|
-|`Environment`  | *(optional)*<br>The environment the app is running under, can be checked in feature flag rules.<br />Default: `""`|
+|`Environment`  | <a name="option_environment"></a>*(optional)*<br>The environment the app is running under, can be checked in feature flag rules.<br />Default: `""`<br>*Check [**"environments"** section](../flag_format/#environments) to understand how to use this parameter.*|
 |`DataExporter` | *(optional)*<br>DataExporter defines how to export data on how your flags are used.<br> *see [export data section](data_collection/index.md) for more details*.|
 |`FileFormat`| *(optional)*<br>Format of your configuration file. Available formats are `yaml`, `toml` and `json`, if you omit the field it will try to unmarshal the file as a `yaml` file.<br>Default: `YAML`|
 |`Logger`   | *(optional)*<br>Logger used to log what `go-feature-flag` is doing.<br />If no logger is provided the module will not log anything.<br>Default: No log|

--- a/docs/flag_format.md
+++ b/docs/flag_format.md
@@ -148,6 +148,35 @@ Compare Expression and their definitions (`a|b` means you can use either one of 
     (key ew "@test.com") and (role eq "backend engineer") and (env eq "pro") and (company eq "go-feature-flag")`
     ```
 
+## Environments
+
+When you initialise `go-feature-flag` you can set an [environment](../configuration/#option_environment) for the instance of this SDK.
+
+```go linenums="1"
+ffclient.Init(ffclient.Config{ 
+    // ...
+    Environment:    "prod",
+    // ...
+})
+```
+
+When an environment is set, it adds a new field in your user called **`env`** that you can use in your rules.  
+It means that you can decide to activate a flag only for some **environment**.
+
+**Example of rules based on the environment:**
+```yaml
+# Flag activate only in dev
+rule: env == "dev"
+```
+```yaml
+# Flag used only in dev and staging environment
+rule: (env == "dev") or (env == "staging")
+```
+```yaml
+# Flag used on non prod environments except for the user 1234 in prod
+rule: (env != "prod") or (user_id == 1234)
+```
+
 ## Advanced configurations
 
 You can have advanced configurations for your flag to have specific behavior for them, such as:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
   - 'Home': 'index.md'
   - 'quickstart.md'
   - 'configuration.md'
+  - 'flag_format.md'
   - 'Store your flag file':
       - 'flag_file/index.md'
       - 'flag_file/s3.md'
@@ -65,7 +66,6 @@ nav:
       - 'flag_file/google_cloud_storage.md'
       - 'flag_file/kubernetes_configmaps.md'
       - 'flag_file/custom.md'
-  - 'flag_format.md'
   - 'users.md'
   - 'Rollout strategies':
       - 'rollout/index.md'


### PR DESCRIPTION
# Description
Adding a section in the documentation to explain environments.
Documentation linked to #246 

# Checklist
- [x] I have updated the documentation (README.md and /docs)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
