### PR TITLE
(feature) Passing the Evaluated Rule Name to the Metadata

### DIFF
--- a/cmd/editor/main.go
+++ b/cmd/editor/main.go
@@ -59,21 +59,9 @@ func EvaluateHandler(c echo.Context) error {
 		ErrorCode:     resolutionDetails.ErrorCode,
 		Failed:        resolutionDetails.ErrorCode != "",
 		Cacheable:     resolutionDetails.Cacheable,
-		Metadata:      constructMetadata(f, resolutionDetails),
+		Metadata:      f.GetMetadata(),
 	}
 	return c.JSON(http.StatusOK, resp)
-}
-
-func constructMetadata(f flag.InternalFlag, resolutionDetails flag.ResolutionDetails) map[string]interface{} {
-	metadata := f.GetMetadata()
-	if resolutionDetails.RuleName == nil || *resolutionDetails.RuleName == "" {
-		return metadata
-	}
-	if metadata == nil {
-		metadata = make(map[string]interface{})
-	}
-	metadata["evaluatedRuleName"] = resolutionDetails.RuleName
-	return metadata
 }
 
 // HealthHandler endpoint to validate that the service is up and running.

--- a/cmd/editor/main.go
+++ b/cmd/editor/main.go
@@ -59,9 +59,21 @@ func EvaluateHandler(c echo.Context) error {
 		ErrorCode:     resolutionDetails.ErrorCode,
 		Failed:        resolutionDetails.ErrorCode != "",
 		Cacheable:     resolutionDetails.Cacheable,
-		Metadata:      f.GetMetadata(),
+		Metadata:      constructMetadata(f, resolutionDetails),
 	}
 	return c.JSON(http.StatusOK, resp)
+}
+
+func constructMetadata(f flag.InternalFlag, resolutionDetails flag.ResolutionDetails) map[string]interface{} {
+	metadata := f.GetMetadata()
+	if resolutionDetails.RuleName == nil || *resolutionDetails.RuleName == "" {
+		return metadata
+	}
+	if metadata == nil {
+		metadata = make(map[string]interface{})
+	}
+	metadata["evaluatedRuleName"] = resolutionDetails.RuleName
+	return metadata
 }
 
 // HealthHandler endpoint to validate that the service is up and running.

--- a/cmd/relayproxy/testdata/controller/flag_eval/rule_apply_false_response.json
+++ b/cmd/relayproxy/testdata/controller/flag_eval/rule_apply_false_response.json
@@ -8,5 +8,8 @@
   "value": {
     "test3": "test"
   },
-  "cacheable": true
+  "cacheable": true,
+  "metadata": {
+    "evaluatedRuleName": "legacyRuleV0"
+  }
 }

--- a/cmd/relayproxy/testdata/controller/flag_eval/rule_apply_response.json
+++ b/cmd/relayproxy/testdata/controller/flag_eval/rule_apply_response.json
@@ -8,5 +8,8 @@
   "value": {
     "test2": "test"
   },
-  "cacheable": true
+  "cacheable": true,
+  "metadata": {
+    "evaluatedRuleName": "legacyRuleV0"
+  }
 }

--- a/variation.go
+++ b/variation.go
@@ -460,6 +460,21 @@ func getVariation[T model.JSONType](
 		TrackEvents:   f.IsTrackEvents(),
 		Version:       f.GetVersion(),
 		Cacheable:     resolutionDetails.Cacheable,
-		Metadata:      f.GetMetadata(),
+		Metadata:      constructMetadata(f, resolutionDetails),
 	}, nil
+}
+
+// constructMetadata is the internal generic func used to enhance model.VariationResult adding
+// the targeting.rule's name (from configuration) to the Metadata.
+// That way, it is possible to see when a targeting rule is match during the evaluation process.
+func constructMetadata(f flag.Flag, resolutionDetails flag.ResolutionDetails) map[string]interface{} {
+	metadata := f.GetMetadata()
+	if resolutionDetails.RuleName == nil || *resolutionDetails.RuleName == "" {
+		return metadata
+	}
+	if metadata == nil {
+		metadata = make(map[string]interface{})
+	}
+	metadata["evaluatedRuleName"] = *resolutionDetails.RuleName
+	return metadata
 }

