### PR TITLE
Fix: update the config of golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,3 @@
-run:
-  skip-dirs:
-    - (^|/)bin($|/)
-    - (^|/)examples($|/)
 linters:
   enable:
     - asciicheck
@@ -43,6 +39,9 @@ linters-settings:
     module-path: github.com/thomaspoignant/go-feature-flag
     lang-version: "1.17"
 issues:
+  exclude-dirs:
+    - (^|/)bin($|/)
+    - (^|/)examples($|/)
   exclude-rules:
     - path: _test.go
       linters:

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ bench: ## Launch the benchmark test
 lint: ## Use golintci-lint on your project
 	mkdir -p ./bin
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s latest # Install linters
-	./bin/golangci-lint run --deadline=5m --timeout=5m ./... # Run linters
+	./bin/golangci-lint run --timeout=5m --timeout=5m ./... # Run linters
 
 ## Help:
 help: ## Show this help.


### PR DESCRIPTION
# Description
Latest golangci update is breaking the CI.
This PR change the deprecation command line params.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)