### PR TITLE
Deprecate GithubToken field in favor of token

### DIFF
--- a/cmd/relayproxy/config/retriever.go
+++ b/cmd/relayproxy/config/retriever.go
@@ -4,24 +4,25 @@ import "fmt"
 
 // RetrieverConf contains all the field to configure a retriever
 type RetrieverConf struct {
-	Kind           RetrieverKind       `mapstructure:"kind" koanf:"kind"`
-	RepositorySlug string              `mapstructure:"repositorySlug" koanf:"repositoryslug"`
-	Branch         string              `mapstructure:"branch" koanf:"branch"`
-	Path           string              `mapstructure:"path" koanf:"path"`
-	GithubToken    string              `mapstructure:"githubToken" koanf:"githubtoken"`
-	URL            string              `mapstructure:"url" koanf:"url"`
-	Timeout        int64               `mapstructure:"timeout" koanf:"timeout"`
-	HTTPMethod     string              `mapstructure:"method" koanf:"method"`
-	HTTPBody       string              `mapstructure:"body" koanf:"body"`
-	HTTPHeaders    map[string][]string `mapstructure:"headers" koanf:"headers"`
-	Bucket         string              `mapstructure:"bucket" koanf:"bucket"`
-	Object         string              `mapstructure:"bucket" koanf:"bucket"`
-	Item           string              `mapstructure:"item" koanf:"item"`
-	Namespace      string              `mapstructure:"namespace" koanf:"namespace"`
-	ConfigMap      string              `mapstructure:"configmap" koanf:"configmap"`
-	Key            string              `mapstructure:"key" koanf:"key"`
-	BaseURL        string              `mapstructure:"baseUrl" koanf:"baseurl"`
-	AuthToken      string              `mapstructure:"token" koanf:"token"`
+	Kind           RetrieverKind `mapstructure:"kind" koanf:"kind"`
+	RepositorySlug string        `mapstructure:"repositorySlug" koanf:"repositoryslug"`
+	Branch         string        `mapstructure:"branch" koanf:"branch"`
+	Path           string        `mapstructure:"path" koanf:"path"`
+	// Deprecated: Please use AuthToken instead
+	GithubToken string              `mapstructure:"githubToken" koanf:"githubtoken"`
+	URL         string              `mapstructure:"url" koanf:"url"`
+	Timeout     int64               `mapstructure:"timeout" koanf:"timeout"`
+	HTTPMethod  string              `mapstructure:"method" koanf:"method"`
+	HTTPBody    string              `mapstructure:"body" koanf:"body"`
+	HTTPHeaders map[string][]string `mapstructure:"headers" koanf:"headers"`
+	Bucket      string              `mapstructure:"bucket" koanf:"bucket"`
+	Object      string              `mapstructure:"bucket" koanf:"bucket"`
+	Item        string              `mapstructure:"item" koanf:"item"`
+	Namespace   string              `mapstructure:"namespace" koanf:"namespace"`
+	ConfigMap   string              `mapstructure:"configmap" koanf:"configmap"`
+	Key         string              `mapstructure:"key" koanf:"key"`
+	BaseURL     string              `mapstructure:"baseUrl" koanf:"baseurl"`
+	AuthToken   string              `mapstructure:"token" koanf:"token"`
 }
 
 // IsValid validate the configuration of the retriever

