### PR TITLE
New retriever for s3 that supports go-aws-sdk-v2 SDK

### DIFF
--- a/cmd/relayproxy/service/gofeatureflag.go
+++ b/cmd/relayproxy/service/gofeatureflag.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/thomaspoignant/go-feature-flag/exporter/s3exporterv2"
 	"github.com/thomaspoignant/go-feature-flag/exporter/sqsexporter"
+	"github.com/thomaspoignant/go-feature-flag/retriever/s3retrieverv2"
 	"time"
 
 	ffclient "github.com/thomaspoignant/go-feature-flag"
@@ -22,7 +23,6 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/retriever/gitlabretriever"
 	"github.com/thomaspoignant/go-feature-flag/retriever/httpretriever"
 	"github.com/thomaspoignant/go-feature-flag/retriever/k8sretriever"
-	"github.com/thomaspoignant/go-feature-flag/retriever/s3retriever"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
 	"k8s.io/client-go/rest"
@@ -132,7 +132,8 @@ func initRetriever(c *config.RetrieverConf) (retriever.Retriever, error) {
 	case config.FileRetriever:
 		return &fileretriever.Retriever{Path: c.Path}, nil
 	case config.S3Retriever:
-		return &s3retriever.Retriever{Bucket: c.Bucket, Item: c.Item}, nil
+		awsConfig, err := awsConf.LoadDefaultConfig(context.Background())
+		return &s3retrieverv2.Retriever{Bucket: c.Bucket, Item: c.Item, AwsConfig: &awsConfig}, err
 	case config.HTTPRetriever:
 		return &httpretriever.Retriever{
 			URL: c.URL,

--- a/retriever/s3retriever/retriever.go
+++ b/retriever/s3retriever/retriever.go
@@ -13,6 +13,7 @@ import (
 )
 
 // Retriever is a configuration struct for a S3 retriever.
+// Deprecated: use s3retrieverv2.Retriever instead.
 type Retriever struct {
 	// Bucket is the name of your S3 Bucket.
 	Bucket string

--- a/retriever/s3retrieverv2/downloader_api.go
+++ b/retriever/s3retrieverv2/downloader_api.go
@@ -1,0 +1,14 @@
+package s3retrieverv2
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"io"
+)
+
+// DownloaderAPI provides methods to manage downloads to an S3 bucket.
+type DownloaderAPI interface {
+	Download(ctx context.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*manager.Downloader)) (
+		n int64, err error)
+}

--- a/retriever/s3retrieverv2/retriever.go
+++ b/retriever/s3retrieverv2/retriever.go
@@ -1,0 +1,78 @@
+package s3retrieverv2
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"os"
+	"sync"
+)
+
+// Retriever is a configuration struct for a S3 retriever.
+type Retriever struct {
+	// Bucket is the name of your S3 Bucket.
+	Bucket string
+
+	// Item is the path to your flag file in your bucket.
+	Item string
+
+	// AwsConfig is the AWS SDK configuration object we will use to
+	// download your feature flag configuration file.
+	AwsConfig *aws.Config
+
+	// downloader is an internal field, it is the downloader use by the AWS-SDK
+	downloader DownloaderAPI
+	init       sync.Once
+}
+
+func (s *Retriever) Retrieve(ctx context.Context) ([]byte, error) {
+	if s.downloader == nil {
+		initErr := s.initializeDownloader(ctx)
+		if initErr != nil {
+			return nil, initErr
+		}
+	}
+
+	// Download the item from the bucket.
+	// If an error occurs, log it and exit.
+	// Otherwise, notify the user that the download succeeded.
+	file, err := os.CreateTemp("", "go_feature_flag")
+	if err != nil {
+		return nil, err
+	}
+
+	s3Req := &s3.GetObjectInput{
+		Bucket: aws.String(s.Bucket),
+		Key:    aws.String(s.Item),
+	}
+	_, err = s.downloader.Download(ctx, file, s3Req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to download item from S3 %q, %v", s.Item, err)
+	}
+	// Read file content
+	content, err := os.ReadFile(file.Name())
+	if err != nil {
+		return nil, err
+	}
+	return content, nil
+}
+
+func (s *Retriever) initializeDownloader(ctx context.Context) error {
+	var initErr error
+	s.init.Do(func() {
+		if s.AwsConfig == nil {
+			cfg, err := config.LoadDefaultConfig(ctx)
+			if err != nil {
+				initErr = fmt.Errorf("impossible to init S3 retriever: %v", err)
+				return
+			}
+			s.AwsConfig = &cfg
+		}
+		client := s3.NewFromConfig(*s.AwsConfig)
+		s.downloader = manager.NewDownloader(client)
+	})
+	return initErr
+}

