### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: '^1.16.0'
       - run: make lint
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: '^1.16.0'
       - run: make test
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: '^1.16.0'
       - run: make coverage
@@ -52,15 +52,15 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: '^1.16.0'
       - name: Run benchmark
         run: make bench | tee bench-output.txt
       - name: Download previous benchmark data
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark


### PR DESCRIPTION
Bump actions v2 to v3

# Description

I've updated GitHub Actions versions for **cache**, **checkout** and **setup-go** from **v2** to **v3** in .worflows/ci.yml
No any changes in main code

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (README.md and /docs)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)
