### PR TITLE
fix: CSV export format is broken

### DIFF
--- a/cmd/relayproxy/config/config.go
+++ b/cmd/relayproxy/config/config.go
@@ -44,8 +44,8 @@ var DefaultExporter = struct {
 	Format:    "JSON",
 	LogFormat: "[{{ .FormattedDate}}] user=\"{{ .UserKey}}\", flag=\"{{ .Key}}\", value=\"{{ .Value}}\"",
 	FileName:  "flag-variation-{{ .Hostname}}-{{ .Timestamp}}.{{ .Format}}",
-	CsvFormat: "{ .Kind}};{{ .ContextKind}};{{ .UserKey}};{{ .CreationDate}};{{ .Key}};{{ .Variation}};" +
-		"{{ .Value}};{{ .Default}}\\n",
+	CsvFormat: "{{ .Kind}};{{ .ContextKind}};{{ .UserKey}};{{ .CreationDate}};{{ .Key}};{{ .Variation}};" +
+		"{{ .Value}};{{ .Default}}\n",
 	FlushInterval:           60000 * time.Millisecond,
 	MaxEventInMemory:        100000,
 	ParquetCompressionCodec: parquet.CompressionCodec_SNAPPY.String(),

--- a/exporter/data_exporter_test.go
+++ b/exporter/data_exporter_test.go
@@ -97,7 +97,7 @@ func TestDataExporterScheduler_exporterReturnError(t *testing.T) {
 
 	// read log
 	logs, _ := os.ReadFile(file.Name())
-	assert.Regexp(t, "\\["+testutils.RFC3339Regex+"\\] error while exporting data: random err\\n", string(logs))
+	assert.Regexp(t, "\\["+testutils.RFC3339Regex+"\\] error while exporting data: random err\n", string(logs))
 }
 
 func TestDataExporterScheduler_nonBulkExporter(t *testing.T) {

--- a/website/docs/openfeature_sdk/openfeature_go.mdx
+++ b/website/docs/openfeature_sdk/openfeature_go.mdx
@@ -10,6 +10,7 @@ description: How to use the OpenFeature GO SDK
 The first things we will do is install the **Open Feature SDK** and the **GO Feature Flag provider**.
 
 ```shell
+go get github.com/open-feature/go-sdk
 go get github.com/open-feature/go-sdk-contrib/providers/go-feature-flag
 ```
 


### PR DESCRIPTION
# Description
The go template configuration for the exporter is broken.
This PR fix the format.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
