### PR TITLE
Add metadata in your flag configuration

### DIFF
--- a/cmd/relayproxy/docs/docs.go
+++ b/cmd/relayproxy/docs/docs.go
@@ -415,6 +415,11 @@ const docTemplate = `{
                     "type": "boolean",
                     "example": false
                 },
+                "metadata": {
+                    "description": "Metadata is a field containing information about your flag such as an issue tracker link, a description, etc ...",
+                    "type": "object",
+                    "additionalProperties": true
+                },
                 "reason": {
                     "description": "reason why we have returned this value.",
                     "type": "string",

--- a/cmd/relayproxy/docs/swagger.json
+++ b/cmd/relayproxy/docs/swagger.json
@@ -406,6 +406,11 @@
                     "type": "boolean",
                     "example": false
                 },
+                "metadata": {
+                    "description": "Metadata is a field containing information about your flag such as an issue tracker link, a description, etc ...",
+                    "type": "object",
+                    "additionalProperties": true
+                },
                 "reason": {
                     "description": "reason why we have returned this value.",
                     "type": "string",

--- a/cmd/relayproxy/docs/swagger.yaml
+++ b/cmd/relayproxy/docs/swagger.yaml
@@ -150,6 +150,11 @@ definitions:
           not exists, ...) and we serve the defaultValue.'
         example: false
         type: boolean
+      metadata:
+        additionalProperties: true
+        description: Metadata is a field containing information about your flag such
+          as an issue tracker link, a description, etc ...
+        type: object
       reason:
         description: reason why we have returned this value.
         example: TARGETING_MATCH

--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -34,7 +34,6 @@ _____________________________________________`
 // @license.url https://github.com/thomaspoignant/go-feature-flag/blob/main/LICENSE
 // @x-logo {"url":"https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/logo_128.png"}
 // @BasePath /
-
 // @securitydefinitions.apikey ApiKeyAuth
 // @in header
 // @name Authorization

--- a/cmd/relayproxy/modeldocs/eval_docs.go
+++ b/cmd/relayproxy/modeldocs/eval_docs.go
@@ -16,4 +16,6 @@ type EvalFlagDoc struct {
 	ErrorCode string `json:"errorCode" example:""`
 	// The flag value for this user.
 	Value interface{} `json:"value"`
+	// Metadata is a field containing information about your flag such as an issue tracker link, a description, etc ...
+	Metadata *map[string]interface{} `json:"metadata" yaml:"metadata,omitempty" toml:"metadata,omitempty"`
 }

--- a/internal/dto/convert_v1.go
+++ b/internal/dto/convert_v1.go
@@ -21,5 +21,6 @@ func ConvertV1DtoToInternalFlag(dto DTO) flag.InternalFlag {
 		Version:         dto.Version,
 		Scheduled:       dto.Scheduled,
 		Experimentation: experimentation,
+		Metadata:        dto.Metadata,
 	}
 }

--- a/internal/dto/dto.go
+++ b/internal/dto/dto.go
@@ -50,6 +50,9 @@ type DTOv1 struct {
 	// an end date for your flag.
 	// When the experimentation is not running, the flag will serve the default value.
 	Experimentation *ExperimentationDto `json:"experimentation,omitempty" yaml:"experimentation,omitempty" toml:"experimentation,omitempty"` // nolint: lll
+
+	// Metadata is a field containing information about your flag such as an issue tracker link, a description, etc ...
+	Metadata *map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty" toml:"metadata,omitempty"`
 }
 
 // DTOv0 describe the fields of a flag.

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -22,4 +22,7 @@ type Flag interface {
 
 	// GetVariationValue return the value of variation from his name
 	GetVariationValue(name string) interface{}
+
+	// GetMetadata return the metadata associated to the flag
+	GetMetadata() map[string]interface{}
 }