--- a/cmd/relayproxy/service/gofeatureflag.go
+++ b/cmd/relayproxy/service/gofeatureflag.go
@@ -91,8 +91,8 @@ func initRetriever(c *config.RetrieverConf) (retriever.Retriever, error) {
 	switch c.Kind {
 	case config.GitHubRetriever:
 		token := c.AuthToken
-		if token == "" && c.GithubToken != "" {
-			token = c.GithubToken
+		if token == "" && c.GithubToken != "" { // nolint: staticcheck
+			token = c.GithubToken // nolint: staticcheck
 		}
 		return &githubretriever.Retriever{
 			RepositorySlug: c.RepositorySlug,

--- a/cmd/relayproxy/service/gofeatureflag.go
+++ b/cmd/relayproxy/service/gofeatureflag.go
@@ -90,6 +90,10 @@ func initRetriever(c *config.RetrieverConf) (retriever.Retriever, error) {
 	// Conversions
 	switch c.Kind {
 	case config.GitHubRetriever:
+		token := c.AuthToken
+		if token == "" && c.GithubToken != "" {
+			token = c.GithubToken
+		}
 		return &githubretriever.Retriever{
 			RepositorySlug: c.RepositorySlug,
 			Branch: func() string {
@@ -99,7 +103,7 @@ func initRetriever(c *config.RetrieverConf) (retriever.Retriever, error) {
 				return c.Branch
 			}(),
 			FilePath:    c.Path,
-			GithubToken: c.GithubToken,
+			GithubToken: token,
 			Timeout:     retrieverTimeout,
 		}, nil
 	case config.GitlabRetriever:

--- a/cmd/relayproxy/service/gofeatureflag_test.go
+++ b/cmd/relayproxy/service/gofeatureflag_test.go
@@ -48,6 +48,42 @@ func Test_initRetriever(t *testing.T) {
 			},
 		},
 		{
+			name:    "Convert Github Retriever with token",
+			wantErr: assert.NoError,
+			conf: &config.RetrieverConf{
+				Kind:           "github",
+				RepositorySlug: "thomaspoignant/go-feature-flag",
+				Path:           "testdata/flag-config.yaml",
+				Timeout:        20,
+				AuthToken:      "xxx",
+			},
+			want: &githubretriever.Retriever{
+				RepositorySlug: "thomaspoignant/go-feature-flag",
+				Branch:         "main",
+				FilePath:       "testdata/flag-config.yaml",
+				GithubToken:    "xxx",
+				Timeout:        20 * time.Millisecond,
+			},
+		},
+		{
+			name:    "Convert Github Retriever with deprecated token",
+			wantErr: assert.NoError,
+			conf: &config.RetrieverConf{
+				Kind:           "github",
+				RepositorySlug: "thomaspoignant/go-feature-flag",
+				Path:           "testdata/flag-config.yaml",
+				Timeout:        20,
+				GithubToken:    "xxx",
+			},
+			want: &githubretriever.Retriever{
+				RepositorySlug: "thomaspoignant/go-feature-flag",
+				Branch:         "main",
+				FilePath:       "testdata/flag-config.yaml",
+				GithubToken:    "xxx",
+				Timeout:        20 * time.Millisecond,
+			},
+		},
+		{
 			name:    "Convert Gitlab Retriever",
 			wantErr: assert.NoError,
 			conf: &config.RetrieverConf{

--- a/website/docs/relay_proxy/configure_relay_proxy.md
+++ b/website/docs/relay_proxy/configure_relay_proxy.md
@@ -52,14 +52,14 @@ In this section we will present all the available retriever configuration availa
 
 ### GitHub
 
-| Field name       | Type   | Default  | Description                                                                                                                                                                                                                           |
-|------------------|--------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `kind`           | string | **none** | **(mandatory)** Value should be **`github`**.<br/>_This field is mandatory and describe which retriever you are using._                                                                                                                |
-| `repositorySlug` | string | **none** | **(mandatory)** The repository slug of the GitHub repository where your file is located _(ex: `thomaspoignant/go-feature-flag`)_.                                                                                                     |
-| `path`           | string | **none** | **(mandatory)** Path to the file inside the repository _(ex: `config/flag/my-flags.yaml`)_.                                                                                                                                           |
-| `branch`         | string | `main`   | The branch we should check in the repository.                                                                                                                                                                                         |
-| `githubToken`    | string | **none** | Github token is used to access a private repository, you need the repo permission ([how to create a GitHub token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)). |
-| `timeout`        | string | `10000`  | Timeout in millisecond used when calling GitHub.                                                                                                                                                                                      |
+| Field name       | Type   | Default  | Description                                                                                                                                                                                                                          |
+|------------------|--------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `kind`           | string | **none** | **(mandatory)** Value should be **`github`**.<br/>_This field is mandatory and describe which retriever you are using._                                                                                                               |
+| `repositorySlug` | string | **none** | **(mandatory)** The repository slug of the GitHub repository where your file is located _(ex: `thomaspoignant/go-feature-flag`)_.                                                                                                    |
+| `path`           | string | **none** | **(mandatory)** Path to the file inside the repository _(ex: `config/flag/my-flags.yaml`)_.                                                                                                                                          |
+| `branch`         | string | `main`   | The branch we should check in the repository.                                                                                                                                                                                        |
+| `token`          | string | **none** | Github token used to access a private repository, you need the repo permission ([how to create a GitHub token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)). |
+| `timeout`        | string | `10000`  | Timeout in millisecond used when calling GitHub.                                                                                                                                                                                     |
 
 ### GitLab
 


### PR DESCRIPTION
# Description
Deprecate the field `GithubToken` in the relay proxy configuration to use a more generic field called `token`.


# Changes include
- [x] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)
Resolve #752 

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