--- a/retriever/s3retrieverv2/retriever_test.go
+++ b/retriever/s3retrieverv2/retriever_test.go
@@ -1,0 +1,80 @@
+package s3retrieverv2
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/testutils"
+	"os"
+	"testing"
+)
+
+func Test_s3Retriever_Retrieve(t *testing.T) {
+	type fields struct {
+		downloader DownloaderAPI
+		bucket     string
+		item       string
+		context    context.Context
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "File on S3",
+			fields: fields{
+				downloader: &testutils.S3ManagerV2Mock{
+					TestDataLocation: "./testdata",
+				},
+				bucket: "Bucket",
+				item:   "valid",
+			},
+			want:    "./testdata/flag-config.yaml",
+			wantErr: false,
+		},
+		{
+			name: "File not present S3",
+			fields: fields{
+				downloader: &testutils.S3ManagerV2Mock{
+					TestDataLocation: "./testdata",
+				},
+				bucket: "Bucket",
+				item:   "no-file",
+			},
+			wantErr: true,
+		},
+		{
+			name: "File on S3 with context",
+			fields: fields{
+				downloader: &testutils.S3ManagerV2Mock{
+					TestDataLocation: "./testdata",
+				},
+				bucket:  "Bucket",
+				item:    "valid",
+				context: context.Background(),
+			},
+			want:    "./testdata/flag-config.yaml",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			awsConf, _ := config.LoadDefaultConfig(context.TODO())
+			s := Retriever{
+				Bucket:     tt.fields.bucket,
+				Item:       tt.fields.item,
+				AwsConfig:  &awsConf,
+				downloader: tt.fields.downloader,
+			}
+			got, err := s.Retrieve(tt.fields.context)
+			assert.Equal(t, tt.wantErr, err != nil, "Retrieve() error = %v, wantErr %v", err, tt.wantErr)
+			if err == nil {
+				want, err := os.ReadFile(tt.want)
+				assert.NoError(t, err)
+				assert.Equal(t, string(want), string(got), "Retrieve() got = %v, want %v", string(want), string(got))
+			}
+		})
+	}
+}

--- a/retriever/s3retrieverv2/testdata/flag-config.yaml
+++ b/retriever/s3retrieverv2/testdata/flag-config.yaml
@@ -1,0 +1,13 @@
+test-flag:
+  rule: key eq "random-key"
+  percentage: 100
+  true: true
+  false: false
+  default: false
+
+test-flag2:
+  rule: key eq "not-a-key"
+  percentage: 100
+  true: true
+  false: false
+  default: false

--- a/testutils/s3managerv2_mock.go
+++ b/testutils/s3managerv2_mock.go
@@ -7,11 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"io"
+	"os"
 	"strings"
 )
 
 type S3ManagerV2Mock struct {
 	S3ManagerMockFileSystem map[string]string
+	TestDataLocation        string
 }
 
 func (s *S3ManagerV2Mock) Upload(ctx context.Context, uploadInput *s3.PutObjectInput, opts ...func(uploader *manager.Uploader)) (*manager.UploadOutput, error) {
@@ -33,4 +35,16 @@ func (s *S3ManagerV2Mock) Upload(ctx context.Context, uploadInput *s3.PutObjectI
 	return &manager.UploadOutput{
 		Location: *uploadInput.Key,
 	}, nil
+}
+
+func (s *S3ManagerV2Mock) Download(ctx context.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*manager.Downloader)) (n int64, err error) {
+	if *input.Key == "valid" {
+		res, _ := os.ReadFile(s.TestDataLocation + "/flag-config.yaml")
+		_, _ = w.WriteAt(res, 0)
+		return 1, nil
+	} else if *input.Key == "no-file" {
+		return 0, errors.New("no file")
+	}
+
+	return 1, nil
 }

