### PR TITLE
Fix documentation Openfeature server sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ _In this example, we are using the javascript SDK, but it is still relevant for 
 #### Install dependencies
 
 ```shell
-npm i @openfeature/js-sdk @openfeature/go-feature-flag-provider
+npm i @openfeature/server-sdk @openfeature/go-feature-flag-provider
 ```
 
 #### Init your Open Feature client
@@ -208,7 +208,7 @@ npm i @openfeature/js-sdk @openfeature/go-feature-flag-provider
 In your app initialization you have to create a client using the Open Feature SDK and initialize it.
 
 ```javascript
-const {OpenFeature} = require("@openfeature/js-sdk");
+const {OpenFeature} = require("@openfeature/server-sdk");
 const {GoFeatureFlagProvider} = require("@openfeature/go-feature-flag-provider");
 
 

--- a/openfeature/provider_tests/js-integration-tests/provider.test.js
+++ b/openfeature/provider_tests/js-integration-tests/provider.test.js
@@ -1,5 +1,5 @@
 const {describe, expect, it, beforeEach, afterEach } = require('@jest/globals');
-const {OpenFeature} = require("@openfeature/js-sdk");
+const {OpenFeature} = require("@openfeature/server-sdk");
 const {GoFeatureFlagProvider} = require("@openfeature/go-feature-flag-provider");
 describe('Provider tests', () => {
   let goffClient;

--- a/website/docs/openfeature_sdk/server_providers/openfeature_javascript.mdx
+++ b/website/docs/openfeature_sdk/server_providers/openfeature_javascript.mdx
@@ -18,14 +18,14 @@ The first things we will do is install the **Open Feature SDK** and the **GO Fea
   <TabItem value="yarn" label="yarn">
 
 ```shell
-yarn add @openfeature/js-sdk @openfeature/go-feature-flag-provider
+yarn add @openfeature/server-sdk @openfeature/go-feature-flag-provider
 ```
 
   </TabItem>
   <TabItem value="npm" label="npm">
 
 ```shell
-npm i @openfeature/js-sdk @openfeature/go-feature-flag-provider
+npm i @openfeature/server-sdk @openfeature/go-feature-flag-provider
 ```
 
   </TabItem>
@@ -40,7 +40,7 @@ This code block shows you how you can create a client that you can use in your a
   <TabItem value="javascript" label="JavaScript">
 
 ```javascript
-const {OpenFeature} = require("@openfeature/js-sdk");
+const {OpenFeature} = require("@openfeature/server-sdk");
 const {GoFeatureFlagProvider} = require("@openfeature/go-feature-flag-provider");
 
 
@@ -57,7 +57,7 @@ const featureFlagClient = OpenFeature.getClient('my-app')
   <TabItem value="ts" label="TypeScript">
 
 ```typescript
-import {EvaluationContext, OpenFeature} from "@openfeature/js-sdk";
+import {EvaluationContext, OpenFeature} from "@openfeature/server-sdk";
 import {GoFeatureFlagProvider} from  "@openfeature/go-feature-flag-provider";
 
 

--- a/website/versioned_docs/version-v1.0.0/getting_started/using-openfeature.md
+++ b/website/versioned_docs/version-v1.0.0/getting_started/using-openfeature.md
@@ -75,7 +75,7 @@ _In this example we are using the javascript SDK, but it is still relevant for a
 ### Install dependencies
 
 ```shell
-npm i @openfeature/js-sdk @openfeature/go-feature-flag-provider
+npm i @openfeature/server-sdk @openfeature/go-feature-flag-provider
 ```
 
 ### Init your Open Feature client
@@ -83,7 +83,7 @@ npm i @openfeature/js-sdk @openfeature/go-feature-flag-provider
 In your app initialization your have to create a client using the Open Feature SDK and initialize it.
 
 ```javascript
-const {OpenFeature} = require("@openfeature/js-sdk");
+const {OpenFeature} = require("@openfeature/server-sdk");
 const {GoFeatureFlagProvider} = require("@openfeature/go-feature-flag-provider");
 
 

--- a/website/versioned_docs/version-v1.0.0/openfeature_sdk/openfeature_javascript.mdx
+++ b/website/versioned_docs/version-v1.0.0/openfeature_sdk/openfeature_javascript.mdx
@@ -17,14 +17,14 @@ The first things we will do is install the **Open Feature SDK** and the **GO Fea
   <TabItem value="yarn" label="yarn">
 
 ```shell
-yarn add @openfeature/js-sdk @openfeature/go-feature-flag-provider
+yarn add @openfeature/server-sdk @openfeature/go-feature-flag-provider
 ```
 
   </TabItem>
   <TabItem value="npm" label="npm">
 
 ```shell
-npm i @openfeature/js-sdk @openfeature/go-feature-flag-provider
+npm i @openfeature/server-sdk @openfeature/go-feature-flag-provider
 ```
 
   </TabItem>


### PR DESCRIPTION
# Description
OpenFeature has changed package name from `js-sdk` to `server-sdk`, updating the documentation.

# Checklist
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
