### PR TITLE
fix(relay-proxy): When converting the context int where seen as float

### DIFF
--- a/cmd/editor/main.go
+++ b/cmd/editor/main.go
@@ -47,7 +47,7 @@ func EvaluateHandler(c echo.Context) error {
 	f := u.Flag.Convert()
 	value, resolutionDetails := f.Value(
 		u.FlagName,
-		utils.ConvertEvaluationCtxFromReq(u.Context.Key, u.Context.Custom),
+		utils.ConvertEvaluationCtxFromRequest(u.Context.Key, u.Context.Custom),
 		flag.Context{
 			DefaultSdkValue: nil,
 		},

--- a/cmd/editor/main.go
+++ b/cmd/editor/main.go
@@ -5,9 +5,9 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	custommiddleware "github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api/middleware"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/log"
-	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/internal/dto"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
+	"github.com/thomaspoignant/go-feature-flag/internal/utils"
 	"github.com/thomaspoignant/go-feature-flag/model"
 	"net/http"
 )
@@ -37,16 +37,6 @@ func main() {
 	e.Logger.Fatal(e.Start(":1323"))
 }
 
-func (c *ContextWrapper) toEvaluationContext() ffcontext.Context {
-	evalCtx := ffcontext.NewEvaluationContext(c.Key)
-	if c.Custom != nil {
-		for k, v := range c.Custom {
-			evalCtx.AddCustomAttribute(k, v)
-		}
-	}
-	return evalCtx
-}
-
 // EvaluateHandler is the function called when calling the endpoint /v1/feature/evaluate.
 // It will perform a flag evaluation and return the resolutionDetails and the value.
 func EvaluateHandler(c echo.Context) error {
@@ -57,7 +47,7 @@ func EvaluateHandler(c echo.Context) error {
 	f := u.Flag.Convert()
 	value, resolutionDetails := f.Value(
 		u.FlagName,
-		u.Context.toEvaluationContext(),
+		utils.ConvertEvaluationCtxFromReq(u.Context.Key, u.Context.Custom),
 		flag.Context{
 			DefaultSdkValue: nil,
 		},

--- a/cmd/relayproxy/controller/utils.go
+++ b/cmd/relayproxy/controller/utils.go
@@ -41,7 +41,7 @@ func evaluationContextFromRequest(req *model.AllFlagRequest) (ffcontext.Context,
 	}
 	if req.EvaluationContext != nil {
 		u := req.EvaluationContext
-		return utils.ConvertEvaluationCtxFromReq(u.Key, u.Custom), nil
+		return utils.ConvertEvaluationCtxFromRequest(u.Key, u.Custom), nil
 	}
 	return userRequestToUser(req.User) // nolint: staticcheck
 }
@@ -53,5 +53,5 @@ func userRequestToUser(u *model.UserRequest) (ffcontext.Context, error) {
 		return ffcontext.EvaluationContext{}, fmt.Errorf("userRequestToUser: impossible to convert user, userRequest nil")
 	}
 	u.Custom["anonymous"] = u.Anonymous
-	return utils.ConvertEvaluationCtxFromReq(u.Key, u.Custom), nil
+	return utils.ConvertEvaluationCtxFromRequest(u.Key, u.Custom), nil
 }

--- a/cmd/relayproxy/controller/utils.go
+++ b/cmd/relayproxy/controller/utils.go
@@ -3,7 +3,7 @@ package controller
 import (
 	"fmt"
 	"github.com/thomaspoignant/go-feature-flag/ffcontext"
-	"github.com/thomaspoignant/go-feature-flag/ffuser"
+	"github.com/thomaspoignant/go-feature-flag/internal/utils"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -41,27 +41,17 @@ func evaluationContextFromRequest(req *model.AllFlagRequest) (ffcontext.Context,
 	}
 	if req.EvaluationContext != nil {
 		u := req.EvaluationContext
-		ctx := ffcontext.NewEvaluationContextBuilder(u.Key)
-		for key, val := range u.Custom {
-			ctx.AddCustom(key, val)
-		}
-		return ctx.Build(), nil
+		return utils.ConvertEvaluationCtxFromReq(u.Key, u.Custom), nil
 	}
 	return userRequestToUser(req.User) // nolint: staticcheck
 }
 
 // userRequestToUser convert a user from the request model.AllFlagRequest to a go-feature-flag ffuser.User
 // nolint: staticcheck
-func userRequestToUser(u *model.UserRequest) (ffuser.User, error) {
+func userRequestToUser(u *model.UserRequest) (ffcontext.Context, error) {
 	if u == nil {
-		// nolint: staticcheck
-		return ffuser.User{}, fmt.Errorf("userRequestToUser: impossible to convert user, userRequest nil")
+		return ffcontext.EvaluationContext{}, fmt.Errorf("userRequestToUser: impossible to convert user, userRequest nil")
 	}
-
-	uBuilder := ffuser.NewUserBuilder(u.Key).Anonymous(u.Anonymous) // nolint: staticcheck
-	for key, val := range u.Custom {
-		uBuilder.AddCustom(key, val)
-	}
-	user := uBuilder.Build()
-	return user, nil
+	u.Custom["anonymous"] = u.Anonymous
+	return utils.ConvertEvaluationCtxFromReq(u.Key, u.Custom), nil
 }

--- a/cmd/relayproxy/controller/utils_test.go
+++ b/cmd/relayproxy/controller/utils_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/model"
 	"github.com/thomaspoignant/go-feature-flag/ffcontext"
-	"github.com/thomaspoignant/go-feature-flag/ffuser"
 	"net/http"
 	"testing"
 )
@@ -128,7 +127,10 @@ func Test_evaluationContextFromRequest(t *testing.T) {
 					},
 				},
 			},