--- a/website/docs/go_module/store_file/s3.md
+++ b/website/docs/go_module/store_file/s3.md
@@ -7,14 +7,13 @@ The [**S3Retriever**](https://pkg.go.dev/github.com/thomaspoignant/go-feature-fl
 
 ## Example
 ```go linenums="1"
+awsConfig, _ := config.LoadDefaultConfig(context.Background())
 err := ffclient.Init(ffclient.Config{
     PollingInterval: 3 * time.Second,
-    Retriever: &s3retriever.Retriever{
+    Retriever: &s3retrieverv2.Retriever{
         Bucket: "tpoi-test",
         Item:   "flag-config.yaml",
-        AwsConfig: aws.Config{
-            Region: aws.String("eu-west-1"),
-        },
+        AwsConfig: &awsCOnfig,
     },
 })
 defer ffclient.Close()
@@ -23,8 +22,8 @@ defer ffclient.Close()
 ## Configuration fields
 To configure your S3 file location:
 
-| Field | Description |
-|---|---|
-|**`Bucket`**| The name of your bucket.|
-|**`Item`**| The location of your file in the bucket.|
-|**`AwsConfig`**| An instance of `aws.Config` that configure your access to AWS <br/>*check [this documentation for more info](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html)*.|
+| Field           | Description                                                                                                                                                                                    |
+|-----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **`Bucket`**    | The name of your bucket.                                                                                                                                                                       |
+| **`Item`**      | The location of your file in the bucket.                                                                                                                                                       |
+| **`AwsConfig`** | An instance of `aws.Config` that configure your access to AWS <br/>*check [this documentation for more info](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html)*. |

--- a/website/docs/openfeature_sdk/server_providers/openfeature_javascript.mdx
+++ b/website/docs/openfeature_sdk/server_providers/openfeature_javascript.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 51
-title: Javascript / Typescript
+title: Node.js
 description: How to use the OpenFeature Javascript SDK
 ---
 import Tabs from '@theme/Tabs';
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 
 
-# Javascript / Typescript SDK usage
+# Node.js
 
 ## Install dependencies
 
@@ -33,7 +33,7 @@ npm i @openfeature/js-sdk @openfeature/go-feature-flag-provider
 
 ## Initialize your Open Feature client
 
-To evaluate the flags you need to have an Open Feature configured in you app.
+To evaluate the flags you need to have an Open Feature configured in your app.
 This code block shows you how you can create a client that you can use in your application.
 
 <Tabs groupId="code">
@@ -74,10 +74,10 @@ const featureFlagClient = OpenFeature.getClient('my-app');
 
 ## Evaluate your flag
 
-This code block explain how you can create an `EvaluationContext` and use it to evaluate your flag.
+This code block explains how you can create an `EvaluationContext` and use it to evaluate your flag.
 
 :::note
-In this example we are evaluating a `boolean` flag, but other types are available.
+In this example, we are evaluating a `boolean` flag, but other types are available.
 
 **Refer to the [Open Feature documentation](https://docs.openfeature.dev/docs/reference/concepts/evaluation-api#basic-evaluation) to know more about it.**
 :::


### PR DESCRIPTION
# Description
New exporter for s3 that supports go-aws-sdk-v2 SDK.
To avoid breaking actual integrations we are introducing a `v2` for the exporter, to use it please use `s3retrieverv2.Retriever` rather than `s3retriever.Retriever`.

We have also deprecated the `s3retriever.Retriever` and updated the documentation to recommend using `v2`.


# Changes include
- [x] New feature (non-breaking change that adds functionality)

# Closes issue(s)
Resolve #987

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
