### PR TITLE
Add GitHub action documentation (lint)

### DIFF
--- a/website/docs/linter.md
+++ b/website/docs/linter.md
@@ -45,3 +45,18 @@ The command line has 2 arguments you should specify.
 |------------------|-------------------------------------------------------------------------------------------------------------------|
 | `--input-file`   | **(mandatory)** The location of your configuration file.                                                          |
 | `--input-format` | **(mandatory)** The format of your current configuration file. <br/>Available formats are `yaml`, `json`, `toml`. |
+
+## GitHub Actions
+
+You can run `go-feature-flag-lint` using GitHub actions:
+
+```yaml
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker://thomaspoignant/go-feature-flag-lint:latest
+        with:
+          args: --input-file=/github/workspace/path/to/your/config.yaml --input-format=yaml
+```


### PR DESCRIPTION
# Description

Thank you for adding the `lint` documentation! I was waiting to add it to our repository to write it, but you had already done it.

I think it might be useful to show people how to use it in GitHub actions, so here it is.