### PR TITLE
Add lint command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -50,6 +50,28 @@ builds:
         goarch: arm
         goarm: 6
 
+  - id: go-feature-flag-lint-cli
+    main: ./cmd/lint
+    binary: go-feature-flag-lint-cli
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - 386
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - 6
+      - 7
+    ignore:
+      - goos: darwin
+        goarch: 386
+      - goos: linux
+        goarch: arm
+        goarm: 6
+
 archives:
   - id: go-feature-flag-migration-cli
     name_template: go-feature-flag-migration-cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
@@ -65,6 +87,16 @@ archives:
     name_template: go-feature-flag-relay-proxy_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
     builds:
       - go-feature-flag-relay-proxy
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+  - id: go-feature-flag-lint-cli
+    name_template: go-feature-flag-lint-cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
+    builds:
+      - go-feature-flag-lint-cli
     replacements:
       darwin: Darwin
       linux: Linux
@@ -105,6 +137,15 @@ dockers:
       - thomaspoignant/go-feature-flag-relay-proxy:{{ .Tag }}
       - thomaspoignant/go-feature-flag-relay-proxy:v{{ .Major }}
       - thomaspoignant/go-feature-flag-relay-proxy:v{{ .Major }}.{{ .Minor }}
+  - goos: linux
+    ids:
+      - go-feature-flag-lint-cli
+    dockerfile: ./cmd/lint/Dockerfile
+    image_templates:
+      - thomaspoignant/go-feature-flag-lint-cli:latest
+      - thomaspoignant/go-feature-flag-lint-cli:{{ .Tag }}
+      - thomaspoignant/go-feature-flag-lint-cli:v{{ .Major }}
+      - thomaspoignant/go-feature-flag-lint-cli:v{{ .Major }}.{{ .Minor }}
 
 brews:
   - ids:
@@ -128,6 +169,17 @@ brews:
     caveats: "A stand alone server to run GO Feature Flag"
     homepage: "https://gofeatureflag.org"
     description: "A stand alone server to run GO Feature Flag"
+    skip_upload: auto
+  - ids:
+      - go-feature-flag-lint-cli
+    name: go-feature-flag-lint-cli
+    tap:
+      owner: thomaspoignant
+      name: homebrew-tap
+      branch: master
+    caveats: "A command line tool to lint your feature flag configuration file"
+    homepage: "https://gofeatureflag.org"
+    description: "A command line tool to lint your feature flag configuration file"
     skip_upload: auto
 
 scoop:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ RESET  := $(shell tput -Txterm sgr0)
 
 all: help
 ## Build:
-build: build-migrationcli build-relayproxy ## Build all the binaries and put the output in out/bin/
+build: build-migrationcli build-relayproxy build-lint ## Build all the binaries and put the output in out/bin/
 
 build-migrationcli: ## Build the migration cli in out/bin/
 	mkdir -p out/bin
@@ -23,6 +23,10 @@ build-migrationcli: ## Build the migration cli in out/bin/
 build-relayproxy: ## Build the relay proxy in out/bin/
 	mkdir -p out/bin
 	GO111MODULE=on $(GOCMD) build -mod vendor -o out/bin/relayproxy ./cmd/relayproxy/
+
+build-lint: ## Build the linter in out/bin/
+	mkdir -p out/bin
+	GO111MODULE=on $(GOCMD) build -mod vendor -o out/bin/lint ./cmd/lint/
 
 build-doc: ## Build the documentation
 	cd website; \

