### PR TITLE
SlackWebhookURL should be a string for compatibility reason

### DIFF
--- a/notifier/slacknotifier/notifier_test.go
+++ b/notifier/slacknotifier/notifier_test.go
@@ -3,7 +3,6 @@ package slacknotifier
 import (
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -140,9 +139,8 @@ func TestSlackNotifier_Notify(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockHTTPClient := &testutils.HTTPClientMock{StatusCode: tt.args.statusCode, ForceError: tt.args.forceError}
 
-			slackURL, _ := url.Parse(tt.args.url)
 			c := Notifier{
-				SlackWebhookURL: *slackURL,
+				SlackWebhookURL: tt.args.url,
 				httpClient:      mockHTTPClient,
 			}
 

--- a/notifier/slacknotifier/notifier_test.go
+++ b/notifier/slacknotifier/notifier_test.go
@@ -131,7 +131,18 @@ func TestSlackNotifier_Notify(t *testing.T) {
 			args: args{
 				statusCode: http.StatusOK,
 				diff:       notifier.DiffCache{},
-				forceError: true,
+			},
+		},
+		{
+			name: "invalid slack url",
+			expected: expected{
+				err:    true,
+				errMsg: "error: (Slack Notifier) invalid SlackWebhookURL: https://{}hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+			},
+			args: args{
+				url:        "https://{}hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				statusCode: http.StatusOK,
+				diff:       notifier.DiffCache{},
 			},
 		},
 	}


### PR DESCRIPTION
# Description
SlackWebhookURL should be a string for compatibility reason

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
