### PR TITLE
chore: only run status report for root repo

### DIFF
--- a/.github/workflows/repostats-collector.yml
+++ b/.github/workflows/repostats-collector.yml
@@ -6,6 +6,7 @@ on:
   
 jobs:
   j1:
+    if: github.repository == 'thomaspoignant/go-feature-flag'
     name: repostats-for-nice-project
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description

I was getting daily reports of a failed GH action run on the fork.
Turned out to be the repo status report workflow, so I added a check to make sure it should run

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #

# Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)