--- a/internal/flag/internal_flag.go
+++ b/internal/flag/internal_flag.go
@@ -50,6 +50,9 @@ type InternalFlag struct {
 	// The version is manually managed when you configure your flags, and it is used to display the information
 	// in the notifications and data collection.
 	Version *string `json:"version,omitempty" yaml:"version,omitempty" toml:"version,omitempty"`
+
+	// Metadata is a field containing information about your flag such as an issue tracker link, a description, etc ...
+	Metadata *map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty" toml:"metadata,omitempty"`
 }
 
 // Value is returning the Value associate to the flag
@@ -69,6 +72,7 @@ func (f *InternalFlag) Value(
 			Variant:   VariationSDKDefault,
 			Reason:    ReasonDisabled,
 			Cacheable: f.isCacheable(),
+			Metadata:  f.GetMetadata(),
 		}
 	}
 
@@ -79,6 +83,7 @@ func (f *InternalFlag) Value(
 				Variant:   VariationSDKDefault,
 				Reason:    ReasonError,
 				ErrorCode: ErrorFlagConfiguration,
+				Metadata:  f.GetMetadata(),
 			}
 	}
 
@@ -88,6 +93,7 @@ func (f *InternalFlag) Value(
 		RuleIndex: variationSelection.ruleIndex,
 		RuleName:  variationSelection.ruleName,
 		Cacheable: variationSelection.cacheable,
+		Metadata:  f.GetMetadata(),
 	}
 }
 
@@ -331,4 +337,12 @@ func (f *InternalFlag) GetVariationValue(name string) interface{} {
 		}
 	}
 	return nil
+}
+
+// GetMetadata return the metadata associated to the flag
+func (f *InternalFlag) GetMetadata() map[string]interface{} {
+	if f.Metadata == nil {
+		return nil
+	}
+	return *f.Metadata
 }

