### PR TITLE
docs: fix GitLab title pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ For now, we have providers for `python`, `java`, `typescript`, `javascript`, `GO
 The module supports different ways of retrieving the flag file.  
 The available retrievers are:
 - **GitHub**
+- **GitLab**
 - **HTTP endpoint**
 - **AWS S3**
 - **Local file**

--- a/website/docs/go_module/store_file/gitlab.md
+++ b/website/docs/go_module/store_file/gitlab.md
@@ -2,7 +2,7 @@
 sidebar_position: 6
 ---
 
-# Github
+# GitLab
 
 The [**Gitlab Retriever**](https://pkg.go.dev/github.com/thomaspoignant/go-feature-flag/retriever/gitlabretriever/#Retriever)
 will perform an HTTP Request to the Gitlab API to get your flags.
@@ -29,7 +29,7 @@ defer ffclient.Close()
 
 ## Configuration fields
 
-To configure the access to your GitHub file:
+To configure the access to your GitLab file:
 
 | Field                | Description                                                                               |
 |----------------------|-------------------------------------------------------------------------------------------|

--- a/website/versioned_docs/version-v1.10.0/go_module/store_file/gitlab.md
+++ b/website/versioned_docs/version-v1.10.0/go_module/store_file/gitlab.md
@@ -2,7 +2,7 @@
 sidebar_position: 6
 ---
 
-# Github
+# GitLab
 
 The [**Gitlab Retriever**](https://pkg.go.dev/github.com/thomaspoignant/go-feature-flag/retriever/gitlabretriever/#Retriever)
 will perform an HTTP Request to the Gitlab API to get your flags.
@@ -29,7 +29,7 @@ defer ffclient.Close()
 
 ## Configuration fields
 
-To configure the access to your GitHub file:
+To configure the access to your GitLab file:
 
 | Field                | Description                                                                               |
 |----------------------|-------------------------------------------------------------------------------------------|

--- a/website/versioned_docs/version-v1.10.1/go_module/store_file/gitlab.md
+++ b/website/versioned_docs/version-v1.10.1/go_module/store_file/gitlab.md
@@ -2,7 +2,7 @@
 sidebar_position: 6
 ---
 
-# Github
+# GitLab
 
 The [**Gitlab Retriever**](https://pkg.go.dev/github.com/thomaspoignant/go-feature-flag/retriever/gitlabretriever/#Retriever)
 will perform an HTTP Request to the Gitlab API to get your flags.
@@ -29,7 +29,7 @@ defer ffclient.Close()
 
 ## Configuration fields
 
-To configure the access to your GitHub file:
+To configure the access to your GitLab file:
 
 | Field                | Description                                                                               |
 |----------------------|-------------------------------------------------------------------------------------------|

--- a/website/versioned_docs/version-v1.10.2/go_module/store_file/gitlab.md
+++ b/website/versioned_docs/version-v1.10.2/go_module/store_file/gitlab.md
@@ -2,7 +2,7 @@
 sidebar_position: 6
 ---
 
-# Github
+# GitLab
 
 The [**Gitlab Retriever**](https://pkg.go.dev/github.com/thomaspoignant/go-feature-flag/retriever/gitlabretriever/#Retriever)
 will perform an HTTP Request to the Gitlab API to get your flags.
@@ -29,7 +29,7 @@ defer ffclient.Close()
 
 ## Configuration fields
 
-To configure the access to your GitHub file:
+To configure the access to your GitLab file:
 
 | Field                | Description                                                                               |
 |----------------------|-------------------------------------------------------------------------------------------|

--- a/website/versioned_docs/version-v1.10.3/go_module/store_file/gitlab.md
+++ b/website/versioned_docs/version-v1.10.3/go_module/store_file/gitlab.md
@@ -2,7 +2,7 @@
 sidebar_position: 6
 ---
 
-# Github
+# GitLab
 
 The [**Gitlab Retriever**](https://pkg.go.dev/github.com/thomaspoignant/go-feature-flag/retriever/gitlabretriever/#Retriever)
 will perform an HTTP Request to the Gitlab API to get your flags.
@@ -29,7 +29,7 @@ defer ffclient.Close()
 
 ## Configuration fields
 
-To configure the access to your GitHub file:
+To configure the access to your GitLab file:
 
 | Field                | Description                                                                               |
 |----------------------|-------------------------------------------------------------------------------------------|

--- a/website/versioned_docs/version-v1.10.4/go_module/store_file/gitlab.md
+++ b/website/versioned_docs/version-v1.10.4/go_module/store_file/gitlab.md
@@ -2,7 +2,7 @@
 sidebar_position: 6
 ---
 
-# Github
+# GitLab
 
 The [**Gitlab Retriever**](https://pkg.go.dev/github.com/thomaspoignant/go-feature-flag/retriever/gitlabretriever/#Retriever)
 will perform an HTTP Request to the Gitlab API to get your flags.
@@ -29,7 +29,7 @@ defer ffclient.Close()
 
 ## Configuration fields
 
-To configure the access to your GitHub file:
+To configure the access to your GitLab file:
 
 | Field                | Description                                                                               |
 |----------------------|-------------------------------------------------------------------------------------------|

--- a/website/versioned_docs/version-v1.11.0/go_module/store_file/gitlab.md
+++ b/website/versioned_docs/version-v1.11.0/go_module/store_file/gitlab.md
@@ -2,7 +2,7 @@
 sidebar_position: 6
 ---
 
-# Github
+# GitLab
 
 The [**Gitlab Retriever**](https://pkg.go.dev/github.com/thomaspoignant/go-feature-flag/retriever/gitlabretriever/#Retriever)
 will perform an HTTP Request to the Gitlab API to get your flags.
@@ -29,7 +29,7 @@ defer ffclient.Close()
 
 ## Configuration fields
 
-To configure the access to your GitHub file:
+To configure the access to your GitLab file:
 
 | Field                | Description                                                                               |
 |----------------------|-------------------------------------------------------------------------------------------|


### PR DESCRIPTION
# Description

This documentation pages for the GitLab retriever stated GitHub.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
