### PR TITLE
fix: Helm documentation type error

### DIFF
--- a/cmd/relayproxy/helm-charts/relay-proxy/values.yaml
+++ b/cmd/relayproxy/helm-charts/relay-proxy/values.yaml
@@ -1,6 +1,5 @@
 relayproxy:
-  # -- (tpl/object) Define this for extra Django environment variables
-  # @notationType -- tpl
+  # -- GO Feature Flag relay proxy configuration as string.
   config: | # This is a configuration example for the relay-proxy
     listen: 1031
     pollingInterval: 1000


### PR DESCRIPTION
# Description
This PR fixes an error of type and description in the helm doc generated.
Thanks @tomflenner for raising it in #1820.

# Closes issue(s)
Resolve #1823

# Checklist
- [x] I have tested this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
