### PR TITLE
Stop using ioutil package

### DIFF
--- a/exporter/fileexporter/exporter_test.go
+++ b/exporter/fileexporter/exporter_test.go
@@ -2,7 +2,6 @@ package fileexporter_test
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -215,7 +214,7 @@ func TestFile_Export(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			outputDir := tt.fields.OutputDir
 			if tt.fields.OutputDir == "" {
-				outputDir, _ = ioutil.TempDir("", "fileExporter")
+				outputDir, _ = os.MkdirTemp("", "fileExporter")
 				defer os.Remove(outputDir)
 			}
 
@@ -231,12 +230,12 @@ func TestFile_Export(t *testing.T) {
 				return
 			}
 
-			files, _ := ioutil.ReadDir(outputDir)
+			files, _ := os.ReadDir(outputDir)
 			assert.Equal(t, 1, len(files), "Directory %s should have only one file", outputDir)
 			assert.Regexp(t, tt.expected.fileNameRegex, files[0].Name(), "Invalid file name")
 
-			expectedContent, _ := ioutil.ReadFile(tt.expected.content)
-			gotContent, _ := ioutil.ReadFile(outputDir + "/" + files[0].Name())
+			expectedContent, _ := os.ReadFile(tt.expected.content)
+			gotContent, _ := os.ReadFile(outputDir + "/" + files[0].Name())
 			assert.Equal(t, string(expectedContent), string(gotContent), "Wrong content in the output file")
 		})
 	}

--- a/exporter/gcstorageexporter/exporter.go
+++ b/exporter/gcstorageexporter/exporter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -64,7 +63,7 @@ func (f *Exporter) Export(ctx context.Context, logger *log.Logger, featureEvents
 	}
 
 	// Create a temp directory to store the file we will produce
-	outputDir, err := ioutil.TempDir("", "go_feature_flag_GoogleCloudStorage_export")
+	outputDir, err := os.MkdirTemp("", "go_feature_flag_GoogleCloudStorage_export")
 	if err != nil {
 		return err
 	}
@@ -84,7 +83,7 @@ func (f *Exporter) Export(ctx context.Context, logger *log.Logger, featureEvents
 	}
 
 	// Upload all the files in the folder to google storage
-	files, err := ioutil.ReadDir(outputDir)
+	files, err := os.ReadDir(outputDir)
 	if err != nil {
 		return err
 	}

--- a/exporter/logsexporter/exporter_test.go
+++ b/exporter/logsexporter/exporter_test.go
@@ -2,8 +2,8 @@ package logsexporter_test
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
+	"os"
 	"testing"
 
 	"github.com/thomaspoignant/go-feature-flag/exporter/logsexporter"
@@ -86,7 +86,7 @@ func TestLog_Export(t *testing.T) {
 				LogFormat: tt.fields.LogFormat,
 			}
 
-			logFile, _ := ioutil.TempFile("", "")
+			logFile, _ := os.CreateTemp("", "")
 			logger := log.New(logFile, "", 0)
 
 			err := f.Export(context.Background(), logger, tt.args.featureEvents)
@@ -98,7 +98,7 @@ func TestLog_Export(t *testing.T) {
 
 			assert.NoError(t, err, "Exporter exporter should not throw errors")
 
-			logContent, _ := ioutil.ReadFile(logFile.Name())
+			logContent, _ := os.ReadFile(logFile.Name())
 			assert.Regexp(t, tt.expectedLog, string(logContent))
 		})
 	}

--- a/exporter/s3exporter/exporter.go
+++ b/exporter/s3exporter/exporter.go
@@ -2,7 +2,6 @@ package s3exporter
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -69,7 +68,7 @@ func (f *Exporter) Export(ctx context.Context, logger *log.Logger, featureEvents
 	}
 
 	// Create a temp directory to store the file we will produce
-	outputDir, err := ioutil.TempDir("", "go_feature_flag_s3_export")
+	outputDir, err := os.MkdirTemp("", "go_feature_flag_s3_export")
 	if err != nil {
 		return err
 	}
