### PR TITLE
doc: Add s3 retriever v1 deprecation notice; add v2 links

### DIFF
--- a/website/docs/go_module/store_file/s3.md
+++ b/website/docs/go_module/store_file/s3.md
@@ -3,7 +3,11 @@ sidebar_position: 3
 ---
 
 # S3 Bucket
-The [**S3Retriever**](https://pkg.go.dev/github.com/thomaspoignant/go-feature-flag/retriever/s3retriever/#Retriever) will use the [aws-sdk](https://github.com/aws/aws-sdk-go) to access your flag in an S3 bucket.
+The [**S3 Retriever v2**](https://pkg.go.dev/github.com/thomaspoignant/go-feature-flag@v1.23.1/retriever/s3retrieverv2) will use the [aws-sdk-go-v2](https://github.com/aws/aws-sdk-go-v2) to access your flag in an S3 bucket.
+
+The [**S3 Retriever v1**](https://pkg.go.dev/github.com/thomaspoignant/go-feature-flag@v1.23.1/retriever/s3retriever) will use the deprecated [aws-sdk-go](https://github.com/aws/aws-sdk-go) to access your flag in an S3 bucket.
+
+[AWS has announce end-of-support for AWS SDK for Go v1](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/), and it's recommended to migrate from S3 Retriever v1 to v2.
 
 ## Example
 ```go showLineNumbers


### PR DESCRIPTION
# Description
The example uses v2, so the links to v1 stuff in the original doc may need to be updated.

# Checklist
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)