--- a/internal/flag/internal_flag_test.go
+++ b/internal/flag/internal_flag_test.go
@@ -35,6 +35,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -48,6 +52,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Variant:   "variation_A",
 				Reason:    flag.ReasonStatic,
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -61,6 +69,10 @@ func TestInternalFlag_Value(t *testing.T) {
 					VariationResult: testconvert.String("variation_A"),
 					Percentages:     &map[string]float64{},
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -74,12 +86,20 @@ func TestInternalFlag_Value(t *testing.T) {
 				Variant:   "variation_A",
 				Reason:    flag.ReasonStatic,
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
 			name: "Should return sdk default value when flag is disabled",
 			flag: flag.InternalFlag{
 				Disable: testconvert.Bool(true),
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -93,6 +113,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Variant:   "SdkDefault",
 				Reason:    flag.ReasonDisabled,
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -102,6 +126,10 @@ func TestInternalFlag_Value(t *testing.T) {
 					Start: testconvert.Time(time.Now().Add(1 * time.Second)),
 					End:   testconvert.Time(time.Now().Add(5 * time.Second)),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -115,6 +143,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Variant:   "SdkDefault",
 				Reason:    flag.ReasonDisabled,
 				Cacheable: false,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -124,6 +156,10 @@ func TestInternalFlag_Value(t *testing.T) {
 					Start: testconvert.Time(time.Now().Add(-15 * time.Second)),
 					End:   testconvert.Time(time.Now().Add(-5 * time.Second)),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -137,6 +173,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Variant:   "SdkDefault",
 				Reason:    flag.ReasonDisabled,
 				Cacheable: false,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -156,6 +196,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -171,6 +215,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				RuleIndex: testconvert.Int(0),
 				RuleName:  testconvert.String("rule1"),
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -196,6 +244,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -211,6 +263,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				RuleIndex: testconvert.Int(1),
 				RuleName:  testconvert.String("rule2"),
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -234,6 +290,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -248,6 +308,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Reason:    flag.ReasonTargetingMatch,
 				RuleIndex: testconvert.Int(1),
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -276,6 +340,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -290,6 +358,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Reason:    flag.ReasonTargetingMatch,
 				RuleIndex: testconvert.Int(1),
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -319,6 +391,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -333,6 +409,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Reason:    flag.ReasonTargetingMatch,
 				RuleIndex: testconvert.Int(2),
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -356,6 +436,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -369,6 +453,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Variant:   flag.VariationSDKDefault,
 				Reason:    flag.ReasonError,
 				ErrorCode: flag.ErrorFlagConfiguration,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -389,6 +477,10 @@ func TestInternalFlag_Value(t *testing.T) {
 						},
 					},
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -402,6 +494,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Variant:   flag.VariationSDKDefault,
 				Reason:    flag.ReasonError,
 				ErrorCode: flag.ErrorFlagConfiguration,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -419,6 +515,10 @@ func TestInternalFlag_Value(t *testing.T) {
 						"variation_B": 100,
 					},
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -432,6 +532,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Variant:   flag.VariationSDKDefault,
 				Reason:    flag.ReasonError,
 				ErrorCode: flag.ErrorFlagConfiguration,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -443,6 +547,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				Scheduled: &[]flag.ScheduledStep{
 					{
@@ -474,6 +582,10 @@ func TestInternalFlag_Value(t *testing.T) {
 			want1: flag.ResolutionDetails{
 				Variant: "variation_A",
 				Reason:  flag.ReasonStatic,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -485,6 +597,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				Scheduled: &[]flag.ScheduledStep{
 					{
@@ -516,6 +632,10 @@ func TestInternalFlag_Value(t *testing.T) {
 			want1: flag.ResolutionDetails{
 				Variant: "variation_B",
 				Reason:  flag.ReasonStatic,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -527,6 +647,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				Scheduled: &[]flag.ScheduledStep{
 					{
@@ -558,6 +682,10 @@ func TestInternalFlag_Value(t *testing.T) {
 			want1: flag.ResolutionDetails{
 				Variant: "variation_B",
 				Reason:  flag.ReasonStatic,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -569,6 +697,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				Scheduled: &[]flag.ScheduledStep{
 					{
@@ -591,6 +723,10 @@ func TestInternalFlag_Value(t *testing.T) {
 			want1: flag.ResolutionDetails{
 				Variant: "variation_A",
 				Reason:  flag.ReasonStatic,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -609,6 +745,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				Scheduled: &[]flag.ScheduledStep{
 					{
@@ -640,6 +780,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Reason:    flag.ReasonTargetingMatch,
 				RuleIndex: testconvert.Int(0),
 				RuleName:  testconvert.String("rule1"),
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -652,6 +796,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_C"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				Scheduled: &[]flag.ScheduledStep{
 					{
@@ -678,6 +826,10 @@ func TestInternalFlag_Value(t *testing.T) {
 			want1: flag.ResolutionDetails{
 				Variant: "variation_C",
 				Reason:  flag.ReasonSplit,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -693,6 +845,10 @@ func TestInternalFlag_Value(t *testing.T) {
 						Query:           testconvert.String("key eq \"user-key\""),
 						VariationResult: testconvert.String("variation_B"),
 					},
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
@@ -728,6 +884,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Reason:    flag.ReasonTargetingMatch,
 				RuleIndex: testconvert.Int(1),
 				RuleName:  testconvert.String("rule2"),
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -739,6 +899,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				Scheduled: &[]flag.ScheduledStep{
 					{
@@ -770,6 +934,10 @@ func TestInternalFlag_Value(t *testing.T) {
 			want1: flag.ResolutionDetails{
 				Variant: "variation_B",
 				Reason:  flag.ReasonStatic,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -781,6 +949,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				Scheduled: &[]flag.ScheduledStep{
 					{
@@ -804,6 +976,10 @@ func TestInternalFlag_Value(t *testing.T) {
 			want1: flag.ResolutionDetails{
 				Variant: flag.VariationSDKDefault,
 				Reason:  flag.ReasonDisabled,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -815,6 +991,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				Scheduled: &[]flag.ScheduledStep{
 					{
@@ -839,6 +1019,10 @@ func TestInternalFlag_Value(t *testing.T) {
 			want1: flag.ResolutionDetails{
 				Variant: "variation_A",
 				Reason:  flag.ReasonStatic,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -850,6 +1034,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				Scheduled: &[]flag.ScheduledStep{
 					{
@@ -884,6 +1072,10 @@ func TestInternalFlag_Value(t *testing.T) {
 			want1: flag.ResolutionDetails{
 				Variant: "variation_A",
 				Reason:  flag.ReasonStatic,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -907,6 +1099,10 @@ func TestInternalFlag_Value(t *testing.T) {
 						},
 					},
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -920,6 +1116,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Variant:   "variation_A",
 				Reason:    flag.ReasonSplit,
 				Cacheable: false,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -939,6 +1139,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -954,6 +1158,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				RuleIndex: testconvert.Int(0),
 				RuleName:  testconvert.String("test-rule"),
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -976,6 +1184,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -991,6 +1203,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				RuleIndex: testconvert.Int(0),
 				RuleName:  testconvert.String("test-rule"),
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -1022,6 +1238,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -1037,6 +1257,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				RuleIndex: testconvert.Int(0),
 				RuleName:  testconvert.String("test-rule"),
 				Cacheable: false,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -1059,6 +1283,10 @@ func TestInternalFlag_Value(t *testing.T) {
 						"variation_B": 50,
 					},
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -1072,6 +1300,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Variant:   "variation_A",
 				Reason:    flag.ReasonSplit,
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -1091,6 +1323,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -1104,6 +1340,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Variant:   "variation_A",
 				Reason:    flag.ReasonDefault,
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -1115,6 +1355,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 			},
 			args: args{
@@ -1129,6 +1373,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Variant:   "variation_A",
 				Reason:    flag.ReasonStatic,
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -1144,6 +1392,10 @@ func TestInternalFlag_Value(t *testing.T) {
 						"variation_B": 0,
 					},
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "my-flag",
@@ -1157,6 +1409,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Variant:   "variation_A",
 				Reason:    flag.ReasonStatic,
 				Cacheable: true,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 		{
@@ -1180,6 +1436,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("B"),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			args: args{
 				flagName: "feature",
@@ -1195,6 +1455,10 @@ func TestInternalFlag_Value(t *testing.T) {
 				Reason:    flag.ReasonTargetingMatch,
 				Cacheable: true,
 				RuleIndex: testconvert.Int(0),
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 		},
 	}
@@ -1389,6 +1653,7 @@ func TestInternalFlag_IsValid(t *testing.T) {
 		Version         *string
 		Experimentation *flag.ExperimentationRollout
 		Scheduled       *[]flag.ScheduledStep
+		Metadata        *map[string]interface{}
 	}
 	tests := []struct {
 		name     string
@@ -1415,6 +1680,10 @@ func TestInternalFlag_IsValid(t *testing.T) {
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("A"),
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			errorMsg: "all variations should have the same type",
 			wantErr:  assert.Error,
@@ -1428,6 +1697,10 @@ func TestInternalFlag_IsValid(t *testing.T) {
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 			},
 			wantErr: assert.NoError,
@@ -1445,6 +1718,10 @@ func TestInternalFlag_IsValid(t *testing.T) {
 						VariationResult: testconvert.String("A"),
 					},
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			errorMsg: "missing default rule",
 			wantErr:  assert.Error,
@@ -1457,6 +1734,10 @@ func TestInternalFlag_IsValid(t *testing.T) {
 				},
 				DefaultRule: &flag.Rule{
 					VariationResult: testconvert.String("A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				Rules: &[]flag.Rule{
 					{
@@ -1507,6 +1788,10 @@ func TestInternalFlag_IsValid(t *testing.T) {
 						"B": 20,
 					},
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			errorMsg: "invalid percentages",
 			wantErr:  assert.Error,
@@ -1522,6 +1807,10 @@ func TestInternalFlag_IsValid(t *testing.T) {
 						"A": 90,
 						"B": 10,
 					},
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				Rules: &[]flag.Rule{
 					{
@@ -1558,6 +1847,10 @@ func TestInternalFlag_IsValid(t *testing.T) {
 						},
 					},
 				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
 			},
 			errorMsg: "each targeting should have a query",
 			wantErr:  assert.Error,
@@ -1568,6 +1861,10 @@ func TestInternalFlag_IsValid(t *testing.T) {
 				Variations: &map[string]*interface{}{
 					"A": testconvert.Interface("A"),
 					"B": testconvert.Interface("B"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				DefaultRule: &flag.Rule{
 					Name: testconvert.String("nothing to return"),
@@ -1582,6 +1879,10 @@ func TestInternalFlag_IsValid(t *testing.T) {
 				Variations: &map[string]*interface{}{
 					"A": testconvert.Interface("A"),
 					"B": testconvert.Interface("B"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				DefaultRule: &flag.Rule{
 					Name: testconvert.String("nothing to return"),
@@ -1608,6 +1909,10 @@ func TestInternalFlag_IsValid(t *testing.T) {
 				Variations: &map[string]*interface{}{
 					"A": testconvert.Interface("A"),
 					"B": testconvert.Interface("B"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
 				},
 				Rules: &[]flag.Rule{
 					{

--- a/internal/flag/resolution_detail.go
+++ b/internal/flag/resolution_detail.go
@@ -20,4 +20,7 @@ type ResolutionDetails struct {
 
 	// Cacheable is set to true if an SDK/provider can cache the value locally.
 	Cacheable bool
+
+	// Metadata is a field containing information about your flag such as an issue tracker link, a description, etc ...
+	Metadata map[string]interface{}
 }

--- a/internal/flagstate/flag_state.go
+++ b/internal/flagstate/flag_state.go
@@ -6,11 +6,12 @@ import (
 
 // FlagState represents the state of an individual feature flag, with regard to a specific user, when it was called.
 type FlagState struct {
-	Value         interface{}           `json:"value"`
-	Timestamp     int64                 `json:"timestamp"`
-	VariationType string                `json:"variationType"`
-	TrackEvents   bool                  `json:"trackEvents"`
-	Failed        bool                  `json:"-"`
-	ErrorCode     flag.ErrorCode        `json:"errorCode"`
-	Reason        flag.ResolutionReason `json:"reason"`
+	Value         interface{}            `json:"value"`
+	Timestamp     int64                  `json:"timestamp"`
+	VariationType string                 `json:"variationType"`
+	TrackEvents   bool                   `json:"trackEvents"`
+	Failed        bool                   `json:"-"`
+	ErrorCode     flag.ErrorCode         `json:"errorCode"`
+	Reason        flag.ResolutionReason  `json:"reason"`
+	Metadata      map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/internal/model/variation_result.go
+++ b/internal/model/variation_result.go
@@ -9,25 +9,27 @@ type JSONType interface {
 
 // VariationResult contains all the field available in a flag variation result.
 type VariationResult[T JSONType] struct {
-	TrackEvents   bool                  `json:"trackEvents"`
-	VariationType string                `json:"variationType"`
-	Failed        bool                  `json:"failed"`
-	Version       string                `json:"version"`
-	Reason        flag.ResolutionReason `json:"reason"`
-	ErrorCode     flag.ErrorCode        `json:"errorCode"`
-	Value         T                     `json:"value"`
-	Cacheable     bool                  `json:"cacheable"`
+	TrackEvents   bool                   `json:"trackEvents"`
+	VariationType string                 `json:"variationType"`
+	Failed        bool                   `json:"failed"`
+	Version       string                 `json:"version"`
+	Reason        flag.ResolutionReason  `json:"reason"`
+	ErrorCode     flag.ErrorCode         `json:"errorCode"`
+	Value         T                      `json:"value"`
+	Cacheable     bool                   `json:"cacheable"`
+	Metadata      map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // RawVarResult is the result of the raw variation call.
 // This is used by ffclient.RawVariation functions, this should be used only by internal calls.
 type RawVarResult struct {
-	TrackEvents   bool                  `json:"trackEvents"`
-	VariationType string                `json:"variationType"`
-	Failed        bool                  `json:"failed"`
-	Version       string                `json:"version"`
-	Reason        flag.ResolutionReason `json:"reason"`
-	ErrorCode     flag.ErrorCode        `json:"errorCode"`
-	Value         interface{}           `json:"value"`
-	Cacheable     bool                  `json:"cacheable"`
+	TrackEvents   bool                   `json:"trackEvents"`
+	VariationType string                 `json:"variationType"`
+	Failed        bool                   `json:"failed"`
+	Version       string                 `json:"version"`
+	Reason        flag.ResolutionReason  `json:"reason"`
+	ErrorCode     flag.ErrorCode         `json:"errorCode"`
+	Value         interface{}            `json:"value"`
+	Cacheable     bool                   `json:"cacheable"`
+	Metadata      map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/testdata/flag-config.yaml
+++ b/testdata/flag-config.yaml
@@ -12,6 +12,9 @@ test-flag:
   defaultRule:
     name: legacyDefaultRule
     variation: Default
+  metadata:
+    description: this is a simple feature flag
+    issue-link: https://jira.xxx/GOFF-01
 
 test-flag2:
   variations:

--- a/testutils/flagv1/flag_data.go
+++ b/testutils/flagv1/flag_data.go
@@ -381,3 +381,7 @@ func convertNilEmpty(input interface{}) string {
 	}
 	return fmt.Sprintf("%v", input)
 }
+
+func (f *FlagData) GetMetadata() map[string]interface{} {
+	return nil
+}

--- a/variation.go
+++ b/variation.go
@@ -275,6 +275,7 @@ func (g *GoFeatureFlag) AllFlagsState(user ffuser.User) flagstate.AllFlags {
 				Failed:      resolutionDetails.ErrorCode != "",
 				ErrorCode:   resolutionDetails.ErrorCode,
 				Reason:      resolutionDetails.Reason,
+				Metadata:    resolutionDetails.Metadata,
 			})
 			continue
 		}
@@ -289,6 +290,7 @@ func (g *GoFeatureFlag) AllFlagsState(user ffuser.User) flagstate.AllFlags {
 				Failed:        resolutionDetails.ErrorCode != "",
 				ErrorCode:     resolutionDetails.ErrorCode,
 				Reason:        resolutionDetails.Reason,
+				Metadata:      resolutionDetails.Metadata,
 			})
 
 		default:
@@ -304,6 +306,7 @@ func (g *GoFeatureFlag) AllFlagsState(user ffuser.User) flagstate.AllFlags {
 					Failed:        true,
 					ErrorCode:     flag.ErrorCodeTypeMismatch,
 					Reason:        flag.ReasonError,
+					Metadata:      resolutionDetails.Metadata,
 				})
 		}
 	}
@@ -400,6 +403,7 @@ func getVariation[T model.JSONType](
 		if f != nil {
 			varResult.TrackEvents = f.IsTrackEvents()
 			varResult.Version = f.GetVersion()
+			varResult.Metadata = f.GetMetadata()
 		}
 		return varResult, err
 	}
@@ -434,6 +438,7 @@ func getVariation[T model.JSONType](
 				Failed:        true,
 				TrackEvents:   f.IsTrackEvents(),
 				Version:       f.GetVersion(),
+				Metadata:      f.GetMetadata(),
 			}, fmt.Errorf(errorWrongVariation, flagKey)
 		}
 	}
@@ -447,5 +452,6 @@ func getVariation[T model.JSONType](
 		TrackEvents:   f.IsTrackEvents(),
 		Version:       f.GetVersion(),
 		Cacheable:     resolutionDetails.Cacheable,
+		Metadata:      f.GetMetadata(),
 	}, nil
 }


### PR DESCRIPTION
# Description
This new feature allows adding a wealth of information about a particular feature flag, such as a configuration URL or the originating Jira issue.

To add those pieces of information, you have a new field in your flag definition called **`metadata`** where you can add all the relevant information you need.
This is a free field, you can add everything you want.

The `metadata` will be sent to all VariationDetails evaluations, so you can retrieve them in your application.
It also sends in the result of the relay-proxy.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
