### PR TITLE
chore: Change/1851 helm config templating

### DIFF
--- a/cmd/relayproxy/helm-charts/relay-proxy/templates/configmap.yaml
+++ b/cmd/relayproxy/helm-charts/relay-proxy/templates/configmap.yaml
@@ -8,4 +8,4 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  goff-proxy.yml: {{- toYaml .Values.relayproxy.config | nindent 4 }}
+  goff-proxy.yml: {{- toYaml (tpl .Values.relayproxy.config .) | nindent 4 }}

--- a/cmd/relayproxy/helm-charts/relay-proxy/values.yaml
+++ b/cmd/relayproxy/helm-charts/relay-proxy/values.yaml
@@ -1,5 +1,5 @@
 relayproxy:
-  # -- GO Feature Flag relay proxy configuration as string.
+  # -- GO Feature Flag relay proxy configuration as string (accept template).
   config: | # This is a configuration example for the relay-proxy
     listen: 1031
     pollingInterval: 1000


### PR DESCRIPTION
# Description
<!-- 
Please add a description of what your pull request is doing.
 - What was the problem?
 - How it is resolved?
 - How can we test the change?
 - If there are breaking changes, please describe them in detail and why we cannot avoid them.
-->
Add support for helm [tpl function](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function) inside the [relayproxy.config](https://github.com/thomaspoignant/go-feature-flag/blob/main/cmd/relayproxy/helm-charts/relay-proxy/values.yaml#L3) helm chart value.

# Tests

Using the helm cli `helm template goff-1851 . -n goff-1851-namespace` to render the helm chart with these values :
```
relayproxy:
  # -- GO Feature Flag relay proxy configuration as string (accept template).
  config: | # This is a configuration example for the relay-proxy
    listen: 1031
    pollingInterval: 1000
    startWithRetrieverError: false
    test: {{ .Release.Namespace }}
    retriever:
      kind: http
      url: https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/examples/retriever_file/flags.goff.yaml
    exporter:
      kind: log
```

Initially we had this output :
```
---
# Source: relay-proxy/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: goff-1851-relay-proxy
  labels:
    app: goff-1851-relay-proxy
    chart: "relay-proxy-1.27.0"
    release: "goff-1851"
    heritage: "Helm"
data:
  goff-proxy.yml:
    |
      listen: 1031
      pollingInterval: 1000
      startWithRetrieverError: false
      test: {{ .Release.Namespace }}
      retriever:
        kind: http
        url: https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/examples/retriever_file/flags.goff.yaml
      exporter:
        kind: log
```
Where the value **test** was not templated.

With the provided fix we have the following output now :
```
---
# Source: relay-proxy/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: goff-1851-relay-proxy
  labels:
    app: goff-1851-relay-proxy
    chart: "relay-proxy-1.27.0"
    release: "goff-1851"
    heritage: "Helm"
data:
  goff-proxy.yml:
    |
      listen: 1031
      pollingInterval: 1000
      startWithRetrieverError: false
      test: goff-1851-namespace
      retriever:
        kind: http
        url: https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/examples/retriever_file/flags.goff.yaml
      exporter:
        kind: log
```
Where the value **test** is now templated using the current custom namespace provided in the cli arg

# Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #1851

# Checklist
- [X] I have tested this code
- [ ] I have added unit test to cover this code -> I didn't see any unit test against the helm chart, maybe I miss something ? 👀 
- [X] I have updated the documentation (`README.md` and `/website/docs`)
- [X] I have followed the [contributing guide](CONTRIBUTING.md)
