### PR TITLE
Fix config files for examples directory

### DIFF
--- a/examples/data_export_file/flags.yaml
+++ b/examples/data_export_file/flags.yaml
@@ -1,7 +1,7 @@
 new-admin-access:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   defaultRule:
     percentage:
@@ -11,7 +11,7 @@ new-admin-access:
 flag-only-for-admin:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   targeting:
     - query: admin eq true

--- a/examples/data_export_googlecloudstorage/flags.yaml
+++ b/examples/data_export_googlecloudstorage/flags.yaml
@@ -1,7 +1,7 @@
 new-admin-access:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   defaultRule:
     percentage:
@@ -11,7 +11,7 @@ new-admin-access:
 flag-only-for-admin:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   targeting:
     - query: admin eq true

--- a/examples/data_export_s3/flags.yaml
+++ b/examples/data_export_s3/flags.yaml
@@ -1,7 +1,7 @@
 new-admin-access:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   defaultRule:
     percentage:
@@ -11,7 +11,7 @@ new-admin-access:
 flag-only-for-admin:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   targeting:
     - query: admin eq true

--- a/examples/retriever_configmap/flags.yaml
+++ b/examples/retriever_configmap/flags.yaml
@@ -1,7 +1,7 @@
 new-admin-access:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   defaultRule:
     percentage:
@@ -11,7 +11,7 @@ new-admin-access:
 flag-only-for-admin:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   targeting:
     - query: admin eq true

--- a/examples/retriever_file/flags.yaml
+++ b/examples/retriever_file/flags.yaml
@@ -1,7 +1,7 @@
 new-admin-access:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   defaultRule:
     percentage:
@@ -15,7 +15,7 @@ new-admin-access:
 flag-only-for-admin:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   targeting:
     - query: admin eq true

--- a/examples/retriever_github/flags.yaml
+++ b/examples/retriever_github/flags.yaml
@@ -1,7 +1,7 @@
 new-admin-access:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   defaultRule:
     percentage:
@@ -11,7 +11,7 @@ new-admin-access:
 flag-only-for-admin:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   targeting:
     - query: admin eq true

--- a/examples/retriever_http/flags.yaml
+++ b/examples/retriever_http/flags.yaml
@@ -1,7 +1,7 @@
 new-admin-access:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   defaultRule:
     percentage:
@@ -11,7 +11,7 @@ new-admin-access:
 flag-only-for-admin:
   variations:
     default_var: false
-    false_var": false
+    false_var: false
     true_var: true
   targeting:
     - query: admin eq true


### PR DESCRIPTION
There is a double quote present in the keys for config files exists in `examples` directory and generating below error:

2023/02/05 21:51:11 something went wrong when getting the flag: wrong variation used for flag new-admin-access

With this change, it will be fixed by removing the double quotes.

# Description
<!-- 
Please add a description of what your pull request is doing.
 - What was the problem?
 - How it is resolved?
 - How can we test the change?
 - If there are breaking changes, please describe them in detail and why we cannot avoid them.
-->

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve # Not Applicable

# Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
