### PR TITLE
chore: update adopters readme with new company

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -8,5 +8,7 @@ Thank you for trusting the `go-feature-flag` and using it in your organization.
 | Chapati systems   | https://chapati.systems/                              |                                        |
 | Lyft              | https://github.com/lyft/atlantis                      | Inside the Atlantis fork used by Lyft. |
 | Tencent           | https://github.com/TencentBlueKing/bkmonitor-datalink | Used inside BKMONITOR-DATALINK.        |
+| Agentero          | https://agentero.com/                                 | FF tool within Agentero platform       |
+
 
 


### PR DESCRIPTION
# Description

This PR includes a tiny change just to include [Agentero](https://agentero.com/) in the list of adopters. 