### PR TITLE
Change endpoint input to be compatible with the webhook exporter

### DIFF
--- a/cmd/relayproxy/controller/collect_eval_data.go
+++ b/cmd/relayproxy/controller/collect_eval_data.go
@@ -42,19 +42,19 @@ func (h *collectEvalData) Handler(c echo.Context) error {
 			http.StatusBadRequest,
 			fmt.Sprintf("collectEvalData: invalid input data %v", err))
 	}
-	if reqBody == nil || reqBody.Data == nil {
+	if reqBody == nil || reqBody.Events == nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "collectEvalData: invalid input data")
 	}
 
-	for _, event := range reqBody.Data {
+	for _, event := range reqBody.Events {
 		h.goFF.CollectEventData(event)
 	}
 
 	// send metric
 	metrics := c.Get(metric.CustomMetrics).(*metric.Metrics)
-	metrics.IncCollectEvalData(float64(len(reqBody.Data)))
+	metrics.IncCollectEvalData(float64(len(reqBody.Events)))
 
 	return c.JSON(http.StatusOK, model.CollectEvalDataResponse{
-		IngestedContentCount: len(reqBody.Data),
+		IngestedContentCount: len(reqBody.Events),
 	})
 }

--- a/cmd/relayproxy/controller/collect_eval_data_test.go
+++ b/cmd/relayproxy/controller/collect_eval_data_test.go
@@ -57,7 +57,7 @@ func Test_collect_eval_data_Handler(t *testing.T) {
 			want: want{
 				handlerErr: true,
 				httpCode:   http.StatusBadRequest,
-				errorMsg: "collectEvalData: invalid input data code=400, message=Syntax error: offset=320, " +
+				errorMsg: "collectEvalData: invalid input data code=400, message=Syntax error: offset=322, " +
 					"error=invalid character '}' after array element, internal=invalid character '}' after array " +
 					"element",
 				errorCode: http.StatusBadRequest,

--- a/cmd/relayproxy/model/collect_eval_data_request.go
+++ b/cmd/relayproxy/model/collect_eval_data_request.go
@@ -6,6 +6,9 @@ import (
 
 // CollectEvalDataRequest is the request to collect data in
 type CollectEvalDataRequest struct {
-	// Data contains the list of feature event that we want to store
-	Data []exporter.FeatureEvent `json:"data"`
+	// Meta are the extra information added during the configuration
+	Meta map[string]string `json:"meta"`
+
+	// events is the list of the event we send in the payload
+	Events []exporter.FeatureEvent `json:"events"`
 }

--- a/cmd/relayproxy/testdata/controller/collect_eval_data/invalid_request.json
+++ b/cmd/relayproxy/testdata/controller/collect_eval_data/invalid_request.json
@@ -1,5 +1,5 @@
 {
-  "data": [
+  "events": [
     {
       "contextKind": "user",
       "creationDate": 1680246000011,

--- a/cmd/relayproxy/testdata/controller/collect_eval_data/invalid_request_data_null.json
+++ b/cmd/relayproxy/testdata/controller/collect_eval_data/invalid_request_data_null.json
@@ -1,3 +1,3 @@
 {
-  "data": null
+  "events": null
 }

--- a/cmd/relayproxy/testdata/controller/collect_eval_data/valid_request.json
+++ b/cmd/relayproxy/testdata/controller/collect_eval_data/valid_request.json
@@ -1,5 +1,5 @@
 {
-  "data": [
+  "events": [
     {
       "contextKind": "user",
       "creationDate": 1680246000011,


### PR DESCRIPTION
# Description
This PR change endpoint input to be compatible with the webhook exporter.

⚠️ This is a breaking change, but since this is a recent addition and it is not documented yet, we accept to have a braking change for this endpoint.

# Changes include
- [x] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
