### PR TITLE
Using GH token to trigger CI

### DIFF
--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -64,6 +64,7 @@ jobs:
           branch: update-relay-proxy-chart-readme-${{ env.GIT_TAG_NAME }}
           title: Update relay proxy helm README ${{ env.GIT_TAG_NAME }}
           body: Automated pull request to update relay-proxy helm chart README ${{ env.GIT_TAG_NAME }}
+          commit-message: Update relay proxy helm README ${{ env.GIT_TAG_NAME }}
           labels: automerge
           assignees: thomaspoignant
           reviewers: thomaspoignant
@@ -71,3 +72,4 @@ jobs:
           signoff: true
           delete-branch: true
           path: ${{ env.MAIN_BRANCH_NAME }}
+          token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,7 @@ jobs:
           branch: create-new-doc-version-${{ env.GIT_TAG_NAME }}
           title: Create a new documentation version ${{ env.GIT_TAG_NAME }}
           body: Automated pull request to create a new documentation version ${{ env.GIT_TAG_NAME }}
+          commit-message: Create a new documentation version ${{ env.GIT_TAG_NAME }}
           labels: automerge
           assignees: thomaspoignant
           reviewers: thomaspoignant
@@ -180,6 +181,7 @@ jobs:
           signoff: true
           delete-branch: true
           path: ${{ env.MAIN_BRANCH_NAME }}
+          token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
 
   bump-relay-proxy-helm-chart:
     # bump-relay-proxy-helm-chart is opening a pull request to bump the appVersion field
@@ -232,6 +234,7 @@ jobs:
           branch: bump-relay-proxy-helm-chart-${{ env.GIT_TAG_NAME }}
           title: Bump relay-proxy helm chart version ${{ env.GIT_TAG_NAME }}
           body: Automated pull request to bump relay-proxy helm chart version ${{ env.GIT_TAG_NAME }}
+          commit-message: Bump relay-proxy helm chart version ${{ env.GIT_TAG_NAME }}
           labels: automerge
           assignees: thomaspoignant
           reviewers: thomaspoignant
@@ -239,6 +242,7 @@ jobs:
           signoff: true
           delete-branch: true
           path: ${{ env.MAIN_BRANCH_NAME }}
+          token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
 
   homebrew:
     name: Bump homebrew-core formula


### PR DESCRIPTION
# Description
Since we are not using any GH Token to open the PR, the CI is not triggering.
This add a new param to use the GH Token while opening the PRs.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Checklist
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