--- a/README.md
+++ b/README.md
@@ -533,6 +533,9 @@ It represents individual flag evaluations and is considered "full fidelity" even
 The format of the data is [described in the documentation](https://gofeatureflag.org/docs/).
 Events are collected and sent in bulk to avoid spamming your exporter.
 
+## Linter
+A command line tool is available to help you lint your configuration file: [go-feature-flag-lint-cli](cmd/lint/README.md).
+
 # How can I contribute?
 This project is open for contribution, see the [contributor's guide](CONTRIBUTING.md) for some helpful tips.
 

--- a/cmd/lint/DOCKERHUB.md
+++ b/cmd/lint/DOCKERHUB.md
@@ -1,0 +1,22 @@
+# GO Feature Flag Lint cli
+
+The lint command lint tool validates that a flags file can be parsed by GO Feature Flag.
+
+## How to use this image
+
+```shell
+docker run \
+  -v $(pwd)/your/configuration_folder:/config \
+  thomaspoignant/go-feature-flag-lint-cli:latest \
+  --input-file=/config/my-go-feature-flag-config.yaml \
+  --input-format=yaml
+```
+
+### Params description
+
+The command line has 2 parameters:
+
+| param            | description                                                                                                       |
+|------------------|-------------------------------------------------------------------------------------------------------------------|
+| `--input-file`   | **(mandatory)** The location of your configuration file.                                                          |
+| `--input-format` | **(mandatory)** The format of your current configuration file. <br/>Available formats are `yaml`, `json`, `toml`. |

--- a/cmd/lint/Dockerfile
+++ b/cmd/lint/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/distroless/base-debian11:latest
+ENTRYPOINT ["/go-feature-flag-lint-cli"]
+COPY go-feature-flag-lint-cli /

--- a/cmd/lint/README.md
+++ b/cmd/lint/README.md
@@ -4,7 +4,17 @@ The lint command lint tool validates that a flags file can be parsed by GO Featu
 
 ## How to install the cli
 
-:construction:
+### Install using Homebrew (mac and linux)
+```shell
+brew tap thomaspoignant/homebrew-tap
+brew install go-feature-flag-lint-cli
+```
+
+### Install using docker
+```shell
+docker pull thomaspoignant/go-feature-flag-lint-cli
+```
+More information about the usage of the container in the [dockerhub page](https://hub.docker.com/r/thomaspoignant/go-feature-flag-lint-cli).
 
 ## How to use the cli
 

--- a/cmd/lint/README.md
+++ b/cmd/lint/README.md
@@ -1,0 +1,21 @@
+# GO Feature Flag Lint cli
+
+The lint command lint tool validates that a flags file can be parsed by GO Feature Flag.
+
+## How to install the cli
+
+:construction:
+
+## How to use the cli
+
+```shell
+# example:
+go-feature-flag-lint --input-format=yaml --input-file=/input/my-go-feature-flag-config.yaml
+```
+
+The command line has 2 parameters:
+
+| param            | description                                                                                                       |
+|------------------|-------------------------------------------------------------------------------------------------------------------|
+| `--input-file`   | **(mandatory)** The location of your configuration file.                                                          |
+| `--input-format` | **(mandatory)** The format of your current configuration file. <br/>Available formats are `yaml`, `json`, `toml`. |

--- a/cmd/lint/README.md
+++ b/cmd/lint/README.md
@@ -1,6 +1,6 @@
 # GO Feature Flag Lint cli
 
-The lint command lint tool validates that a flags file can be parsed by GO Feature Flag.
+The lint command line tool validates that a flags file can be parsed by GO Feature Flag.
 
 ## How to install the cli
 

--- a/cmd/lint/linter.go
+++ b/cmd/lint/linter.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/thomaspoignant/go-feature-flag/internal/dto"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+type Linter struct {
+	InputFile   string
+	InputFormat string
+}
+
+func (l *Linter) Lint() []error {
+	dat, err := os.ReadFile(l.InputFile)
+	if err != nil {
+		return []error{err}
+	}
+
+	var flags map[string]dto.DTO
+	switch strings.ToLower(l.InputFormat) {
+	case "toml":
+		err = toml.Unmarshal(dat, &flags)
+	case "json":
+		err = json.Unmarshal(dat, &flags)
+	case "yaml":
+		err = yaml.Unmarshal(dat, &flags)
+	default:
+		return []error{fmt.Errorf("%s: invalid input format: %s", l.InputFile, l.InputFormat)}
+	}
+	if err != nil {
+		return []error{fmt.Errorf("%s: could not parse file: %w", l.InputFile, err)}
+	}
+
+	errs := make([]error, 0)
+	for key, flagDto := range flags {
+		flag := flagDto.Convert()
+		if err := flag.IsValid(); err != nil {
+			errs = append(errs, fmt.Errorf("%s: invalid flag %s: %w", l.InputFile, key, err))
+		}
+	}
+
+	return errs
+}

--- a/cmd/lint/linter_test.go
+++ b/cmd/lint/linter_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+)
+import "testing"
+
+func TestLinter_Lint(t *testing.T) {
+	tests := []struct {
+		name    string
+		linter  Linter
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "flag-config.yaml",
+			linter: Linter{
+				InputFile:   "../../testdata/flag-config.yaml",
+				InputFormat: "YAML",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "flag-config.json",
+			linter: Linter{
+				InputFile:   "../../testdata/flag-config.json",
+				InputFormat: "JSON",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "flag-config.toml",
+			linter: Linter{
+				InputFile:   "../../testdata/flag-config.toml",
+				InputFormat: "TOML",
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "invalid yaml",
+			linter: Linter{
+				InputFile:   "testdata/invalid.yaml",
+				InputFormat: "yaml",
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid json",
+			linter: Linter{
+				InputFile:   "testdata/invalid.json",
+				InputFormat: "json",
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid input format",
+			linter: Linter{
+				InputFile:   "testdata/invalid.json",
+				InputFormat: "swift",
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid toml",
+			linter: Linter{
+				InputFile:   "testdata/invalid.toml",
+				InputFormat: "toml",
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "no variation",
+			linter: Linter{
+				InputFile:   "testdata/no-variation.yaml",
+				InputFormat: "yaml",
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "no default rule",
+			linter: Linter{
+				InputFile:   "testdata/no-default-rule.yaml",
+				InputFormat: "yaml",
+			},
+			wantErr: assert.Error,
+		},
+		{
+			name: "invalid rule",
+			linter: Linter{
+				InputFile:   "testdata/invalid-rule.yaml",
+				InputFormat: "yaml",
+			},
+			wantErr: assert.Error,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := tt.linter.Lint()
+			for _, err := range errs {
+				tt.wantErr(t, err, fmt.Sprintf("Lint(): %s", err))
+			}
+		})
+	}
+}

--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/jessevdk/go-flags"
+)
+
+func main() {
+	var opts struct {
+		InputFile   string `short:"f" long:"input-file" description:"Location of the flag file you want to lint." required:"true"` //nolint: lll
+		InputFormat string `long:"input-format" description:"Format of your input file (YAML, JSON or TOML)" required:"true"`      //nolint: lll
+	}
+	_, err := flags.Parse(&opts)
+	if flags.WroteHelp(err) {
+		os.Exit(0)
+	}
+	if err != nil {
+		log.Fatal("impossible to parse command line parameters", err)
+	}
+
+	linter := Linter{
+		InputFile:   opts.InputFile,
+		InputFormat: opts.InputFormat,
+	}
+
+	errs := linter.Lint()
+	if len(errs) > 0 {
+		for _, err := range errs {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+		}
+		os.Exit(len(errs))
+	}
+}

--- a/cmd/lint/testdata/invalid-rule.yaml
+++ b/cmd/lint/testdata/invalid-rule.yaml
@@ -1,0 +1,10 @@
+flag:
+  variations:
+    A: false
+    B: true
+  targeting:
+    - percentage:
+        A: 0
+        B: 100
+  defaultRule:
+    variation: A

--- a/cmd/lint/testdata/invalid.json
+++ b/cmd/lint/testdata/invalid.json
@@ -1,0 +1,17 @@
+"test-flag": {
+  "variations": {
+    "true_var": true,
+    "false_var": false
+  },
+  "targeting": [
+    {
+      "query": "key eq \"random-key\"",
+      "percentage": "toto"
+    }
+  ],
+  "defaultRule": {
+    "variation": "false_var"
+  },
+    "trackEvents": false
+  }
+}

--- a/cmd/lint/testdata/invalid.toml
+++ b/cmd/lint/testdata/invalid.toml
@@ -1,0 +1,10 @@
+[test-flag]
+trackEvents = false
+[test-flag.variations]
+true_var = true
+false_var = false
+[[test-flag.targeting]]
+query = 'key eq "random-key"'
+percentage = "toto
+[test-flag.defaultRule]
+variation = "false_var"

--- a/cmd/lint/testdata/invalid.yaml
+++ b/cmd/lint/testdata/invalid.yaml
@@ -1,0 +1,10 @@
+test-flag:
+  variations:
+    true_var: true
+    false_var: false
+  targeting:
+    - query: key eq "random-key"
+      percentage: "toto"
+  defaultRule:
+    variation: false_var
+  trackEvents: false

--- a/cmd/lint/testdata/no-default-rule.yaml
+++ b/cmd/lint/testdata/no-default-rule.yaml
@@ -1,0 +1,9 @@
+flag:
+  variations:
+    A: false
+    B: true
+  targeting:
+    - query: key eq "random-key"
+      percentage:
+        A: 0
+        B: 100

--- a/cmd/lint/testdata/no-variation.yaml
+++ b/cmd/lint/testdata/no-variation.yaml
@@ -1,0 +1,8 @@
+flag:
+  targeting:
+    - query: key eq "random-key"
+      percentage:
+        A: 0
+        B: 100
+  defaultRule:
+    variation: true


### PR DESCRIPTION
# Description

This PR adds a new lint command to verify that flag files can be parsed by GO Feature Flag.

The command will exit with a non-zero code if any errors are detected. Individual errors are printed out to stderr.

It's pretty barebones but does the job well. We could consider adding different output formats like json to enable easier processing of the errors, but that would require a little more design consideration.

It's been a while since I wrote any Go, so don't feel like you have to be nice in the comments 😉

Returning `[]error` from `Lint` doesn't feel idiomatic at all. I've considered bringing a dependency like https://github.com/hashicorp/go-multierror but I'd like to get your opinion first.
We could also create a struct to store errors and return that instead. Something like:

```go
type LintError struct {
	File string
	Err  error
}
```

Do you have a preference on where documentation should be written on the website?

# Changes include

- [x] Adds a new `lint` command

# Closes issue(s)

Resolve #511 

# Checklist
- [X] I have tested this code
- [X] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [X] I have followed the [contributing guide](CONTRIBUTING.md)
