### PR TITLE
Bump go to 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.18.0'
+          go-version: '^1.19.0'
       - run: make vendor
       - run: make build
   Lint:
@@ -32,7 +32,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.18.0'
+          go-version: '^1.19.0'
       - run: make lint
 
   Test:
@@ -46,7 +46,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.18.0'
+          go-version: '^1.19.0'
       - run: make test
 
   Coverage:
@@ -60,7 +60,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.18.0'
+          go-version: '^1.19.0'
       - run: make coverage
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
@@ -77,7 +77,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.18.0'
+          go-version: '^1.19.0'
       - run: make swagger
       - run: git diff --exit-code --quiet
 
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.18.0'
+          go-version: '^1.19.0'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
@@ -110,7 +110,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.18.0'
+          go-version: '^1.19.0'
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5
         with:
@@ -135,7 +135,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.18.0'
+          go-version: '^1.19.0'
       - name: Run benchmark
         run: make bench | tee bench-output.txt
       - name: Download previous benchmark data

--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '>=1.17.0'
+          go-version: '>=1.19.0'
 
       - name: Update chart README
         if: steps.changed-files-specific.outputs.any_changed == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.18.0'
+          go-version: '^1.19.0'
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.5
         with:
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.18.0'
+          go-version: '^1.19.0'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -291,7 +291,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.18.0'
+          go-version: '^1.19.0'
 
       - name: Build jsonschema-generator
         working-directory: ./release/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thomaspoignant/go-feature-flag
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/storage v1.33.0

--- a/openfeature/provider_tests/go-integration-tests/go.mod
+++ b/openfeature/provider_tests/go-integration-tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/thomaspoignant/go-feature-flag/openfeature/provider_tests/go-integration-tests
 
-go 1.20
+go 1.19
 
 require (
 	github.com/open-feature/go-sdk v1.8.0


### PR DESCRIPTION
# Description
Following the deprecation [policy](https://go.dev/doc/devel/release#policy) of go, `1.18` is not supported, we are following the policy and bump everything to `1.19`.

# Checklist
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
