### PR TITLE
Release relay proxy under 2 names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,28 @@ jobs:
           username: ${DOCKER_USERNAME}
           password: ${DOCKER_PASSWORD}
           repository: thomaspoignant/go-feature-flag-relay-proxy
+          readme: "./cmd/relayproxy/DOCKERHUB_deprecated.md"
+
+  dockerhub-go-feature-flag-server:
+    runs-on: ubuntu-latest
+    name: Upload dockerhub readme
+    needs:
+      - goreleaser
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Release readme to DockerHub
+        uses: ms-jpq/sync-dockerhub-readme@v1
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        with:
+          username: ${DOCKER_USERNAME}
+          password: ${DOCKER_PASSWORD}
+          repository: thomaspoignant/go-feature-flag
           readme: "./cmd/relayproxy/DOCKERHUB.md"
 
   doc-release:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,9 +30,35 @@ builds:
         goarch: arm
         goarm: 6
 
+  # DEPRECATED: check go-feature-flag
+  # We aim to deprecate the name relay proxy, so the main build should be called go-feature-flag
   - id: go-feature-flag-relay-proxy
     main: ./cmd/relayproxy
     binary: go-feature-flag-relay-proxy
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - 386
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - 6
+      - 7
+    ignore:
+      - goos: darwin
+        goarch: 386
+      - goos: linux
+        goarch: arm
+        goarm: 6
+
+  - id: go-feature-flag
+    main: ./cmd/relayproxy
+    binary: go-feature-flag
     env:
       - CGO_ENABLED=0
     goos:
