### PR TITLE
Fix confusion in RetrieverConf's struct tag declaration

### DIFF
--- a/cmd/relayproxy/config/retriever.go
+++ b/cmd/relayproxy/config/retriever.go
@@ -16,7 +16,7 @@ type RetrieverConf struct {
 	HTTPBody    string              `mapstructure:"body" koanf:"body"`
 	HTTPHeaders map[string][]string `mapstructure:"headers" koanf:"headers"`
 	Bucket      string              `mapstructure:"bucket" koanf:"bucket"`
-	Object      string              `mapstructure:"bucket" koanf:"bucket"`
+	Object      string              `mapstructure:"object" koanf:"object"`
 	Item        string              `mapstructure:"item" koanf:"item"`
 	Namespace   string              `mapstructure:"namespace" koanf:"namespace"`
 	ConfigMap   string              `mapstructure:"configmap" koanf:"configmap"`


### PR DESCRIPTION
# Description
<!-- 
Please add a description of what your pull request is doing.
 - What was the problem?
 - How it is resolved?
 - How can we test the change?
 - If there are breaking changes, please describe them in detail and why we cannot avoid them.
-->
In the struct tag declaration of RetrieverConf's Object field, which is being mistaken for `bucket`, the correct value should be `object`.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #1265

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
