### PR TITLE
relayproxy: Add the possibility to have 2 differents port for metrics and business

### DIFF
--- a/cmd/relayproxy/api/server_test.go
+++ b/cmd/relayproxy/api/server_test.go
@@ -1,0 +1,134 @@
+package api_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/log"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/service"
+	"github.com/thomaspoignant/go-feature-flag/notifier"
+	"go.uber.org/zap"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func Test_Starting_RelayProxy_with_monitoring_on_same_port(t *testing.T) {
+	proxyConf := &config.Config{
+		Retriever: &config.RetrieverConf{
+			Kind: "file",
+			Path: "../../../testdata/flag-config.yaml",
+		},
+		ListenPort: 11024,
+	}
+	zapLog := log.InitLogger()
+	defer func() { _ = zapLog.Sync() }()
+
+	metricsV2, err := metric.NewMetrics()
+	if err != nil {
+		zapLog.Error("impossible to initialize prometheus metrics", zap.Error(err))
+	}
+	wsService := service.NewWebsocketService()
+	defer wsService.Close() // close all the open connections
+	prometheusNotifier := metric.NewPrometheusNotifier(metricsV2)
+	proxyNotifier := service.NewNotifierWebsocket(wsService)
+	goff, err := service.NewGoFeatureFlagClient(proxyConf, zapLog, []notifier.Notifier{
+		prometheusNotifier,
+		proxyNotifier,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	services := service.Services{
+		MonitoringService:    service.NewMonitoring(goff),
+		WebsocketService:     wsService,
+		GOFeatureFlagService: goff,
+		Metrics:              metricsV2,
+	}
+
+	s := api.New(proxyConf, services, zapLog)
+	go func() { s.Start() }()
+	defer s.Stop()
+
+	time.Sleep(10 * time.Millisecond)
+
+	response, err := http.Get("http://localhost:11024/health")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+
+	responseM, err := http.Get("http://localhost:11024/metrics")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, responseM.StatusCode)
+
+	responseI, err := http.Get("http://localhost:11024/info")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, responseI.StatusCode)
+}
+
+func Test_Starting_RelayProxy_with_monitoring_on_different_port(t *testing.T) {
+	proxyConf := &config.Config{
+		Retriever: &config.RetrieverConf{
+			Kind: "file",
+			Path: "../../../testdata/flag-config.yaml",
+		},
+		ListenPort:     11024,
+		MonitoringPort: 11025,
+	}
+	zapLog := log.InitLogger()
+	defer func() { _ = zapLog.Sync() }()
+
+	metricsV2, err := metric.NewMetrics()
+	if err != nil {
+		zapLog.Error("impossible to initialize prometheus metrics", zap.Error(err))
+	}
+	wsService := service.NewWebsocketService()
+	defer wsService.Close() // close all the open connections
+	prometheusNotifier := metric.NewPrometheusNotifier(metricsV2)
+	proxyNotifier := service.NewNotifierWebsocket(wsService)
+	goff, err := service.NewGoFeatureFlagClient(proxyConf, zapLog, []notifier.Notifier{
+		prometheusNotifier,
+		proxyNotifier,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	services := service.Services{
+		MonitoringService:    service.NewMonitoring(goff),
+		WebsocketService:     wsService,
+		GOFeatureFlagService: goff,
+		Metrics:              metricsV2,
+	}
+
+	s := api.New(proxyConf, services, zapLog)
+	go func() { s.Start() }()
+	defer s.Stop()
+
+	time.Sleep(10 * time.Millisecond)
+
+	response, err := http.Get("http://localhost:11024/health")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, response.StatusCode)
+
+	responseM, err := http.Get("http://localhost:11024/metrics")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, responseM.StatusCode)
+
+	responseI, err := http.Get("http://localhost:11024/info")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, responseI.StatusCode)
+
+	responseH1, err := http.Get("http://localhost:11025/health")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, responseH1.StatusCode)
+
+	responseM1, err := http.Get("http://localhost:11025/metrics")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, responseM1.StatusCode)
+
+	responseI1, err := http.Get("http://localhost:11025/info")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, responseI1.StatusCode)
+}

--- a/cmd/relayproxy/config/config.go
+++ b/cmd/relayproxy/config/config.go
@@ -187,6 +187,10 @@ type Config struct {
 	// Default: ""
 	OpenTelemetryOtlpEndpoint string `mapstructure:"openTelemetryOtlpEndpoint" koanf:"opentelemetryotlpendpoint"`
 
+	// MonitoringPort (optional) is the port we are using to expose the metrics and healthchecks
+	// If not set we will use the same port as the proxy
+	MonitoringPort int `mapstructure:"monitoringPort" koanf:"monitoringport"`
+
 	// ---- private fields
 
 	// apiKeySet is the internal representation of an API keys list configured

--- a/website/docs/relay_proxy/monitor_relay_proxy.md
+++ b/website/docs/relay_proxy/monitor_relay_proxy.md
@@ -40,5 +40,16 @@ of the relay proxy.
 ### `/metrics`
 This endpoint is providing metrics about the relay proxy in the prometheus format.
 
+## Use specific port for the monitoring
+You can configure a different port for the monitoring endpoints.   
+This is useful if you want to expose the monitoring endpoints on a different port than the main service.
 
+```yaml
+# ...
+monitoringPort: 1032
+# ...
+```
 
+:::note
+By default the monitoring endpoints are exposed on the same port as the main service.
+:::


### PR DESCRIPTION
# Description
Following issue #1499, this PR introduces the possibility of running `metrics` and `health checks` on different ports.
This is a requirement for some companies that prefer not to mix the 2 things simultaneously.

In this implementation, we are starting another instance of `echo` for the metrics if the param `monitoringPort` is set in the configuration.
If this option is not set the monitoring will continue to work on the same port of the business logic.

# Changes include
- [x] New feature (non-breaking change that adds functionality)

# Closes issue(s)
Resolve #1499

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
