### PR TITLE
Fix goreleaser archive fail

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,7 @@ builds:
 
 archives:
   - id: go-feature-flag-migration-cli
+    name_template: go-feature-flag-migration-cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
     builds:
       - go-feature-flag-migration-cli
     replacements:
@@ -61,6 +62,7 @@ archives:
       386: i386
       amd64: x86_64
   - id: go-feature-flag-relay-proxy
+    name_template: go-feature-flag-relay-proxy_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
     builds:
       - go-feature-flag-relay-proxy
     replacements:


### PR DESCRIPTION
# Description
Goreleaser was not able to generate the archive and was failing.
_See https://github.com/thomaspoignant/go-feature-flag/actions/runs/3248914028/jobs/5330696927_.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (README.md and /docs)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
