### PR TITLE
⚠️ Changing the Notifier interface to simplify go routine handling

### DIFF
--- a/cmd/relayproxy/service/notifier_relayproxy.go
+++ b/cmd/relayproxy/service/notifier_relayproxy.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"github.com/thomaspoignant/go-feature-flag/notifier"
-	"sync"
 )
 
 type notifierRelayProxy struct {
@@ -15,8 +14,7 @@ func NewNotifierRelayProxy(websocketService WebsocketService) notifier.Notifier 
 	}
 }
 
-func (n *notifierRelayProxy) Notify(diff notifier.DiffCache, waitGroup *sync.WaitGroup) error {
-	defer waitGroup.Done()
+func (n *notifierRelayProxy) Notify(diff notifier.DiffCache) error {
 	n.websocketService.BroadcastFlagChanges(diff)
 	return nil
 }

--- a/cmd/relayproxy/service/notifier_relayproxy_test.go
+++ b/cmd/relayproxy/service/notifier_relayproxy_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/service"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,15 +87,8 @@ func TestNotify(t *testing.T) {
 		},
 	}
 
-	// Create a WaitGroup to ensure the goroutine completes before asserting the results
-	waitGroup := &sync.WaitGroup{}
-	waitGroup.Add(1)
-
 	// Call the Notify function
-	err := n.Notify(diff, waitGroup)
-
-	// Wait for the goroutine to complete
-	waitGroup.Wait()
+	err := n.Notify(diff)
 
 	// Assertions
 	assert.NoError(t, err)

