### PR TITLE
Bump relay-proxy helm chart version v1.26.0

### DIFF
--- a/cmd/relayproxy/helm-charts/relay-proxy/Chart.yaml
+++ b/cmd/relayproxy/helm-charts/relay-proxy/Chart.yaml
@@ -5,8 +5,8 @@ sources:
   - "https://github.com/thomaspoignant/go-feature-flag"
 description: A Helm chart to deploy go-feature-flag-relay proxy into Kubernetes
 type: application
-version: 1.25.1
-appVersion: "v1.25.1"
+version: 1.26.0
+appVersion: "v1.26.0"
 icon: https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/logo.png
 maintainers:
   - name: thomaspoignant


### PR DESCRIPTION
Automated pull request to bump relay-proxy helm chart version v1.26.0