### PR TITLE
[BUGFIX] Helm conditional for HPA K8s API version

### DIFF
--- a/cmd/relayproxy/helm-charts/relay-proxy/templates/hpa.yaml
+++ b/cmd/relayproxy/helm-charts/relay-proxy/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta1" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "relay-proxy.fullname" . }}


### PR DESCRIPTION
# Description
`autoscaling/v2beta1` is deprecated in K8s v1.25 and should be replaced with `autoscaling/v2` since K8s v1.23. This change adds Helm conditional to check whether K8s API supports newer version and use it in the rendered template if possible.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
