### PR TITLE
Fix race condition when closing not using the singleton

### DIFF
--- a/feature_flag.go
+++ b/feature_flag.go
@@ -33,6 +33,7 @@ func Init(config Config) error {
 
 // Close the component by stopping the background refresh and clean the cache.
 func Close() {
+	onceFF = sync.Once{}
 	ff.Close()
 }
 
@@ -102,7 +103,6 @@ func New(config Config) (*GoFeatureFlag, error) {
 
 // Close wait until thread are done
 func (g *GoFeatureFlag) Close() {
-	onceFF = sync.Once{}
 	if g != nil {
 		if g.cache != nil {
 			// clear the cache


### PR DESCRIPTION
# Description
This is the implementation of the proposed solution on this PR https://github.com/thomaspoignant/go-feature-flag/pull/425.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)
Resolve #425

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (README.md and /docs)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
