### PR TITLE
Adds generate-helm-docs to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ swagger: ## Build swagger documentation
 	$(GOCMD) install github.com/swaggo/swag/cmd/swag@latest
 	cd cmd/relayproxy && swag init --parseDependency --parseDepth=1 --parseInternal --markdownFiles docs
 
+generate-helm-docs: ## Generates helm documentation for the project
+	$(GOCMD) install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+	helm-docs
+
 ## Test:
 test: ## Run the tests of the project
 	$(GOTEST) -v -race ./...

--- a/cmd/relayproxy/helm-charts/relay-proxy/Chart.yaml
+++ b/cmd/relayproxy/helm-charts/relay-proxy/Chart.yaml
@@ -1,6 +1,8 @@
 apiVersion: v2
 name: relay-proxy
 home: https://gofeatureflag.org
+sources:
+  - "https://github.com/thomaspoignant/go-feature-flag"
 description: A Helm chart to deploy go-feature-flag-relay proxy into Kubernetes
 type: application
 version: 1.7.0

--- a/cmd/relayproxy/helm-charts/relay-proxy/README.md
+++ b/cmd/relayproxy/helm-charts/relay-proxy/README.md
@@ -1,21 +1,662 @@
-# `relay-proxy` Helm Chart
+# relay-proxy
 
