### PR TITLE
Fix 525: ff.RawVariation not working with default value as nil

### DIFF
--- a/variation.go
+++ b/variation.go
@@ -418,15 +418,17 @@ func getVariation[T model.JSONType](
 	case T:
 		v = val
 	default:
-		return model.VariationResult[T]{
-			Value:         sdkDefaultValue,
-			VariationType: flag.VariationSDKDefault,
-			Reason:        flag.ReasonError,
-			ErrorCode:     flag.ErrorCodeTypeMismatch,
-			Failed:        true,
-			TrackEvents:   f.IsTrackEvents(),
-			Version:       f.GetVersion(),
-		}, fmt.Errorf(errorWrongVariation, flagKey)
+		if val != nil {
+			return model.VariationResult[T]{
+				Value:         sdkDefaultValue,
+				VariationType: flag.VariationSDKDefault,
+				Reason:        flag.ReasonError,
+				ErrorCode:     flag.ErrorCodeTypeMismatch,
+				Failed:        true,
+				TrackEvents:   f.IsTrackEvents(),
+				Version:       f.GetVersion(),
+			}, fmt.Errorf(errorWrongVariation, flagKey)
+		}
 	}
 
 	return model.VariationResult[T]{

--- a/variation_test.go
+++ b/variation_test.go
@@ -3710,6 +3710,26 @@ func TestRawVariation(t *testing.T) {
 			wantErr:     false,
 			expectedLog: "",
 		},
+		{
+			name: "should use interface default value if the flag is disabled",
+			args: args{
+				flagKey:      "disable-flag",
+				user:         ffuser.NewUser("random-key"),
+				defaultValue: nil,
+				cacheMock: NewCacheMock(&flag.InternalFlag{
+					Disable: testconvert.Bool(true),
+				}, nil),
+			},
+			want: model.RawVarResult{
+				TrackEvents:   true,
+				VariationType: flag.VariationSDKDefault,
+				Failed:        false,
+				Reason:        flag.ReasonDisabled,
+				Value:         nil,
+			},
+			wantErr:     false,
+			expectedLog: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description
ff.RawVariation not working with default value as nil.
This PR allow to have nil as default value.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #525

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