--- a/internal/cache/notification_service.go
+++ b/internal/cache/notification_service.go
@@ -34,7 +34,8 @@ func (c *notificationService) Notify(oldCache map[string]flag.Flag, newCache map
 			c.waitGroup.Add(1)
 			notif := n
 			go func() {
-				err := notif.Notify(diff, c.waitGroup)
+				defer c.waitGroup.Done()
+				err := notif.Notify(diff)
 				if err != nil {
 					fflog.Printf(log, "error while calling the notifier: %v", err)
 				}

--- a/notifier/logsnotifier/notifier.go
+++ b/notifier/logsnotifier/notifier.go
@@ -1,19 +1,16 @@
 package logsnotifier
 
 import (
+	"github.com/thomaspoignant/go-feature-flag/notifier"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log"
-	"sync"
-
-	"github.com/thomaspoignant/go-feature-flag/notifier"
 )
 
 type Notifier struct {
 	Logger *log.Logger
 }
 
-func (c *Notifier) Notify(diff notifier.DiffCache, wg *sync.WaitGroup) error {
-	defer wg.Done()
+func (c *Notifier) Notify(diff notifier.DiffCache) error {
 	for key := range diff.Deleted {
 		fflog.Printf(c.Logger, "flag %v removed\n", key)
 	}

--- a/notifier/logsnotifier/notifier_test.go
+++ b/notifier/logsnotifier/notifier_test.go
@@ -3,7 +3,6 @@ package logsnotifier
 import (
 	"log"
 	"os"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,157 +15,44 @@ import (
 
 func TestLogNotifier_Notify(t *testing.T) {
 	type args struct {
-		diff notifier.DiffCache
-		wg   *sync.WaitGroup
 	}
 	tests := []struct {
 		name     string
 		args     args
+		diff     notifier.DiffCache
 		expected string
 	}{
 		{
 			name: "Flag deleted",
-			args: args{
-				diff: notifier.DiffCache{
-					Deleted: map[string]flag.Flag{
-						"test-flag": &flag.InternalFlag{
-							Variations: &map[string]*interface{}{
-								"Default": testconvert.Interface(false),
-								"False":   testconvert.Interface(false),
-								"True":    testconvert.Interface(true),
-							},
-							DefaultRule: &flag.Rule{
-								Name: testconvert.String("legacyDefaultRule"),
-								Percentages: &map[string]float64{
-									"False": 0,
-									"True":  100,
-								},
+			diff: notifier.DiffCache{
+				Deleted: map[string]flag.Flag{
+					"test-flag": &flag.InternalFlag{
+						Variations: &map[string]*interface{}{
+							"Default": testconvert.Interface(false),
+							"False":   testconvert.Interface(false),
+							"True":    testconvert.Interface(true),
+						},
+						DefaultRule: &flag.Rule{
+							Name: testconvert.String("legacyDefaultRule"),
+							Percentages: &map[string]float64{
+								"False": 0,
+								"True":  100,
 							},
 						},
 					},
-					Updated: map[string]notifier.DiffUpdated{},
-					Added:   map[string]flag.Flag{},
 				},
-				wg: &sync.WaitGroup{},
+				Updated: map[string]notifier.DiffUpdated{},
+				Added:   map[string]flag.Flag{},
 			},
 			expected: "^\\[" + testutils.RFC3339Regex + "\\] flag test-flag removed",
 		},
 		{
 			name: "Update flag",
-			args: args{
-				diff: notifier.DiffCache{
-					Deleted: map[string]flag.Flag{},
-					Updated: map[string]notifier.DiffUpdated{
-						"test-flag": {
-							Before: &flag.InternalFlag{
-								Rules: &[]flag.Rule{
-									{
-										Name:  testconvert.String("legacyRuleV0"),
-										Query: testconvert.String("key eq \"random-key\""),
-										Percentages: &map[string]float64{
-											"False": 0,
-											"True":  100,
-										},
-									},
-								},
-								Variations: &map[string]*interface{}{
-									"Default": testconvert.Interface(false),
-									"False":   testconvert.Interface(false),
-									"True":    testconvert.Interface(true),
-								},
-								DefaultRule: &flag.Rule{
-									Name:            testconvert.String("legacyDefaultRule"),
-									VariationResult: testconvert.String("Default"),
-								},
-							},
-							After: &flag.InternalFlag{
-								Variations: &map[string]*interface{}{
-									"Default": testconvert.Interface(false),
-									"False":   testconvert.Interface(false),
-									"True":    testconvert.Interface(true),
-								},
-								DefaultRule: &flag.Rule{
-									Name: testconvert.String("legacyDefaultRule"),
-									Percentages: &map[string]float64{
-										"False": 0,
-										"True":  100,
-									},
-								},
-							},
-						},
-					},
-					Added: map[string]flag.Flag{},
-				},
-				wg: &sync.WaitGroup{},
-			},
-			expected: "^\\[" + testutils.RFC3339Regex + "\\] flag test-flag updated",
-		},
-		{
-			name: "Disable flag",
-			args: args{
-				diff: notifier.DiffCache{
-					Deleted: map[string]flag.Flag{},
-					Updated: map[string]notifier.DiffUpdated{
-						"test-flag": {
-							Before: &flag.InternalFlag{
-								Rules: &[]flag.Rule{
-									{
-										Name:  testconvert.String("legacyRuleV0"),
-										Query: testconvert.String("key eq \"random-key\""),
-										Percentages: &map[string]float64{
-											"False": 0,
-											"True":  100,
-										},
-									},
-								},
-								Variations: &map[string]*interface{}{
-									"Default": testconvert.Interface(false),
-									"False":   testconvert.Interface(false),
-									"True":    testconvert.Interface(true),
-								},
-								DefaultRule: &flag.Rule{
-									Name:            testconvert.String("legacyDefaultRule"),
-									VariationResult: testconvert.String("Default"),
-								},
-							},
-							After: &flag.InternalFlag{
-								Rules: &[]flag.Rule{
-									{
-										Name:  testconvert.String("legacyRuleV0"),
-										Query: testconvert.String("key eq \"random-key\""),
-										Percentages: &map[string]float64{
-											"False": 0,
-											"True":  100,
-										},
-									},
-								},
-								Variations: &map[string]*interface{}{
-									"Default": testconvert.Interface(false),
-									"False":   testconvert.Interface(false),
-									"True":    testconvert.Interface(true),
-								},
-								DefaultRule: &flag.Rule{
-									Name:            testconvert.String("legacyDefaultRule"),
-									VariationResult: testconvert.String("Default"),
-								},
-								Disable: testconvert.Bool(true),
-							},
-						},
-					},
-					Added: map[string]flag.Flag{},
-				},
-				wg: &sync.WaitGroup{},
-			},
-			expected: "^\\[" + testutils.RFC3339Regex + "\\] flag test-flag is turned OFF",
-		},
-		{
-			name: "Add flag",
-			args: args{
-				diff: notifier.DiffCache{
-					Deleted: map[string]flag.Flag{},
-					Updated: map[string]notifier.DiffUpdated{},
-					Added: map[string]flag.Flag{
-						"add-test-flag": &flag.InternalFlag{
+			diff: notifier.DiffCache{
+				Deleted: map[string]flag.Flag{},
+				Updated: map[string]notifier.DiffUpdated{
+					"test-flag": {
+						Before: &flag.InternalFlag{
 							Rules: &[]flag.Rule{
 								{
 									Name:  testconvert.String("legacyRuleV0"),
@@ -187,67 +73,164 @@ func TestLogNotifier_Notify(t *testing.T) {
 								VariationResult: testconvert.String("Default"),
 							},
 						},
+						After: &flag.InternalFlag{
+							Variations: &map[string]*interface{}{
+								"Default": testconvert.Interface(false),
+								"False":   testconvert.Interface(false),
+								"True":    testconvert.Interface(true),
+							},
+							DefaultRule: &flag.Rule{
+								Name: testconvert.String("legacyDefaultRule"),
+								Percentages: &map[string]float64{
+									"False": 0,
+									"True":  100,
+								},
+							},
+						},
 					},
 				},
-				wg: &sync.WaitGroup{},
+				Added: map[string]flag.Flag{},
+			},
+			expected: "^\\[" + testutils.RFC3339Regex + "\\] flag test-flag updated",
+		},
+		{
+			name: "Disable flag",
+			diff: notifier.DiffCache{
+				Deleted: map[string]flag.Flag{},
+				Updated: map[string]notifier.DiffUpdated{
+					"test-flag": {
+						Before: &flag.InternalFlag{
+							Rules: &[]flag.Rule{
+								{
+									Name:  testconvert.String("legacyRuleV0"),
+									Query: testconvert.String("key eq \"random-key\""),
+									Percentages: &map[string]float64{
+										"False": 0,
+										"True":  100,
+									},
+								},
+							},
+							Variations: &map[string]*interface{}{
+								"Default": testconvert.Interface(false),
+								"False":   testconvert.Interface(false),
+								"True":    testconvert.Interface(true),
+							},
+							DefaultRule: &flag.Rule{
+								Name:            testconvert.String("legacyDefaultRule"),
+								VariationResult: testconvert.String("Default"),
+							},
+						},
+						After: &flag.InternalFlag{
+							Rules: &[]flag.Rule{
+								{
+									Name:  testconvert.String("legacyRuleV0"),
+									Query: testconvert.String("key eq \"random-key\""),
+									Percentages: &map[string]float64{
+										"False": 0,
+										"True":  100,
+									},
+								},
+							},
+							Variations: &map[string]*interface{}{
+								"Default": testconvert.Interface(false),
+								"False":   testconvert.Interface(false),
+								"True":    testconvert.Interface(true),
+							},
+							DefaultRule: &flag.Rule{
+								Name:            testconvert.String("legacyDefaultRule"),
+								VariationResult: testconvert.String("Default"),
+							},
+							Disable: testconvert.Bool(true),
+						},
+					},
+				},
+				Added: map[string]flag.Flag{},
+			},
+			expected: "^\\[" + testutils.RFC3339Regex + "\\] flag test-flag is turned OFF",
+		},
+		{
+			name: "Add flag",
+			diff: notifier.DiffCache{
+				Deleted: map[string]flag.Flag{},
+				Updated: map[string]notifier.DiffUpdated{},
+				Added: map[string]flag.Flag{
+					"add-test-flag": &flag.InternalFlag{
+						Rules: &[]flag.Rule{
+							{
+								Name:  testconvert.String("legacyRuleV0"),
+								Query: testconvert.String("key eq \"random-key\""),
+								Percentages: &map[string]float64{
+									"False": 0,
+									"True":  100,
+								},
+							},
+						},
+						Variations: &map[string]*interface{}{
+							"Default": testconvert.Interface(false),
+							"False":   testconvert.Interface(false),
+							"True":    testconvert.Interface(true),
+						},
+						DefaultRule: &flag.Rule{
+							Name:            testconvert.String("legacyDefaultRule"),
+							VariationResult: testconvert.String("Default"),
+						},
+					},
+				},
 			},
 			expected: "^\\[" + testutils.RFC3339Regex + "\\] flag add-test-flag added",
 		},
 		{
 			name: "Enable flag",
-			args: args{
-				diff: notifier.DiffCache{
-					Deleted: map[string]flag.Flag{},
-					Updated: map[string]notifier.DiffUpdated{
-						"test-flag": {
-							After: &flag.InternalFlag{
-								Rules: &[]flag.Rule{
-									{
-										Name:  testconvert.String("legacyRuleV0"),
-										Query: testconvert.String("key eq \"random-key\""),
-										Percentages: &map[string]float64{
-											"False": 0,
-											"True":  100,
-										},
+			diff: notifier.DiffCache{
+				Deleted: map[string]flag.Flag{},
+				Updated: map[string]notifier.DiffUpdated{
+					"test-flag": {
+						After: &flag.InternalFlag{
+							Rules: &[]flag.Rule{
+								{
+									Name:  testconvert.String("legacyRuleV0"),
+									Query: testconvert.String("key eq \"random-key\""),
+									Percentages: &map[string]float64{
+										"False": 0,
+										"True":  100,
 									},
-								},
-								Variations: &map[string]*interface{}{
-									"Default": testconvert.Interface(false),
-									"False":   testconvert.Interface(false),
-									"True":    testconvert.Interface(true),
-								},
-								DefaultRule: &flag.Rule{
-									Name:            testconvert.String("legacyDefaultRule"),
-									VariationResult: testconvert.String("Default"),
 								},
 							},
-							Before: &flag.InternalFlag{
-								Rules: &[]flag.Rule{
-									{
-										Name:  testconvert.String("legacyRuleV0"),
-										Query: testconvert.String("key eq \"random-key\""),
-										Percentages: &map[string]float64{
-											"False": 0,
-											"True":  100,
-										},
-									},
-								},
-								Variations: &map[string]*interface{}{
-									"Default": testconvert.Interface(false),
-									"False":   testconvert.Interface(false),
-									"True":    testconvert.Interface(true),
-								},
-								DefaultRule: &flag.Rule{
-									Name:            testconvert.String("legacyDefaultRule"),
-									VariationResult: testconvert.String("Default"),
-								},
-								Disable: testconvert.Bool(true),
+							Variations: &map[string]*interface{}{
+								"Default": testconvert.Interface(false),
+								"False":   testconvert.Interface(false),
+								"True":    testconvert.Interface(true),
+							},
+							DefaultRule: &flag.Rule{
+								Name:            testconvert.String("legacyDefaultRule"),
+								VariationResult: testconvert.String("Default"),
 							},
 						},
+						Before: &flag.InternalFlag{
+							Rules: &[]flag.Rule{
+								{
+									Name:  testconvert.String("legacyRuleV0"),
+									Query: testconvert.String("key eq \"random-key\""),
+									Percentages: &map[string]float64{
+										"False": 0,
+										"True":  100,
+									},
+								},
+							},
+							Variations: &map[string]*interface{}{
+								"Default": testconvert.Interface(false),
+								"False":   testconvert.Interface(false),
+								"True":    testconvert.Interface(true),
+							},
+							DefaultRule: &flag.Rule{
+								Name:            testconvert.String("legacyDefaultRule"),
+								VariationResult: testconvert.String("Default"),
+							},
+							Disable: testconvert.Bool(true),
+						},
 					},
-					Added: map[string]flag.Flag{},
 				},
-				wg: &sync.WaitGroup{},
+				Added: map[string]flag.Flag{},
 			},
 			expected: "^\\[" + testutils.RFC3339Regex + "\\] flag test-flag is turned ON",
 		},
@@ -260,8 +243,7 @@ func TestLogNotifier_Notify(t *testing.T) {
 			c := &Notifier{
 				Logger: log.New(logOutput, "", 0),
 			}
-			tt.args.wg.Add(1)
-			_ = c.Notify(tt.args.diff, tt.args.wg)
+			_ = c.Notify(tt.diff)
 			log, _ := os.ReadFile(logOutput.Name())
 			assert.Regexp(t, tt.expected, string(log))
 		})

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -1,9 +1,5 @@
 package notifier
 
-import (
-	"sync"
-)
-
 type Notifier interface {
-	Notify(cache DiffCache, waitGroup *sync.WaitGroup) error
+	Notify(cache DiffCache) error
 }

--- a/notifier/slacknotifier/notifier.go
+++ b/notifier/slacknotifier/notifier.go
@@ -35,9 +35,7 @@ type Notifier struct {
 	init       sync.Once
 }
 
-func (c *Notifier) Notify(diff notifier.DiffCache, wg *sync.WaitGroup) error {
-	defer wg.Done()
-
+func (c *Notifier) Notify(diff notifier.DiffCache) error {
 	if c.SlackWebhookURL == "" {
 		return fmt.Errorf("error: (Slack Notifier) invalid notifier configuration, no " +
 			"SlackWebhookURL provided for the slack notifier")

--- a/notifier/slacknotifier/notifier_test.go
+++ b/notifier/slacknotifier/notifier_test.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -199,9 +198,7 @@ func TestSlackNotifier_Notify(t *testing.T) {
 				httpClient:      mockHTTPClient,
 			}
 
-			w := sync.WaitGroup{}
-			w.Add(1)
-			err := c.Notify(tt.args.diff, &w)
+			err := c.Notify(tt.args.diff)
 
 			if tt.expected.err {
 				assert.ErrorContains(t, err, tt.expected.errMsg)

--- a/notifier/webhooknotifier/notifier.go
+++ b/notifier/webhooknotifier/notifier.go
@@ -24,49 +24,49 @@ type webhookReqBody struct {
 
 // Notifier will call your endpoint URL with a POST request with the following format
 //
-// {
-//   "meta": {
-//     "hostname": "server01"
-//   },
-//   "flags": {
-//     "deleted": {
-//       "test-flag": {
-//         "rule": "key eq \"random-key\"",
-//         "percentage": 100,
-//         "true": true,
-//         "false": false,
-//         "default": false
-//       }
-//     },
-//     "added": {
-//       "test-flag3": {
-//         "percentage": 5,
-//         "true": "test",
-//         "false": "false",
-//         "default": "default"
-//       }
-//     },
-//     "updated": {
-//       "test-flag2": {
-//         "old_value": {
-//           "rule": "key eq \"not-a-key\"",
-//           "percentage": 100,
-//           "true": true,
-//           "false": false,
-//           "default": false
-//         },
-//         "new_value": {
-//           "disable": true,
-//           "rule": "key eq \"not-a-key\"",
-//           "percentage": 100,
-//           "true": true,
-//           "false": false,
-//           "default": false
-//         }
-//       }
-//     }
-//   }
-// }
+//	{
+//	  "meta": {
+//	    "hostname": "server01"
+//	  },
+//	  "flags": {
+//	    "deleted": {
+//	      "test-flag": {
+//	        "rule": "key eq \"random-key\"",
+//	        "percentage": 100,
+//	        "true": true,
+//	        "false": false,
+//	        "default": false
+//	      }
+//	    },
+//	    "added": {
+//	      "test-flag3": {
+//	        "percentage": 5,
+//	        "true": "test",
+//	        "false": "false",
+//	        "default": "default"
+//	      }
+//	    },
+//	    "updated": {
+//	      "test-flag2": {
+//	        "old_value": {
+//	          "rule": "key eq \"not-a-key\"",
+//	          "percentage": 100,
+//	          "true": true,
+//	          "false": false,
+//	          "default": false
+//	        },
+//	        "new_value": {
+//	          "disable": true,
+//	          "rule": "key eq \"not-a-key\"",
+//	          "percentage": 100,
+//	          "true": true,
+//	          "false": false,
+//	          "default": false
+//	        }
+//	      }
+//	    }
+//	  }
+//	}
 type Notifier struct {
 	// EndpointURL of your webhook
 	EndpointURL string
@@ -84,8 +84,7 @@ type Notifier struct {
 	init       sync.Once
 }
 
-func (c *Notifier) Notify(diff notifier.DiffCache, wg *sync.WaitGroup) error {
-	defer wg.Done()
+func (c *Notifier) Notify(diff notifier.DiffCache) error {
 	if c.EndpointURL == "" {
 		return fmt.Errorf("invalid notifier configuration, no endpointURL provided for the webhook notifier")
 	}

--- a/notifier/webhooknotifier/notifier_test.go
+++ b/notifier/webhooknotifier/notifier_test.go
@@ -262,9 +262,7 @@ func Test_webhookNotifier_Notify(t *testing.T) {
 				Headers:     tt.args.headers,
 			}
 
-			w := sync.WaitGroup{}
-			w.Add(1)
-			err := c.Notify(tt.args.diff, &w)
+			err := c.Notify(tt.args.diff)
 
 			if tt.expected.err {
 				assert.ErrorContains(t, err, tt.expected.errorMsg)
@@ -311,9 +309,7 @@ func Test_webhookNotifier_no_meta_data(t *testing.T) {
 		init:        sync.Once{},
 	}
 
-	w := sync.WaitGroup{}
-	w.Add(1)
-	err := c.Notify(diff, &w)
+	err := c.Notify(diff)
 
 	assert.NoError(t, err)
 	var m map[string]interface{}

--- a/website/docs/go_module/notifier/custom.md
+++ b/website/docs/go_module/notifier/custom.md
@@ -7,6 +7,8 @@ sidebar_position: 30
 To create a custom notifier you must have a `struct` that implements the
 [`notifier.Notifier`](https://pkg.go.dev/github.com/thomaspoignant/go-feature-flag/notifier/notifier) interface.
 
+In parameter you will receive a `notifier.DiffCache` struct that will tell you what has changed in your flag configuration.
+
 ```go
 import (
 	ffclient "github.com/thomaspoignant/go-feature-flag"
@@ -15,9 +17,7 @@ import (
 )
 
 type Notifier struct{}
-func (c *Notifier) Notify(diff notifier.DiffCache, wg *sync.WaitGroup) error {
-	defer waitGroup.Done() // don't forget this line, if you don't have it you can break your notifications
-	
+func (c *Notifier) Notify(diff notifier.DiffCache) error {
 	// ...
 	// do whatever you want here
 }


### PR DESCRIPTION
# Description
⚠️⚠️⚠️ This is a breaking change if you had custom notifiers, you will have to update them before using this version.

The previous interface for the `Notifier` was:

```go
func (n *notifierRelayProxy) Notify(diff notifier.DiffCache, waitGroup *sync.WaitGroup) error
```

As you can see we were requesting people implementing custom notifiers to take care of the `sync.WaitGroup` lifecycle.
It could be a source of bugs if the notifiers were not doing it properly.

We changed the interface to
```go
func (n *notifierRelayProxy) Notify(diff notifier.DiffCache) error
```
and now the lifecycle of the go routine is purely managed by GO Feature Flag.

# Changes include
- [x] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