-This folder contains a basic helm-chart to deploy `go-feature-flag-relay-proxy` inside Kubernetes.
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.7.0](https://img.shields.io/badge/AppVersion-v1.7.0-informational?style=flat-square) 
 
-Please [create an issue](https://github.com/thomaspoignant/go-feature-flag/issues/new/choose) or submit a pull request
-for any issues or missing features.
+A Helm chart to deploy go-feature-flag-relay proxy into Kubernetes
 
+## How to use the chart
 
-## How to use the chart.
-Please replace the keys `relayproxy.config` in  the `Values.yaml` to fit your configuration.   
-This file will be stored as `configmap` in your cluster and be mount as a volume for the `relay-proxy`.
+Please replace the keys `relayproxy.config` in  the `Values.yaml` to fit
+your configuration. This file will be stored as `configmap` in your cluster and
+be mount as a volume for the `relay-proxy`.
 
-After in the current folder run:
+After changing the working directory to `cmd/relayproxy/helm-charts/relay-proxy`,
+run the below command:
+
 ```shell
 helm install . --name-template=go-feature-flag-relay-proxy
 ```
 
 It will install the chart in your cluster.
+
+**Homepage:** <https://gofeatureflag.org>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| thomaspoignant | <thomas.poignant@gofeatureflag.org> | <https://gofeatureflag.org> |
+
+
+
+
+
+
+
+
+
+
+## Values
+
+<table>
+	<thead>
+		<th>Key</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</thead>
+	<tbody>
+		<tr>
+			<td id="affinity">
+				<a href="./values.yaml#L122">affinity</a>
+            </td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>
+				Affinity settings for pod assignment to nodes
+			</td>
+		</tr>
+		<tr>
+			<td id="autoscaling">
+				<a href="./values.yaml#L103">autoscaling</a>
+            </td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{
+  "enabled": false,
+  "maxReplicas": 100,
+  "minReplicas": 1,
+  "targetCPUUtilizationPercentage": 80,
+  "targetMemoryUtilizationPercentage": 80
+}
+</pre>
+</div>
+			</td>
+			<td>
+				automatically scale the deployment up and down based on observed CPU and memory utilization
+			</td>
+		</tr>
+		<tr>
+			<td id="autoscaling--enabled">
+				<a href="./values.yaml#L105">autoscaling.enabled</a>
+            </td>
+			<td>
+bool
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>
+				enable autoscaling
+			</td>
+		</tr>
+		<tr>
+			<td id="autoscaling--maxReplicas">
+				<a href="./values.yaml#L109">autoscaling.maxReplicas</a>
+            </td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+100
+</pre>
+</div>
+			</td>
+			<td>
+				max replicas to scale to
+			</td>
+		</tr>
+		<tr>
+			<td id="autoscaling--minReplicas">
+				<a href="./values.yaml#L107">autoscaling.minReplicas</a>
+            </td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1
+</pre>
+</div>
+			</td>
+			<td>
+				min replicas to scale to
+			</td>
+		</tr>
+		<tr>
+			<td id="autoscaling--targetCPUUtilizationPercentage">
+				<a href="./values.yaml#L111">autoscaling.targetCPUUtilizationPercentage</a>
+            </td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+80
+</pre>
+</div>
+			</td>
+			<td>
+				target CPU utilization percentage to spin up new pods
+			</td>
+		</tr>
+		<tr>
+			<td id="autoscaling--targetMemoryUtilizationPercentage">
+				<a href="./values.yaml#L113">autoscaling.targetMemoryUtilizationPercentage</a>
+            </td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+80
+</pre>
+</div>
+			</td>
+			<td>
+				target memory utilization percentage to spin up new pods
+			</td>
+		</tr>
+		<tr>
+			<td id="env">
+				<a href="./values.yaml#L15">env</a>
+            </td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>
+				Environment variables to pass to the relay proxy
+			</td>
+		</tr>
+		<tr>
+			<td id="fullnameOverride">
+				<a href="./values.yaml#L42">fullnameOverride</a>
+            </td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>
+				Completely override the deployment name for kubernetes objects
+			</td>
+		</tr>
+		<tr>
+			<td id="image--pullPolicy">
+				<a href="./values.yaml#L33">image.pullPolicy</a>
+            </td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"IfNotPresent"
+</pre>
+</div>
+			</td>
+			<td>
+				The image is pulled only if it is not already present locally
+			</td>
+		</tr>
+		<tr>
+			<td id="image--repository">
+				<a href="./values.yaml#L31">image.repository</a>
+            </td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"thomaspoignant/go-feature-flag-relay-proxy"
+</pre>
+</div>
+			</td>
+			<td>
+				The image repository to pull from
+			</td>
+		</tr>
+		<tr>
+			<td id="image--tag">
+				<a href="./values.yaml#L35">image.tag</a>
+            </td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>
+				Overrides the image tag whose default is the chart appVersion
+			</td>
+		</tr>
+		<tr>
+			<td id="imagePullSecrets">
+				<a href="./values.yaml#L38">imagePullSecrets</a>
+            </td>
+			<td>
+list
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>
+				Specify imagePullSecrets to be used for the deployment
+			</td>
+		</tr>
+		<tr>
+			<td id="ingress">
+				<a href="./values.yaml#L76">ingress</a>
+            </td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{
+  "annotations": {},
+  "className": "",
+  "enabled": false,
+  "hosts": [
+    {
+      "host": "chart-example.local",
+      "paths": [
+        {
+          "path": "/",
+          "pathType": "ImplementationSpecific"
+        }
+      ]
+    }
+  ],
+  "tls": []
+}
+</pre>
+</div>
+			</td>
+			<td>
+				Ingress configuration
+			</td>
+		</tr>
+		<tr>
+			<td id="ingress--annotations">
+				<a href="./values.yaml#L82">ingress.annotations</a>
+            </td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>
+				Annotations to add to the ingress
+			</td>
+		</tr>
+		<tr>
+			<td id="ingress--className">
+				<a href="./values.yaml#L80">ingress.className</a>
+            </td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>
+				Ingress class name
+			</td>
+		</tr>
+		<tr>
+			<td id="ingress--enabled">
+				<a href="./values.yaml#L78">ingress.enabled</a>
+            </td>
+			<td>
+bool
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+false
+</pre>
+</div>
+			</td>
+			<td>
+				Enable ingress
+			</td>
+		</tr>
+		<tr>
+			<td id="nameOverride">
+				<a href="./values.yaml#L40">nameOverride</a>
+            </td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>
+				replaces the name of the chart in the Chart.yaml file
+			</td>
+		</tr>
+		<tr>
+			<td id="nodeSelector">
+				<a href="./values.yaml#L116">nodeSelector</a>
+            </td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>
+				Node labels for pod assignment
+			</td>
+		</tr>
+		<tr>
+			<td id="podAnnotations">
+				<a href="./values.yaml#L54">podAnnotations</a>
+            </td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>
+				Pod annotations to add to the deployment
+			</td>
+		</tr>
+		<tr>
+			<td id="podSecurityContext">
+				<a href="./values.yaml#L57">podSecurityContext</a>
+            </td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>
+				A security context defines privilege and access control settings for a Pod
+			</td>
+		</tr>
+		<tr>
+			<td id="relayproxy--config">
+				<a href="./values.yaml#L4">relayproxy.config</a>
+            </td>
+			<td>
+tpl/object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="tpl">
+relayproxy.config: |
+  listen: 1031
+  pollingInterval: 1000
+  startWithRetrieverError: false
+  retriever:
+    kind: http
+    url: https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/examples/retriever_file/flags.yaml
+  exporter:
+    kind: log
+  
+</pre>
+</div>
+			</td>
+			<td>
+				Define this for extra Django environment variables
+			</td>
+		</tr>
+		<tr>
+			<td id="replicaCount">
+				<a href="./values.yaml#L27">replicaCount</a>
+            </td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1
+</pre>
+</div>
+			</td>
+			<td>
+				The number of replicas to create for the deployment
+			</td>
+		</tr>
+		<tr>
+			<td id="resources--requests--cpu">
+				<a href="./values.yaml#L100">resources.requests.cpu</a>
+            </td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"500m"
+</pre>
+</div>
+			</td>
+			<td>
+				The amount of cpu to request for the container
+			</td>
+		</tr>
+		<tr>
+			<td id="resources--requests--memory">
+				<a href="./values.yaml#L98">resources.requests.memory</a>
+            </td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"128Mi"
+</pre>
+</div>
+			</td>
+			<td>
+				The amount of memory to request for the container
+			</td>
+		</tr>
+		<tr>
+			<td id="securityContext">
+				<a href="./values.yaml#L61">securityContext</a>
+            </td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>
+				A security context defines privilege and access control settings for a Container
+			</td>
+		</tr>
+		<tr>
+			<td id="service--port">
+				<a href="./values.yaml#L73">service.port</a>
+            </td>
+			<td>
+int
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+1031
+</pre>
+</div>
+			</td>
+			<td>
+				The port to expose on the service
+			</td>
+		</tr>
+		<tr>
+			<td id="service--type">
+				<a href="./values.yaml#L71">service.type</a>
+            </td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+"ClusterIP"
+</pre>
+</div>
+			</td>
+			<td>
+				The type of service to create
+			</td>
+		</tr>
+		<tr>
+			<td id="serviceAccount--annotations">
+				<a href="./values.yaml#L48">serviceAccount.annotations</a>
+            </td>
+			<td>
+object
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+{}
+</pre>
+</div>
+			</td>
+			<td>
+				Annotations to add to the service account
+			</td>
+		</tr>
+		<tr>
+			<td id="serviceAccount--create">
+				<a href="./values.yaml#L46">serviceAccount.create</a>
+            </td>
+			<td>
+bool
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+true
+</pre>
+</div>
+			</td>
+			<td>
+				Specifies whether a service account should be created
+			</td>
+		</tr>
+		<tr>
+			<td id="serviceAccount--name">
+				<a href="./values.yaml#L51">serviceAccount.name</a>
+            </td>
+			<td>
+string
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+""
+</pre>
+</div>
+			</td>
+			<td>
+				The name of the service account to use. If not set and create is true, a name is generated using the fullname template
+			</td>
+		</tr>
+		<tr>
+			<td id="tolerations">
+				<a href="./values.yaml#L119">tolerations</a>
+            </td>
+			<td>
+list
+</td>
+			<td>
+				<div style="max-width: 300px;">
+<pre lang="json">
+[]
+</pre>
+</div>
+			</td>
+			<td>
+				Tolerations for pod assignment
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+
 
 ## Advanced
 You can edit the `values.yaml` file to enable an ingress or the autoscaling.

--- a/cmd/relayproxy/helm-charts/relay-proxy/README.md.gotmpl
+++ b/cmd/relayproxy/helm-charts/relay-proxy/README.md.gotmpl
@@ -1,0 +1,92 @@
+{{ template "chart.header" . }}
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+## How to use the chart
+
+Please replace the keys `relayproxy.config` in  the `Values.yaml` to fit
+your configuration. This file will be stored as `configmap` in your cluster and
+be mount as a volume for the `relay-proxy`.
+
+After changing the working directory to `cmd/relayproxy/helm-charts/relay-proxy`,
+run the below command:
+
+```shell
+helm install . --name-template=go-feature-flag-relay-proxy
+```
+
+It will install the chart in your cluster.
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ define "chart.valueDefaultColumnRender" }}
+{{- $defaultValue := (default .Default .AutoDefault)  -}}
+{{- $notationType := .NotationType }}
+{{- if (and (hasPrefix "`" $defaultValue) (hasSuffix "`" $defaultValue) ) -}}
+{{- $defaultValue = (toPrettyJson (fromJson (trimAll "`" (default .Default .AutoDefault) ) ) ) -}}
+{{- $notationType = "json" }}
+{{- end -}}
+{{- if (eq $notationType "tpl" ) }}
+<pre lang="{{ $notationType }}">
+{{ .Key }}: |
+{{- $defaultValue | nindent 2 }}
+</pre>
+{{- else if (eq $notationType "email") }}
+<a href="mailto:{{ $defaultValue }}" style="color: green;">"{{ $defaultValue }}"</a>
+{{- else }}
+<pre lang="{{ $notationType }}">
+{{ $defaultValue }}
+</pre>
+{{- end }}
+{{ end }}
+
+{{ define "chart.typeColumnRender" }}
+{{- if (eq .Type "string/email") }}
+<a href="#stringemail" title="{{- template "chart.valuetypes.email" -}}">{{.Type}}</a>
+{{- else if (eq .Type "k8s/storage/persistent-volume/access-modes" )}}
+<a target="_blank" 
+   href="https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes"
+   >{{- .Type }}</a>
+{{- else }}
+{{ .Type }}
+{{- end }}
+{{ end }}
+
+{{ define "chart.valuesTableHtml" }}
+<table>
+	<thead>
+		<th>Key</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</thead>
+	<tbody>
+	{{- range .Values }}
+		<tr>
+			<td id="{{ .Key | replace "." "--" }}">
+				<a href="./values.yaml#L{{ .LineNumber }}">{{ .Key }}</a>
+            </td>
+			<td>
+				{{- template "chart.typeColumnRender" . -}}
+            </td>
+			<td>
+				<div style="max-width: 300px;">{{ template "chart.valueDefaultColumnRender" . }}</div>
+			</td>
+			<td>
+				{{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }}
+			</td>
+		</tr>
+	{{- end }}
+	</tbody>
+</table>
+{{ end }}
+
+{{ template "chart.valuesSectionHtml" . }}
+
+## Advanced
+You can edit the `values.yaml` file to enable an ingress or the autoscaling.