@@ -89,7 +88,7 @@ func (f *Exporter) Export(ctx context.Context, logger *log.Logger, featureEvents
 	}
 
 	// Upload all the files in the folder to Exporter
-	files, err := ioutil.ReadDir(outputDir)
+	files, err := os.ReadDir(outputDir)
 	if err != nil {
 		return err
 	}

--- a/exporter/s3exporter/exporter_test.go
+++ b/exporter/s3exporter/exporter_test.go
@@ -2,7 +2,6 @@ package s3exporter
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -187,7 +186,7 @@ func TestS3_Export(t *testing.T) {
 
 			assert.NoError(t, err, "Export should not error")
 			assert.Equal(t, 1, len(s3ManagerMock.S3ManagerMockFileSystem), "we should have 1 file in our mock")
-			expectedContent, _ := ioutil.ReadFile(tt.expectedFile)
+			expectedContent, _ := os.ReadFile(tt.expectedFile)
 			for k, v := range s3ManagerMock.S3ManagerMockFileSystem {
 				assert.Equal(t, string(expectedContent), v, "invalid file content")
 				assert.Regexp(t, tt.expectedName, k, "invalid file name")

--- a/exporter/webhookexporter/exporter.go
+++ b/exporter/webhookexporter/exporter.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -94,7 +94,7 @@ func (f *Exporter) Export(ctx context.Context, logger *log.Logger, featureEvents
 	}
 
 	request, err := http.NewRequestWithContext(
-		ctx, http.MethodPost, f.EndpointURL, ioutil.NopCloser(bytes.NewReader(payload)))
+		ctx, http.MethodPost, f.EndpointURL, io.NopCloser(bytes.NewReader(payload)))
 	if err != nil {
 		return err
 	}

--- a/exporter/webhookexporter/exporter_test.go
+++ b/exporter/webhookexporter/exporter_test.go
@@ -3,7 +3,6 @@ package webhookexporter
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -166,7 +165,7 @@ func TestWebhook_Export(t *testing.T) {
 
 			assert.NoError(t, err)
 			if tt.expected.bodyFilePath != "" {
-				c, err := ioutil.ReadFile(tt.expected.bodyFilePath)
+				c, err := os.ReadFile(tt.expected.bodyFilePath)
 				fmt.Println(err)
 				assert.JSONEq(t, string(c), tt.fields.httpClient.Body)
 			}

--- a/feature_flag_bench_test.go
+++ b/feature_flag_bench_test.go
@@ -3,7 +3,7 @@ package ffclient_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"text/template"
 	"time"
@@ -19,7 +19,7 @@ var client *ffclient.GoFeatureFlag
 
 // init is creating a flag file for this test with the expected date.
 func init() {
-	content, _ := ioutil.ReadFile("testdata/benchmark/flag-config.yaml")
+	content, _ := os.ReadFile("testdata/benchmark/flag-config.yaml")
 	t, _ := template.New("example-flag-config").Parse(string(content))
 
 	var buf bytes.Buffer
@@ -33,8 +33,8 @@ func init() {
 		DateAfter:  time.Now().Add(3 * time.Second).Format(time.RFC3339),
 	})
 
-	flagFile, _ := ioutil.TempFile("", "")
-	_ = ioutil.WriteFile(flagFile.Name(), buf.Bytes(), 0o600)
+	flagFile, _ := os.CreateTemp("", "")
+	_ = os.WriteFile(flagFile.Name(), buf.Bytes(), 0o600)
 
 	client, _ = ffclient.New(ffclient.Config{
 		PollingInterval: 1 * time.Second,

--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -1,7 +1,6 @@
 package ffclient_test
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -174,8 +173,8 @@ func TestUpdateFlag(t *testing.T) {
   false: false
   default: false`
 
-	flagFile, _ := ioutil.TempFile("", "")
-	_ = ioutil.WriteFile(flagFile.Name(), []byte(initialFileContent), 0o600)
+	flagFile, _ := os.CreateTemp("", "")
+	_ = os.WriteFile(flagFile.Name(), []byte(initialFileContent), 0o600)
 
 	gffClient1, _ := ffclient.New(ffclient.Config{
 		PollingInterval: 1 * time.Second,
@@ -194,7 +193,7 @@ func TestUpdateFlag(t *testing.T) {
   false: false
   default: false`
 
-	_ = ioutil.WriteFile(flagFile.Name(), []byte(updatedFileContent), 0o600)
+	_ = os.WriteFile(flagFile.Name(), []byte(updatedFileContent), 0o600)
 
 	flagValue, _ = gffClient1.BoolVariation("test-flag", ffuser.NewUser("random-key"), false)
 	assert.True(t, flagValue)
@@ -213,8 +212,8 @@ func TestImpossibleToLoadfile(t *testing.T) {
   false: false
   default: false`
 
-	flagFile, _ := ioutil.TempFile("", "impossible")
-	_ = ioutil.WriteFile(flagFile.Name(), []byte(initialFileContent), 0o600)
+	flagFile, _ := os.CreateTemp("", "impossible")
+	_ = os.WriteFile(flagFile.Name(), []byte(initialFileContent), 0o600)
 
 	gffClient1, _ := ffclient.New(ffclient.Config{
 		PollingInterval: 1 * time.Second,
@@ -245,7 +244,7 @@ func TestFlagFileUnreachable(t *testing.T) {
   false: "false"
   default: "false"`
 
-	tempDir, _ := ioutil.TempDir("", "")
+	tempDir, _ := os.MkdirTemp("", "")
 	defer os.Remove(tempDir)
 
 	flagFilePath := tempDir + "_FlagFileUnreachable.yaml"
@@ -262,7 +261,7 @@ func TestFlagFileUnreachable(t *testing.T) {
 	flagValue, _ := gff.StringVariation("test-flag", ffuser.NewUser("random-key"), "SDKdefault")
 	assert.Equal(t, "SDKdefault", flagValue, "should use the SDK default value")
 
-	_ = ioutil.WriteFile(flagFilePath, []byte(initialFileContent), 0o600)
+	_ = os.WriteFile(flagFilePath, []byte(initialFileContent), 0o600)
 	time.Sleep(2 * time.Second)
 
 	flagValue, _ = gff.StringVariation("test-flag", ffuser.NewUser("random-key"), "SDKdefault")

--- a/internal/dataexporter/data_exporter_test.go
+++ b/internal/dataexporter/data_exporter_test.go
@@ -3,7 +3,6 @@ package dataexporter_test
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -79,7 +78,7 @@ func TestDataExporterScheduler_defaultFlush(t *testing.T) {
 func TestDataExporterScheduler_exporterReturnError(t *testing.T) {
 	mockExporter := mock.Exporter{Err: errors.New("random err"), ExpectedNumberErr: 1, Bulk: true}
 
-	file, _ := ioutil.TempFile("", "log")
+	file, _ := os.CreateTemp("", "log")
 	defer file.Close()
 	defer os.Remove(file.Name())
 	logger := log.New(file, "", 0)
@@ -100,7 +99,7 @@ func TestDataExporterScheduler_exporterReturnError(t *testing.T) {
 	assert.Equal(t, inputEvents[:201], mockExporter.GetExportedEvents())
 
 	// read log
-	logs, _ := ioutil.ReadFile(file.Name())
+	logs, _ := os.ReadFile(file.Name())
 	assert.Regexp(t, "\\["+testutils.RFC3339Regex+"\\] error while exporting data: random err\\n", string(logs))
 }
 

--- a/notifier/logsnotifier/notifier_test.go
+++ b/notifier/logsnotifier/notifier_test.go
@@ -1,7 +1,6 @@
 package logsnotifier
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -156,7 +155,7 @@ func TestLogNotifier_Notify(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logOutput, _ := ioutil.TempFile("", "")
+			logOutput, _ := os.CreateTemp("", "")
 			defer os.Remove(logOutput.Name())
 
 			c := &Notifier{
@@ -164,7 +163,7 @@ func TestLogNotifier_Notify(t *testing.T) {
 			}
 			tt.args.wg.Add(1)
 			_ = c.Notify(tt.args.diff, tt.args.wg)
-			log, _ := ioutil.ReadFile(logOutput.Name())
+			log, _ := os.ReadFile(logOutput.Name())
 			assert.Regexp(t, tt.expected, string(log))
 		})
 	}

--- a/notifier/slacknotifier/notifier.go
+++ b/notifier/slacknotifier/notifier.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -60,7 +60,7 @@ func (c *Notifier) Notify(diff notifier.DiffCache, wg *sync.WaitGroup) error {
 	request := http.Request{
 		Method: http.MethodPost,
 		URL:    slackURL,
-		Body:   ioutil.NopCloser(bytes.NewReader(payload)),
+		Body:   io.NopCloser(bytes.NewReader(payload)),
 		Header: map[string][]string{"Content-type": {"application/json"}},
 	}
 	response, err := c.httpClient.Do(&request)

--- a/notifier/slacknotifier/notifier_test.go
+++ b/notifier/slacknotifier/notifier_test.go
@@ -1,7 +1,6 @@
 package slacknotifier
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -164,7 +163,7 @@ func TestSlackNotifier_Notify(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				hostname, _ := os.Hostname()
-				content, _ := ioutil.ReadFile(tt.expected.bodyPath)
+				content, _ := os.ReadFile(tt.expected.bodyPath)
 				expectedContent := strings.ReplaceAll(string(content), "{{hostname}}", hostname)
 				assert.JSONEq(t, expectedContent, mockHTTPClient.Body)
 				assert.Equal(t, tt.expected.signature, mockHTTPClient.Signature)

--- a/notifier/webhooknotifier/notifier.go
+++ b/notifier/webhooknotifier/notifier.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -133,7 +133,7 @@ func (c *Notifier) Notify(diff notifier.DiffCache, wg *sync.WaitGroup) error {
 		Method: "POST",
 		URL:    endpointURL,
 		Header: headers,
-		Body:   ioutil.NopCloser(bytes.NewReader(payload)),
+		Body:   io.NopCloser(bytes.NewReader(payload)),
 	}
 	response, err := c.httpClient.Do(&request)
 	// Log if something went wrong while calling the webhook.

--- a/notifier/webhooknotifier/notifier_test.go
+++ b/notifier/webhooknotifier/notifier_test.go
@@ -2,8 +2,8 @@ package webhooknotifier
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"sync"
 	"testing"
 
@@ -172,7 +172,7 @@ func Test_webhookNotifier_Notify(t *testing.T) {
 				assert.ErrorContains(t, err, tt.expected.errorMsg)
 			} else {
 				assert.NoError(t, err)
-				content, _ := ioutil.ReadFile(tt.expected.bodyPath)
+				content, _ := os.ReadFile(tt.expected.bodyPath)
 				assert.JSONEq(t, string(content), mockHTTPClient.Body)
 				assert.Equal(t, tt.expected.signature, mockHTTPClient.Signature)
 			}

--- a/retriever/fileretriever/retriever.go
+++ b/retriever/fileretriever/retriever.go
@@ -2,7 +2,7 @@ package fileretriever
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 )
 
 // Retriever is a configuration struct for a local flat file.
@@ -12,7 +12,7 @@ type Retriever struct {
 
 // Retrieve is reading the file and return the content
 func (r *Retriever) Retrieve(ctx context.Context) ([]byte, error) {
-	content, err := ioutil.ReadFile(r.Path)
+	content, err := os.ReadFile(r.Path)
 	if err != nil {
 		return nil, err
 	}

--- a/retriever/gcstorageretriever/retriever.go
+++ b/retriever/gcstorageretriever/retriever.go
@@ -6,7 +6,6 @@ import (
 	"crypto/md5" //nolint: gosec
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"cloud.google.com/go/storage"
 
@@ -76,7 +75,7 @@ func (retriever *Retriever) Retrieve(ctx context.Context) (content []byte, err e
 	defer retriever.rC.Close()
 
 	// Read all contents from the Reader.
-	content, err = ioutil.ReadAll(retriever.rC)
+	content, err = io.ReadAll(retriever.rC)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"unable to read from GCP Object %s in Bucket %s, error: %s", retriever.Bucket, retriever.Object, err,

--- a/retriever/gcstorageretriever/retriever_test.go
+++ b/retriever/gcstorageretriever/retriever_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/md5" //nolint: gosec
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -114,7 +114,7 @@ func TestGCStorageRetriever_Retrieve(t *testing.T) {
 			}
 
 			// Read default file.
-			want, err := ioutil.ReadFile("./testdata/flag-config.yaml")
+			want, err := os.ReadFile("./testdata/flag-config.yaml")
 			assert.NoError(t, err)
 			r.cache = want
 
@@ -132,7 +132,7 @@ func TestGCStorageRetriever_Retrieve(t *testing.T) {
 				// If expect data not to be in cache, mock the
 				// remote hash to a different one that the local hash.
 
-				want, err = ioutil.ReadFile("./testdata/flag-config-updated.yaml")
+				want, err = os.ReadFile("./testdata/flag-config-updated.yaml")
 				assert.NoError(t, err)
 
 				md5Hash = md5.Sum(want) //nolint: gosec

--- a/retriever/httpretriever/retriever.go
+++ b/retriever/httpretriever/retriever.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -84,7 +84,7 @@ func (r *Retriever) Retrieve(ctx context.Context) ([]byte, error) {
 	}
 
 	// read content of the URL.
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/retriever/s3retriever/retriever.go
+++ b/retriever/s3retriever/retriever.go
@@ -3,7 +3,8 @@ package s3retriever
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -32,7 +33,7 @@ func (s *Retriever) Retrieve(ctx context.Context) ([]byte, error) {
 	// Download the item from the bucket.
 	// If an error occurs, log it and exit.
 	// Otherwise, notify the user that the download succeeded.
-	file, err := ioutil.TempFile("", "go_feature_flag")
+	file, err := os.CreateTemp("", "go_feature_flag")
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +65,7 @@ func (s *Retriever) Retrieve(ctx context.Context) ([]byte, error) {
 	}
 
 	// Read file content
-	content, err := ioutil.ReadAll(file)
+	content, err := io.ReadAll(file)
 	if err != nil {
 		return nil, err
 	}

--- a/retriever/s3retriever/retriever_test.go
+++ b/retriever/s3retriever/retriever_test.go
@@ -2,7 +2,7 @@ package s3retriever
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -73,7 +73,7 @@ func Test_s3Retriever_Retrieve(t *testing.T) {
 			got, err := s.Retrieve(tt.fields.context)
 			assert.Equal(t, tt.wantErr, err != nil, "Retrieve() error = %v, wantErr %v", err, tt.wantErr)
 			if err == nil {
-				want, err := ioutil.ReadFile(tt.want)
+				want, err := os.ReadFile(tt.want)
 				assert.NoError(t, err)
 				assert.Equal(t, string(want), string(got), "Retrieve() got = %v, want %v", string(want), string(got))
 			}

--- a/testutils/mock/httpmock.go
+++ b/testutils/mock/httpmock.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -17,7 +17,7 @@ func (m *HTTP) Do(req *http.Request) (*http.Response, error) {
 	success := &http.Response{
 		Status:     "OK",
 		StatusCode: http.StatusOK,
-		Body: ioutil.NopCloser(bytes.NewReader([]byte(`test-flag:
+		Body: io.NopCloser(bytes.NewReader([]byte(`test-flag:
  rule: key eq "random-key"
  percentage: 100
  true: true
@@ -29,7 +29,7 @@ func (m *HTTP) Do(req *http.Request) (*http.Response, error) {
 	error := &http.Response{
 		Status:     "KO",
 		StatusCode: http.StatusInternalServerError,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 	}
 
 	if strings.HasSuffix(req.URL.String(), "error") {

--- a/testutils/mock_gc_storage_reader.go
+++ b/testutils/mock_gc_storage_reader.go
@@ -3,7 +3,7 @@ package testutils
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 )
 
 type GCStorageReaderMock struct {
@@ -24,7 +24,7 @@ func (r *GCStorageReaderMock) Read(p []byte) (n int, err error) {
 
 	// Set the mocked data to be read.
 	if r.data == nil {
-		r.data, err = ioutil.ReadFile(r.FileToRead)
+		r.data, err = os.ReadFile(r.FileToRead)
 		if err != nil {
 			return 0, err
 		}

--- a/testutils/mock_httpclient.go
+++ b/testutils/mock_httpclient.go
@@ -3,7 +3,7 @@ package testutils
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -19,11 +19,11 @@ func (h *HTTPClientMock) Do(req *http.Request) (*http.Response, error) {
 		return nil, errors.New("random error")
 	}
 
-	b, _ := ioutil.ReadAll(req.Body)
+	b, _ := io.ReadAll(req.Body)
 	h.Body = string(b)
 	h.Signature = req.Header.Get("X-Hub-Signature-256")
 	resp := &http.Response{
-		Body: ioutil.NopCloser(bytes.NewReader([]byte(""))),
+		Body: io.NopCloser(bytes.NewReader([]byte(""))),
 	}
 	resp.StatusCode = h.StatusCode
 	return resp, nil

--- a/testutils/mock_s3manager.go
+++ b/testutils/mock_s3manager.go
@@ -3,7 +3,7 @@ package testutils
 import (
 	"errors"
 	"io"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -20,7 +20,7 @@ func (s *S3ManagerMock) Download(at io.WriterAt, input *s3.GetObjectInput,
 	f ...func(*s3manager.Downloader),
 ) (int64, error) {
 	if *input.Key == "valid" {
-		res, _ := ioutil.ReadFile(s.TestDataLocation + "/flag-config.yaml")
+		res, _ := os.ReadFile(s.TestDataLocation + "/flag-config.yaml")
 		_, _ = at.WriteAt(res, 0)
 		return 1, nil
 	} else if *input.Key == "no-file" {

--- a/variation_test.go
+++ b/variation_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -217,7 +216,7 @@ func TestBoolVariation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// init logger
-			file, _ := ioutil.TempFile("", "log")
+			file, _ := os.CreateTemp("", "log")
 			logger := log.New(file, "", 0)
 
 			ff = &GoFeatureFlag{
@@ -238,7 +237,7 @@ func TestBoolVariation(t *testing.T) {
 			got, err := BoolVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
 
 			if tt.expectedLog != "" {
-				content, _ := ioutil.ReadFile(file.Name())
+				content, _ := os.ReadFile(file.Name())
 				assert.Regexp(t, tt.expectedLog, string(content))
 			}
 
@@ -419,7 +418,7 @@ func TestFloat64Variation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// init logger
-			file, _ := ioutil.TempFile("", "log")
+			file, _ := os.CreateTemp("", "log")
 			logger := log.New(file, "", 0)
 
 			ff = &GoFeatureFlag{
@@ -440,7 +439,7 @@ func TestFloat64Variation(t *testing.T) {
 			got, err := Float64Variation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
 
 			if tt.expectedLog != "" {
-				content, _ := ioutil.ReadFile(file.Name())
+				content, _ := os.ReadFile(file.Name())
 				assert.Regexp(t, tt.expectedLog, string(content))
 			}
 			if tt.wantErr {
@@ -638,7 +637,7 @@ func TestJSONArrayVariation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// init logger
-			file, _ := ioutil.TempFile("", "log")
+			file, _ := os.CreateTemp("", "log")
 			logger := log.New(file, "", 0)
 
 			ff = &GoFeatureFlag{
@@ -661,7 +660,7 @@ func TestJSONArrayVariation(t *testing.T) {
 			}
 			assert.Equal(t, tt.want, got, "JSONArrayVariation() got = %v, want %v", got, tt.want)
 			if tt.expectedLog != "" {
-				content, _ := ioutil.ReadFile(file.Name())
+				content, _ := os.ReadFile(file.Name())
 				assert.Regexp(t, tt.expectedLog, string(content))
 			}
 			// clean logger
@@ -816,7 +815,7 @@ func TestJSONVariation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// init logger
-			file, _ := ioutil.TempFile("", "log")
+			file, _ := os.CreateTemp("", "log")
 			logger := log.New(file, "", 0)
 
 			ff = &GoFeatureFlag{
@@ -837,7 +836,7 @@ func TestJSONVariation(t *testing.T) {
 			got, err := JSONVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
 
 			if tt.expectedLog != "" {
-				content, _ := ioutil.ReadFile(file.Name())
+				content, _ := os.ReadFile(file.Name())
 				assert.Regexp(t, tt.expectedLog, string(content))
 			}
 
@@ -1001,7 +1000,7 @@ func TestStringVariation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// init logger
-			file, _ := ioutil.TempFile("", "log")
+			file, _ := os.CreateTemp("", "log")
 			logger := log.New(file, "", 0)
 
 			ff = &GoFeatureFlag{
@@ -1021,7 +1020,7 @@ func TestStringVariation(t *testing.T) {
 			got, err := StringVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
 
 			if tt.expectedLog != "" {
-				content, _ := ioutil.ReadFile(file.Name())
+				content, _ := os.ReadFile(file.Name())
 				assert.Regexp(t, tt.expectedLog, string(content))
 			}
 
@@ -1202,7 +1201,7 @@ func TestIntVariation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// init logger
-			file, _ := ioutil.TempFile("", "log")
+			file, _ := os.CreateTemp("", "log")
 			logger := log.New(file, "", 0)
 
 			ff = &GoFeatureFlag{
@@ -1222,7 +1221,7 @@ func TestIntVariation(t *testing.T) {
 			got, err := IntVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
 
 			if tt.expectedLog != "" {
-				content, _ := ioutil.ReadFile(file.Name())
+				content, _ := os.ReadFile(file.Name())
 				assert.Regexp(t, tt.expectedLog, string(content))
 			}
 
@@ -1296,7 +1295,7 @@ func TestAllFlagsState(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// init logger
-			exportDir, _ := ioutil.TempDir("", "export")
+			exportDir, _ := os.MkdirTemp("", "export")
 			tt.config.DataExporter = DataExporter{
 				FlushInterval:    1000,
 				MaxEventInMemory: 1,
@@ -1320,7 +1319,7 @@ func TestAllFlagsState(t *testing.T) {
 			assert.Equal(t, tt.valid, allFlagsState.IsValid())
 
 			// expected JSON output - we force the timestamp
-			expected, _ := ioutil.ReadFile(tt.jsonOutput)
+			expected, _ := os.ReadFile(tt.jsonOutput)
 			var f map[string]interface{}
 			_ = json.Unmarshal(expected, &f)
 			if expectedFlags, ok := f["flags"].(map[string]interface{}); ok {
@@ -1607,7 +1606,7 @@ func TestRawVariation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// init logger
-			file, _ := ioutil.TempFile("", "log")
+			file, _ := os.CreateTemp("", "log")
 			logger := log.New(file, "", 0)
 
 			ff = &GoFeatureFlag{
@@ -1628,7 +1627,7 @@ func TestRawVariation(t *testing.T) {
 			got, err := ff.RawVariation(tt.args.flagKey, tt.args.user, tt.args.defaultValue)
 
 			if tt.expectedLog != "" {
-				content, _ := ioutil.ReadFile(file.Name())
+				content, _ := os.ReadFile(file.Name())
 				assert.Regexp(t, tt.expectedLog, string(content))
 			}
 


### PR DESCRIPTION
# Description
`ioutil` package is deprecated, we are using the new native functions.

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (README.md and /docs)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