-			want: ffuser.NewUserBuilder("key-1").Anonymous(false).AddCustom("custom-field", true).Build(),
+			want: ffcontext.NewEvaluationContextBuilder("key-1").
+				AddCustom("anonymous", false).
+				AddCustom("custom-field", true).
+				Build(),
 		},
 	}
 

--- a/ffcontext/context_builder.go
+++ b/ffcontext/context_builder.go
@@ -29,7 +29,7 @@ type evaluationContextBuilderImpl struct {
 }
 
 // Deprecated: Anonymous is to flag the context for an anonymous context or not.
-// This function is here for compatibility reason, please consider to use AddCustom("anonymous", true)
+// This function is here for compatibility reason, please consider using AddCustom("anonymous", true)
 // instead of using this function.
 func (u *evaluationContextBuilderImpl) Anonymous(anonymous bool) EvaluationContextBuilder {
 	u.custom["anonymous"] = anonymous

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/xitongsys/parquet-go-source v0.0.0-20230830030807-0dd610dbff1d
 	go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.46.1
 	go.opentelemetry.io/otel v1.21.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0
 	go.opentelemetry.io/otel/sdk v1.21.0
 	go.uber.org/zap v1.26.0
@@ -144,7 +145,6 @@ require (
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect

--- a/internal/utils/evaluation_ctx_converter.go
+++ b/internal/utils/evaluation_ctx_converter.go
@@ -2,11 +2,11 @@ package utils
 
 import "github.com/thomaspoignant/go-feature-flag/ffcontext"
 
-// ConvertEvaluationCtxFromReq convert a request to a ffcontext.Context
+// ConvertEvaluationCtxFromRequest convert the result of an unmarshal request from the API to a ffcontext.Context
 // @param targetingKey the targeting key to use for the context
 // @param custom the custom attributes to add to the context
 // @return ffcontext.Context
-func ConvertEvaluationCtxFromReq(targetingKey string, custom map[string]interface{}) ffcontext.Context {
+func ConvertEvaluationCtxFromRequest(targetingKey string, custom map[string]interface{}) ffcontext.Context {
 	ctx := ffcontext.NewEvaluationContextBuilder(targetingKey)
 	for k, v := range custom {
 		switch val := v.(type) {

--- a/internal/utils/evaluation_ctx_converter.go
+++ b/internal/utils/evaluation_ctx_converter.go
@@ -1,0 +1,24 @@
+package utils
+
+import "github.com/thomaspoignant/go-feature-flag/ffcontext"
+
+// ConvertEvaluationCtxFromReq convert a request to a ffcontext.Context
+// @param targetingKey the targeting key to use for the context
+// @param custom the custom attributes to add to the context
+// @return ffcontext.Context
+func ConvertEvaluationCtxFromReq(targetingKey string, custom map[string]interface{}) ffcontext.Context {
+	ctx := ffcontext.NewEvaluationContextBuilder(targetingKey)
+	for k, v := range custom {
+		switch val := v.(type) {
+		case float64:
+			if IsIntegral(val) {
+				ctx.AddCustom(k, int(val))
+				continue
+			}
+			ctx.AddCustom(k, val)
+		default:
+			ctx.AddCustom(k, val)
+		}
+	}
+	return ctx.Build()
+}

--- a/internal/utils/evaluation_ctx_converter_test.go
+++ b/internal/utils/evaluation_ctx_converter_test.go
@@ -1,0 +1,70 @@
+package utils_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
+	"github.com/thomaspoignant/go-feature-flag/internal/utils"
+	"testing"
+)
+
+func Test_ConvertEvaluationCtxFromReq(t *testing.T) {
+	type fields struct {
+		Key    string
+		Custom map[string]interface{}
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   ffcontext.Context
+	}{
+		{
+			name: "simple case",
+			fields: fields{
+				Key: "2323f37b-eef7-4bbc-856f-7d16c67de3ae",
+				Custom: map[string]interface{}{
+					"company_name": "go feature flag",
+				},
+			},
+			want: ffcontext.
+				NewEvaluationContextBuilder("2323f37b-eef7-4bbc-856f-7d16c67de3ae").
+				AddCustom("company_name", "go feature flag").
+				Build(),
+		},
+		{
+			name: "should return a float if the value is a float",
+			fields: fields{
+				Key: "2323f37b-eef7-4bbc-856f-7d16c67de3ae",
+				Custom: map[string]interface{}{
+					"company_name": "go feature flag",
+					"company_id":   1.1,
+				},
+			},
+			want: ffcontext.
+				NewEvaluationContextBuilder("2323f37b-eef7-4bbc-856f-7d16c67de3ae").
+				AddCustom("company_name", "go feature flag").
+				AddCustom("company_id", 1.1).
+				Build(),
+		},
+		{
+			name: "should return an int if the value is a float but without decimal",
+			fields: fields{
+				Key: "2323f37b-eef7-4bbc-856f-7d16c67de3ae",
+				Custom: map[string]interface{}{
+					"company_name": "go feature flag",
+					"company_id":   1.0,
+				},
+			},
+			want: ffcontext.
+				NewEvaluationContextBuilder("2323f37b-eef7-4bbc-856f-7d16c67de3ae").
+				AddCustom("company_name", "go feature flag").
+				AddCustom("company_id", 1).
+				Build(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := utils.ConvertEvaluationCtxFromReq(tt.fields.Key, tt.fields.Custom)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/utils/evaluation_ctx_converter_test.go
+++ b/internal/utils/evaluation_ctx_converter_test.go
@@ -63,7 +63,7 @@ func Test_ConvertEvaluationCtxFromReq(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := utils.ConvertEvaluationCtxFromReq(tt.fields.Key, tt.fields.Custom)
+			got := utils.ConvertEvaluationCtxFromRequest(tt.fields.Key, tt.fields.Custom)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/utils/number_utils.go
+++ b/internal/utils/number_utils.go
@@ -1,0 +1,6 @@
+package utils
+
+// IsIntegral returns true if the float is an integer.
+func IsIntegral(val float64) bool {
+	return val == float64(int64(val))
+}

--- a/internal/utils/number_utils_test.go
+++ b/internal/utils/number_utils_test.go
@@ -1,0 +1,39 @@
+package utils_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/internal/utils"
+	"testing"
+)
+
+func TestIsIntegral(t *testing.T) {
+	type args struct {
+		val float64
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "1.0 is an integer",
+			args: args{
+				val: 1.0,
+			},
+			want: true,
+		},
+		// check that 1.1 is not an integer
+		{
+			name: "1.1 is not an integer",
+			args: args{
+				val: 1.1,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, utils.IsIntegral(tt.args.val), "IsIntegral(%v)", tt.args.val)
+		})
+	}
+}


### PR DESCRIPTION
# Description
When converting the evaluation context int fields where seen as float, which result to some errors when building rules.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Closes issue(s)
Resolve #1338

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
