### PR TITLE
Deactivate java integration test

### DIFF
--- a/openfeature/provider_tests/integration_tests.sh
+++ b/openfeature/provider_tests/integration_tests.sh
@@ -31,7 +31,7 @@ wait_relay_proxy 1032
 echo "------------------------------------------------------------------------------------------------"
 echo "----------- JAVA PROVIDER TESTS ----------------------------------------------------------------"
 echo "------------------------------------------------------------------------------------------------"
-mvn -f $(pwd)/openfeature/provider_tests/java-integration-tests/pom.xml test
+# mvn -f $(pwd)/openfeature/provider_tests/java-integration-tests/pom.xml test
 
 # Launch js integration tests
 echo "------------------------------------------------------------------------------------------------"


### PR DESCRIPTION
# Description
We have an issue because of a bug in the java SDK, we have to deactivate the test.
Please follow this issue https://github.com/open-feature/java-sdk/issues/552 when resolved we can reactivate the tests.


# Changes include
- [x] Breaking changes (change that is not backward-compatible and/or changes current functionality)

