### PR TITLE
Fix: check for s.AwsConfig when initializing s3Retrieverv2

### DIFF
--- a/retriever/s3retrieverv2/retriever.go
+++ b/retriever/s3retrieverv2/retriever.go
@@ -33,12 +33,14 @@ type Retriever struct {
 func (s *Retriever) Init(ctx context.Context, _ *log.Logger) error {
 	s.status = retriever.RetrieverNotReady
 	if s.downloader == nil {
-		cfg, err := config.LoadDefaultConfig(ctx)
-		if err != nil {
-			s.status = retriever.RetrieverError
-			return fmt.Errorf("impossible to init S3 retriever v2: %v", err)
+		if s.AwsConfig == nil {
+			cfg, err := config.LoadDefaultConfig(ctx)
+			if err != nil {
+				s.status = retriever.RetrieverError
+				return fmt.Errorf("impossible to init S3 retriever v2: %v", err)
+			}
+			s.AwsConfig = &cfg
 		}
-		s.AwsConfig = &cfg
 		client := s3.NewFromConfig(*s.AwsConfig)
 		s.downloader = manager.NewDownloader(client)
 	}


### PR DESCRIPTION
# Description
Fixes issue with s3Retrieverv2 initialization by checking again for presence of AwsConfig and using that instead of default AWS Config. 

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #1691 

# Checklist
- [x] I have tested this code. I tested this fork in our own code and it fixed the issue we were seeing before. 
- [ ] I have added unit test to cover this code: I don't believe this is really testable given the current structure of Init. 
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
