### PR TITLE
Fix rule with environment

### DIFF
--- a/ffuser/user.go
+++ b/ffuser/user.go
@@ -39,3 +39,9 @@ func (u *User) IsAnonymous() bool {
 func (u *User) GetCustom() map[string]interface{} {
 	return u.custom
 }
+
+func (u *User) AddCustomAttribute(name string, value interface{}) {
+	if name != "" {
+		u.custom[name] = value
+	}
+}

--- a/internal/flag/internal_flag.go
+++ b/internal/flag/internal_flag.go
@@ -60,6 +60,10 @@ func (f *InternalFlag) Value(
 ) (interface{}, ResolutionDetails) {
 	f.applyScheduledRolloutSteps()
 
+	if evaluationCtx.Environment != "" {
+		user.AddCustomAttribute("env", evaluationCtx.Environment)
+	}
+
 	if f.IsDisable() || f.isExperimentationOver() {
 		return evaluationCtx.DefaultSdkValue, ResolutionDetails{
 			Variant:   VariationSDKDefault,


### PR DESCRIPTION
# Description
During the migration to version `v1.0.0` we broke the system that was allowing to have different rules per environment.
This PR fix the problem.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Closes issue(s)
Resolve #697

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