--- a/variation_test.go
+++ b/variation_test.go
@@ -502,6 +502,89 @@ func TestBoolVariationDetails(t *testing.T) {
 				Value:         true,
 				TrackEvents:   true,
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
+			},
+			wantErr:     false,
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"true\", variation=\"True\"\n",
+		},
+		{
+			name: "Get rule name on metadata, rule apply",
+			args: args{
+				flagKey:      "test-flag",
+				user:         ffcontext.NewAnonymousEvaluationContext("random-key"),
+				defaultValue: true,
+				cacheMock: NewCacheMock(&flag.InternalFlag{
+					Rules: &[]flag.Rule{
+						{
+							Name:  testconvert.String("legacyRuleV0"),
+							Query: testconvert.String("key eq \"random-key\""),
+							Percentages: &map[string]float64{
+								"False": 0,
+								"True":  100,
+							},
+						},
+					},
+					Variations: &map[string]*interface{}{
+						"Default": testconvert.Interface(false),
+						"False":   testconvert.Interface(false),
+						"True":    testconvert.Interface(true),
+					},
+					DefaultRule: &flag.Rule{
+						Name:            testconvert.String("legacyDefaultRule"),
+						VariationResult: testconvert.String("Default"),
+					},
+				}, nil),
+			},
+			want: model.VariationResult[bool]{
+				VariationType: "True",
+				Failed:        false,
+				Reason:        flag.ReasonTargetingMatch,
+				Value:         true,
+				TrackEvents:   true,
+				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
+			},
+			wantErr:     false,
+			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"true\", variation=\"True\"\n",
+		},
+		{
+			name: "Get no rule name on metadata, rule apply has not name",
+			args: args{
+				flagKey:      "test-flag",
+				user:         ffcontext.NewAnonymousEvaluationContext("random-key"),
+				defaultValue: true,
+				cacheMock: NewCacheMock(&flag.InternalFlag{
+					Rules: &[]flag.Rule{
+						{
+							Query: testconvert.String("key eq \"random-key\""),
+							Percentages: &map[string]float64{
+								"False": 0,
+								"True":  100,
+							},
+						},
+					},
+					Variations: &map[string]*interface{}{
+						"Default": testconvert.Interface(false),
+						"False":   testconvert.Interface(false),
+						"True":    testconvert.Interface(true),
+					},
+					DefaultRule: &flag.Rule{
+						Name:            testconvert.String("legacyDefaultRule"),
+						VariationResult: testconvert.String("Default"),
+					},
+				}, nil),
+			},
+			want: model.VariationResult[bool]{
+				VariationType: "True",
+				Failed:        false,
+				Reason:        flag.ReasonTargetingMatch,
+				Value:         true,
+				TrackEvents:   true,
+				Cacheable:     true,
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"true\", variation=\"True\"\n",
@@ -541,6 +624,9 @@ func TestBoolVariationDetails(t *testing.T) {
 				Value:         false,
 				TrackEvents:   true,
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"false\", variation=\"False\"\n",
@@ -1094,6 +1180,9 @@ func TestFloat64VariationDetails(t *testing.T) {
 				Failed:        false,
 				Reason:        flag.ReasonTargetingMatch,
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"120.12\", variation=\"True\"\n",
@@ -1133,6 +1222,9 @@ func TestFloat64VariationDetails(t *testing.T) {
 				Failed:        false,
 				Reason:        flag.ReasonTargetingMatchSplit,
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"121.12\", variation=\"False\"\n",
@@ -1666,6 +1758,9 @@ func TestJSONArrayVariationDetails(t *testing.T) {
 				Reason:        flag.ReasonTargetingMatch,
 				Value:         []interface{}{"true"},
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"\\[true\\]\"\n",
@@ -2172,6 +2267,9 @@ func TestJSONVariationDetails(t *testing.T) {
 				Reason:        flag.ReasonTargetingMatch,
 				Value:         map[string]interface{}{"true": true},
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"map\\[true:true\\]\", variation=\"True\"\n",
@@ -2211,6 +2309,9 @@ func TestJSONVariationDetails(t *testing.T) {
 				Reason:        flag.ReasonTargetingMatchSplit,
 				Value:         map[string]interface{}{"false": true},
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"map\\[false:true\\]\", variation=\"False\"\n",
@@ -2652,6 +2753,9 @@ func TestStringVariationDetails(t *testing.T) {
 				Reason:        flag.ReasonTargetingMatch,
 				Value:         "true",
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"true\", variation=\"True\"\n",
@@ -2691,6 +2795,9 @@ func TestStringVariationDetails(t *testing.T) {
 				Reason:        flag.ReasonTargetingMatchSplit,
 				Value:         "false",
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"false\", variation=\"False\"\n",
@@ -3162,6 +3269,9 @@ func TestIntVariationDetails(t *testing.T) {
 				Reason:        flag.ReasonTargetingMatch,
 				Value:         120,
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"120\", variation=\"True\"\n",
@@ -3201,6 +3311,9 @@ func TestIntVariationDetails(t *testing.T) {
 				Reason:        flag.ReasonTargetingMatchSplit,
 				Value:         121,
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"121\", variation=\"False\"\n",
@@ -3240,6 +3353,9 @@ func TestIntVariationDetails(t *testing.T) {
 				Reason:        flag.ReasonTargetingMatch,
 				Value:         120,
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"120\", variation=\"True\"\n",
@@ -3640,6 +3756,9 @@ func TestRawVariation(t *testing.T) {
 				TrackEvents:   true,
 				Reason:        flag.ReasonTargetingMatch,
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key\", flag=\"test-flag\", value=\"map\\[test2:test\\]\", variation=\"True\"",
@@ -3679,6 +3798,9 @@ func TestRawVariation(t *testing.T) {
 				TrackEvents:   true,
 				Reason:        flag.ReasonTargetingMatchSplit,
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^\\[" + testutils.RFC3339Regex + "\\] user=\"random-key-ssss1\", flag=\"test-flag\", value=\"map\\[test3:test\\]\", variation=\"False\"",
@@ -3719,6 +3841,9 @@ func TestRawVariation(t *testing.T) {
 				TrackEvents:   false,
 				Reason:        flag.ReasonTargetingMatch,
 				Cacheable:     true,
+				Metadata: map[string]interface{}{
+					"evaluatedRuleName": "legacyRuleV0",
+				},
 			},
 			wantErr:     false,
 			expectedLog: "^$",

--- a/website/docs/configure_flag/rule_format.md
+++ b/website/docs/configure_flag/rule_format.md
@@ -150,3 +150,10 @@ my-flag:
   defaultRule:
     variation: C
 ```
+
+## Get the rule name in the metadata
+
+When you use a rule in your targeting, you can get the name of the rule in the metadata of the variation.  
+The information on what rule has been used to serve the variation is available in the metadata of the variation in the field called `evaluatedRuleName`.
+
+If you are interested about this information, you have to name your rules by adding the field `name` in your rule. This name will be extract and added in the `evaluatedRuleName` field of the metadata.


### PR DESCRIPTION
# Description

The Evaluated Rule Name is needed during our experiment analysis phase. During this phase, we need to keep track of the user that has been assigned to a defined variant. Our experiment tends to have different rules, such as internal experiments, free account experiments, etc... Those phases can happen in parallel, and we need to define how the phase is performing. That way the $reason$ on the response is not enough and the metadata must be enhanced. 

Because it is possible to set a variant to a target group, if we don't keep track of the rule, we can have a Sample Mismatch. E.g. if we set enterprise user to variant off, and not enterprise user to 50:50 on and off. That means we will have many more off-users than on. In this case, the reason is enough, but we have the case where enterprise can also be split on a small percentage causing the mismatching.


# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)

Resolve #

# Checklist
- [X] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [X] I have followed the [contributing guide](CONTRIBUTING.md)