@@ -91,6 +117,8 @@ archives:
       {{- if not (eq .Amd64 \"v1\") }}{{ .Amd64 }}{{ end }}"
     builds:
       - go-feature-flag-migration-cli
+
+  # DEPRECATED: check go-feature-flag
   - id: go-feature-flag-relay-proxy
     name_template: "go-feature-flag-relay-proxy_\
       {{ .Version }}_\
@@ -103,6 +131,19 @@ archives:
       {{- if not (eq .Amd64 \"v1\") }}{{ .Amd64 }}{{ end }}"
     builds:
       - go-feature-flag-relay-proxy
+
+  - id: go-feature-flag
+    name_template: "go-feature-flag_\
+      {{ .Version }}_\
+      {{- title .Os }}_\
+      {{- if eq .Arch \"amd64\" }}x86_64\
+      {{- else if eq .Arch \"386\" }}i386\
+      {{- else }}{{ .Arch }}{{ end }}\
+      {{- with .Arm }}v{{ . }}{{ end }}\
+      {{- with .Mips }}_{{ . }}{{ end }}\
+      {{- if not (eq .Amd64 \"v1\") }}{{ .Amd64 }}{{ end }}"
+    builds:
+      - go-feature-flag
   - id: go-feature-flag-lint
     name_template: "go-feature-flag-lint_\
       {{ .Version }}_\
@@ -131,13 +172,13 @@ changelog:
       - 'vendor'
 
 dockers:
-# relay-proxy
+# DEPRECATED: check go-feature-flag
   - use: buildx
     goos: linux
     goarch: amd64
     ids:
       - go-feature-flag-relay-proxy
-    dockerfile: ./cmd/relayproxy/DockerfileGoreleaser
+    dockerfile: ./cmd/relayproxy/DockerfileGoreleaserRelayProxy
     image_templates:
       - thomaspoignant/go-feature-flag-relay-proxy:v{{ .RawVersion }}-amd64
     build_flag_templates:
@@ -147,7 +188,7 @@ dockers:
     goarch: arm64
     ids:
       - go-feature-flag-relay-proxy
-    dockerfile: ./cmd/relayproxy/DockerfileGoreleaser
+    dockerfile: ./cmd/relayproxy/DockerfileGoreleaserRelayProxy
     image_templates:
       - thomaspoignant/go-feature-flag-relay-proxy:v{{ .RawVersion }}-arm64v8
     build_flag_templates:
@@ -158,9 +199,42 @@ dockers:
     goarm: 7
     ids:
       - go-feature-flag-relay-proxy
-    dockerfile: ./cmd/relayproxy/DockerfileGoreleaser
+    dockerfile: ./cmd/relayproxy/DockerfileGoreleaserRelayProxy
     image_templates:
       - thomaspoignant/go-feature-flag-relay-proxy:v{{ .RawVersion }}-armv7
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+
+# go-feature-flag
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    ids:
+      - go-feature-flag
+    dockerfile: ./cmd/relayproxy/DockerfileGoreleaser
+    image_templates:
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-amd64
+    build_flag_templates:
+      - "--platform=linux/amd64"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    ids:
+      - go-feature-flag
+    dockerfile: ./cmd/relayproxy/DockerfileGoreleaser
+    image_templates:
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-arm64v8
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+    ids:
+      - go-feature-flag
+    dockerfile: ./cmd/relayproxy/DockerfileGoreleaser
+    image_templates:
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-armv7
     build_flag_templates:
       - "--platform=linux/arm/v7"
 
@@ -231,7 +305,7 @@ dockers:
       - "--platform=linux/arm/v7"
 
 docker_manifests:
-# rely-proxy
+  # DEPRECATED: check go-feature-flag
   - name_template: thomaspoignant/go-feature-flag-relay-proxy:latest
     id: go-feature-flag-relay-proxy-latest
     image_templates:
@@ -256,6 +330,32 @@ docker_manifests:
       - thomaspoignant/go-feature-flag-relay-proxy:v{{ .RawVersion }}-arm64v8
       - thomaspoignant/go-feature-flag-relay-proxy:v{{ .RawVersion }}-armv7
       - thomaspoignant/go-feature-flag-relay-proxy:v{{ .RawVersion }}-amd64
+
+  # go-feature-flag
+  - name_template: thomaspoignant/go-feature-flag:latest
+    id: go-feature-flag-latest
+    image_templates:
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-arm64v8
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-armv7
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-amd64
+  - name_template: thomaspoignant/go-feature-flag:v{{ .RawVersion }}
+    id: go-feature-flag-tag
+    image_templates:
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-arm64v8
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-armv7
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-amd64
+  - name_template: thomaspoignant/go-feature-flag:v{{ .Major }}
+    id: go-feature-flag-major
+    image_templates:
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-arm64v8
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-armv7
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-amd64
+  - name_template: thomaspoignant/go-feature-flag:v{{ .Major }}.{{ .Minor }}
+    id: go-feature-flag-minor
+    image_templates:
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-arm64v8
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-armv7
+      - thomaspoignant/go-feature-flag:v{{ .RawVersion }}-amd64
 # migration-cli
   - name_template: thomaspoignant/go-feature-flag-migration-cli:latest
     id: go-feature-flag-migration-cli-latest
@@ -319,9 +419,21 @@ brews:
     homepage: "https://github.com/thomaspoignant/go-feature-flag/cmd/migrationcli"
     description: "A migration command line to move your feature flag configuration file from format GO Feature Flag v0.X to v1.X"
     skip_upload: auto
+  # DEPRECATED: check go-feature-flag
   - ids:
       - go-feature-flag-relay-proxy
     name: go-feature-flag-relay-proxy
+    tap:
+      owner: thomaspoignant
+      name: homebrew-tap
+      branch: master
+    caveats: "A stand alone server to run GO Feature Flag"
+    homepage: "https://gofeatureflag.org"
+    description: "A stand alone server to run GO Feature Flag"
+    skip_upload: auto
+  - ids:
+      - go-feature-flag
+    name: go-feature-flag
     tap:
       owner: thomaspoignant
       name: homebrew-tap
@@ -343,6 +455,7 @@ brews:
     skip_upload: auto
 
 scoops:
+
   - url_template: https://github.com/thomaspoignant/go-feature-flag/releases/download/{{ .Tag }}/{{ .ArtifactName }}
     ids: [go-feature-flag-migration-cli ]
     name: go-feature-flag-migration-cli
@@ -353,9 +466,20 @@ scoops:
     homepage: "https://gofeatureflag.org"
     license: MIT
 
+  # DEPRECATED: check go-feature-flag
   - url_template: https://github.com/thomaspoignant/go-feature-flag/releases/download/{{ .Tag }}/{{ .ArtifactName }}
     ids: [go-feature-flag-relay-proxy ]
     name: go-feature-flag-relay-proxy
+    bucket:
+      owner: go-feature-flag
+      name: scoop
+    commit_msg_template: "Scoop update for {{ .ProjectName }} version {{ .Tag }}"
+    homepage: "https://gofeatureflag.org"
+    license: MIT
+
+  - url_template: https://github.com/thomaspoignant/go-feature-flag/releases/download/{{ .Tag }}/{{ .ArtifactName }}
+    ids: [go-feature-flag ]
+    name: go-feature-flag
     bucket:
       owner: go-feature-flag
       name: scoop

--- a/cmd/relayproxy/DOCKERHUB_deprecated.md
+++ b/cmd/relayproxy/DOCKERHUB_deprecated.md
@@ -1,0 +1,81 @@
+# GO Feature Flag Relay Proxy
+
+<p align="center">
+  <img width="250" height="238" src="https://github.com/thomaspoignant/go-feature-flag/raw/main/logo.png" alt="go-feature-flag logo" />
+</p>
+
+<p align="center">
+  <img alt="Docker Image Version" src="https://img.shields.io/docker/v/thomaspoignant/go-feature-flag-relay-proxy?sort=semver&color=green"/>
+  <img alt="Docker Image Size" src="https://img.shields.io/docker/image-size/thomaspoignant/go-feature-flag-relay-proxy?sort=semver"/>
+  <img alt="Docker Hub downloads" src="https://img.shields.io/docker/pulls/thomaspoignant/go-feature-flag-relay-proxy?logo=docker"/>
+  <a href="https://github.com/thomaspoignant/go-feature-flag/blob/main/LICENSE"><img src="https://img.shields.io/github/license/thomaspoignant/go-feature-flag" alt="License"/></a>
+  <a href="https://gophers.slack.com/messages/go-feature-flag"><img src="https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=green" alt="Join us on slack"></a> 
+</p>
+
+
+--- 
+
+# What is GO Feature Flag Relay Proxy?
+
+The GO Feature Flag Relay Proxy retrieve your feature flag configuration file using [`thomaspoignant/go-feature-flag`](https://github.com/thomaspoignant/go-feature-flag) SDK and expose APIs to get your flags variations.  
+It lets a number of servers to connect to a single configuration file.
+
+This can be useful if you want to use the same feature flags configuration file for frontend and backend, this allows to be language agnostic by using standard protocol.
+
+For more information about GO Feature Flag Relay Proxy, please visit [github.com/thomaspoignant/go-feature-flag](https://github.com/thomaspoignant/go-feature-flag/tree/main/cmd/relayproxy).
+
+
+# Quick reference
+
+- This default distribution is the official distribution for `go-feature-flag-relay-proxy`.
+
+- Where to file issues: 
+  [https://github.com/thomaspoignant/go-feature-flag/issues/](https://github.com/thomaspoignant/go-feature-flag/issues/new?assignees=&labels=bug%2C+relay-proxy%2C+docker%2C+needs-triage&template=bug.md&title=(bug%20docker)).
+
+- Source are available in [`go-feature-flag` repo](https://github.com/thomaspoignant/go-feature-flag/tree/main/cmd/relayproxy).
+
+- All versions are available in the [tags](https://hub.docker.com/r/thomaspoignant/go-feature-flag-relay-proxy/tags).
+
+- Release notes are available [here](https://github.com/thomaspoignant/go-feature-flag/releases).
+
+
+# How to use this image
+
+**`go-feature-flag-relay-proxy`** requires a configuration file to be used.
+
+By default, we expect to have this configuration file in the `/goff` directory of the container and the file should be named `goff-proxy.yaml`.  
+
+The default port used for the service is `1031`.
+
+```shell
+docker run \
+  -v $(pwd)/goff-proxy.yaml:/goff/goff-proxy.yaml \
+  thomaspoignant/go-feature-flag-relay-proxy:latest
+```
+
+## Test it locally
+
+This is a small example on how to run `go-feature-flag-relay-proxy` locally.
+
+```shell
+# Download an example of a basic configuration file.
+curl https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/cmd/relayproxy/testdata/config/valid-file.yaml -o goff-proxy.yaml
+
+# Launch the container
+docker run \
+  -p 1031:1031 \
+  -v $(pwd)/goff-proxy.yaml:/goff/goff-proxy.yaml \
+  thomaspoignant/go-feature-flag-relay-proxy:latest
+  
+# Call the API
+curl -X 'POST' \
+  'http://localhost:1031/v1/feature/flag-only-for-admin/eval'  -H 'accept: application/json'  -H 'Content-Type: application/json' \
+  -d '{ "user": { "key": "contact@gofeatureflag.org", "anonymous": true, "custom": { "admin": true, "email": "contact@gofeatureflag.org" }}, "defaultValue": "false"}'
+```
+
+# License
+
+View [license](https://github.com/thomaspoignant/go-feature-flag/blob/main/LICENSE) information for the software contained in this image.
+
+## How can I contribute?
+This project is open for contribution, see the [contributor's guide](https://github.com/thomaspoignant/go-feature-flag/blob/main/CONTRIBUTING.md) for some helpful tips.

--- a/cmd/relayproxy/DockerfileGoreleaser
+++ b/cmd/relayproxy/DockerfileGoreleaser
@@ -1,3 +1,3 @@
 FROM gcr.io/distroless/base-debian11:latest
-COPY ./go-feature-flag-relay-proxy /go-feature-flag-relay-proxy
-CMD ["/go-feature-flag-relay-proxy"]
+COPY ./go-feature-flag /go-feature-flag
+CMD ["/go-feature-flag"]

--- a/cmd/relayproxy/DockerfileGoreleaserRelayProxy
+++ b/cmd/relayproxy/DockerfileGoreleaserRelayProxy
@@ -1,0 +1,3 @@
+FROM gcr.io/distroless/base-debian11:latest
+COPY ./go-feature-flag-relay-proxy /go-feature-flag-relay-proxy
+CMD ["/go-feature-flag-relay-proxy"]


### PR DESCRIPTION
# Description
Release relay proxy under 2 names.

As discussed [here](https://github.com/thomaspoignant/go-feature-flag/issues/753) the name `relay proxy` is a bit misleading, so to prepare any change we will release the relay proxy with 2 versions 
- `go-feature-flag-relay-proxy` 
- `go-feature-flag`

It will ease the change of name in the future.

# Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
