### PR TITLE
fix: Add missing default extension for configuration

### DIFF
--- a/cmd/relayproxy/config/config.go
+++ b/cmd/relayproxy/config/config.go
@@ -242,6 +242,7 @@ func locateConfigFile(inputFilePath string) (string, error) {
 		"yaml",
 		"toml",
 		"json",
+		"yml",
 	}
 
 	if inputFilePath != "" {


### PR DESCRIPTION
# Description
Add missing default extension for configuration
# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
