### PR TITLE
fix: Use GITHUB api instead of the public link

### DIFF
--- a/retriever/githubretriever/retriever.go
+++ b/retriever/githubretriever/retriever.go
@@ -34,17 +34,19 @@ func (r *Retriever) Retrieve(ctx context.Context) ([]byte, error) {
 		branch = "main"
 	}
 
-	// add header for Github Token if specified
 	header := http.Header{}
+	header.Add("Accept", "application/vnd.github.raw")
+	header.Add("X-GitHub-Api-Version", "2022-11-28")
+	// add header for GitHub Token if specified
 	if r.GithubToken != "" {
-		header.Add("Authorization", fmt.Sprintf("token %s", r.GithubToken))
+		header.Add("Authorization", fmt.Sprintf("Bearer %s", r.GithubToken))
 	}
 
 	URL := fmt.Sprintf(
-		"https://raw.githubusercontent.com/%s/%s/%s",
+		"https://api.github.com/repos/%s/contents/%s?ref=%s",
 		r.RepositorySlug,
-		branch,
-		r.FilePath)
+		r.FilePath,
+		branch)
 
 	httpRetriever := httpretriever.Retriever{
 		URL:     URL,

--- a/retriever/githubretriever/retriever_test.go
+++ b/retriever/githubretriever/retriever_test.go
@@ -154,7 +154,7 @@ func Test_github_Retrieve(t *testing.T) {
 				assert.Equal(t, http.MethodGet, tt.fields.httpClient.Req.Method)
 				assert.Equal(t, tt.want, got)
 				if tt.fields.githubToken != "" {
-					assert.Equal(t, "token "+tt.fields.githubToken, tt.fields.httpClient.Req.Header.Get("Authorization"))
+					assert.Equal(t, "Bearer "+tt.fields.githubToken, tt.fields.httpClient.Req.Header.Get("Authorization"))
 				}
 			}
 		})

--- a/testutils/mock/http_mock.go
+++ b/testutils/mock/http_mock.go
@@ -37,7 +37,7 @@ func (m *HTTP) Do(req *http.Request) (*http.Response, error) {
 		Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 	}
 
-	if strings.HasSuffix(req.URL.String(), "error") {
+	if strings.Contains(req.URL.String(), "error") {
 		return nil, errors.New("http error")
 	} else if strings.HasSuffix(req.URL.String(), "httpError") {
 		return error, nil


### PR DESCRIPTION
# Description
Before this PR we were using the GitHub public link to retrieve your feature flags.
It was closing some caching issues.

This PR now uses the API directly so it should avoid this issues.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