--- a/cmd/relayproxy/helm-charts/relay-proxy/values.yaml
+++ b/cmd/relayproxy/helm-charts/relay-proxy/values.yaml
@@ -1,4 +1,6 @@
 relayproxy:
+  # -- (tpl/object) Define this for extra Django environment variables
+  # @notationType -- tpl
   config: | # This is a configuration example for the relay-proxy
     listen: 1031
     pollingInterval: 1000
@@ -9,7 +11,7 @@ relayproxy:
     exporter:
       kind: log
 
-# Environment variables to pass to the relay proxy
+# -- Environment variables to pass to the relay proxy
 env: {}
   # Examples:
   # ENV_VARIABLE_EXAMPLE:
@@ -21,32 +23,41 @@ env: {}
   #       name: my-secret-name
   #       key: my-secret-key
 
+# -- The number of replicas to create for the deployment
 replicaCount: 1
 
 image:
+  # -- The image repository to pull from
   repository: thomaspoignant/go-feature-flag-relay-proxy
+  # -- The image is pulled only if it is not already present locally
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # -- Overrides the image tag whose default is the chart appVersion
   tag: ""
 
+# -- Specify imagePullSecrets to be used for the deployment
 imagePullSecrets: []
+# -- replaces the name of the chart in the Chart.yaml file
 nameOverride: ""
