### PR TITLE
[Draft] Feature to set Offline flag for ff client

### DIFF
--- a/background_updater.go
+++ b/background_updater.go
@@ -35,8 +35,22 @@ func newBackgroundUpdater(pollingInterval time.Duration, useJitter bool) backgro
 	}
 }
 
-// close stop the ticker and close the channel.
+// close stops the ticker and closes the channel.
 func (bgu *backgroundUpdater) close() {
-	bgu.ticker.Stop()
-	close(bgu.updaterChan)
+	if bgu.ticker != nil {
+		bgu.ticker.Stop()
+	}
+	if !bgu.isClosed() {
+		close(bgu.updaterChan)
+	}
+}
+
+// isClosed checks if the channel is closed.
+func (bgu *backgroundUpdater) isClosed() bool {
+	select {
+	case <-bgu.updaterChan:
+		return true
+	default:
+	}
+	return false
 }

--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -2,22 +2,20 @@ package ffclient_test
 
 import (
 	"errors"
-	"github.com/thomaspoignant/go-feature-flag/ffcontext"
-	"github.com/thomaspoignant/go-feature-flag/testutils/initializableretriever"
 	"log"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/thomaspoignant/go-feature-flag/internal/flag"
-	"github.com/thomaspoignant/go-feature-flag/retriever"
-
-	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
-	"github.com/thomaspoignant/go-feature-flag/retriever/s3retriever"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
+	"github.com/thomaspoignant/go-feature-flag/internal/flag"
+	"github.com/thomaspoignant/go-feature-flag/retriever"
+	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
+	"github.com/thomaspoignant/go-feature-flag/retriever/s3retriever"
+	"github.com/thomaspoignant/go-feature-flag/testutils/initializableretriever"
 	"github.com/thomaspoignant/go-feature-flag/testutils/mock"
 )
 
@@ -464,4 +462,34 @@ func TestGoFeatureFlag_GetCacheRefreshDate(t *testing.T) {
 			assert.Equal(t, tt.hasRefresh, date1.Before(date2))
 		})
 	}
+}
+
+func TestGoFeatureFlag_SetOffline(t *testing.T) {
+	gffClient, err := ffclient.New(ffclient.Config{
+		PollingInterval: 5 * time.Second,
+		Retriever:       &fileretriever.Retriever{Path: "testdata/flag-config.yaml"},
+		Logger:          log.New(os.Stdout, "", 0),
+		Offline:         false,
+	})
+
+	if err != nil {
+		log.Print("Failed to initialize the client")
+		t.Fatal(err) // Exit the test if initialization fails
+	}
+
+	defer gffClient.Close()
+
+	// Init should be ok
+	assert.NoError(t, err)
+
+	// Happy Path
+	got := gffClient.SetOffline(true)
+	want := true
+
+	assert.Equal(t, got, want)
+
+	// Sad Path
+	got = gffClient.SetOffline(false)
+
+	assert.NotEqual(t, got, want)
 }


### PR DESCRIPTION
Why: To optimize the ff client

How: Added a new function named SetOffline, and that takes boolean as a parameter, and returns the updated value. It will start or stop the flag updater daemon based on the input. The background_updater is also updated to check for close() signals.

Tags: [ffclient, enhancement, feature]

# Description
<!-- 
Please add a description of what your pull request is doing.
 - What was the problem?
 - How it is resolved?
 - How can we test the change?
 - If there are breaking changes, please describe them in detail and why we cannot avoid them.
-->

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-compatible and/or changes current functionality)

# Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #

# Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)