+# -- Completely override the deployment name for kubernetes objects
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
+  # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- Pod annotations to add to the deployment
 podAnnotations: {}
 
+# -- A security context defines privilege and access control settings for a Pod
 podSecurityContext: {}
   # fsGroup: 2000
 
+# -- A security context defines privilege and access control settings for a Container
 securityContext: {}
   # capabilities:
   #   drop:
@@ -56,12 +67,18 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
+  # -- The type of service to create
   type: ClusterIP
+  # -- The port to expose on the service
   port: 1031
 
+# -- Ingress configuration
 ingress:
+  # -- Enable ingress
   enabled: false
+  # -- Ingress class name
   className: ""
+  # -- Annotations to add to the ingress
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -77,18 +94,29 @@ ingress:
 
 resources:
   requests:
+    # -- The amount of memory to request for the container
     memory: "128Mi"
+    # -- The amount of cpu to request for the container
     cpu: "500m"
 
+# -- automatically scale the deployment up and down based on observed CPU and memory utilization
 autoscaling:
+  # -- enable autoscaling
   enabled: false
+  # -- min replicas to scale to
   minReplicas: 1
+  # -- max replicas to scale to
   maxReplicas: 100
+  # -- target CPU utilization percentage to spin up new pods
   targetCPUUtilizationPercentage: 80
+  # -- target memory utilization percentage to spin up new pods
   targetMemoryUtilizationPercentage: 80
 
+# -- Node labels for pod assignment
 nodeSelector: {}
 
+# -- Tolerations for pod assignment
 tolerations: []
 
+# -- Affinity settings for pod assignment to nodes
 affinity: {}


### PR DESCRIPTION
Why: to generate helm docs based on values.yaml file

How:
 - using helm-docs[1] binary
 - adding readme.go.tmpl as a template to generate docs

Tags: #helm-docs #makefile #readme #issue-664

# Description
A new command has been added as a part of Makefile to generate the helm documentation.

# Changes include
- [x] New feature (non-breaking change that adds functionality)

# Closes issue(s)
Resolve #664 

# Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)

[1] https://github.com/norwoodj/helm-docs