### PR TITLE
fix(OFREP): keep targetingKey in the custom data to continue to have rules enabled

### DIFF
--- a/cmd/relayproxy/ofrep/evaluate.go
+++ b/cmd/relayproxy/ofrep/evaluate.go
@@ -205,7 +205,6 @@ func assertOFREPEvaluateRequest(ofrepEvalReq *model.OFREPEvalFlagRequest) *model
 
 func evaluationContextFromOFREPRequest(ctx map[string]any) (ffcontext.Context, error) {
 	if targetingKey, ok := ctx["targetingKey"].(string); ok {
-		delete(ctx, "targetingKey")
 		evalCtx := utils.ConvertEvaluationCtxFromRequest(targetingKey, ctx)
 		return evalCtx, nil
 	}

--- a/cmd/relayproxy/ofrep/evaluate_test.go
+++ b/cmd/relayproxy/ofrep/evaluate_test.go
@@ -224,6 +224,18 @@ func Test_Evaluate(t *testing.T) {
 				bodyFile: "../testdata/ofrep/responses/not_found.json",
 			},
 		},
+		{
+			name: "targeting using the field targetingKey in the rules",
+			args: args{
+				bodyFile:            "../testdata/ofrep/valid_targeting_key_query_request.json",
+				configFlagsLocation: configFlagsLocation,
+				flagKey:             "targeting-key-rule",
+			},
+			want: want{
+				httpCode: http.StatusOK,
+				bodyFile: "../testdata/ofrep/responses/valid_targeting_key_query_response.json",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/relayproxy/testdata/controller/all_flags/valid_response.json
+++ b/cmd/relayproxy/testdata/controller/all_flags/valid_response.json
@@ -73,6 +73,14 @@
       "trackEvents": true,
       "errorCode": "",
       "reason": "DEFAULT"
+    },
+    "targeting-key-rule": {
+      "value": false,
+      "timestamp": 1652273630,
+      "variationType": "false_var",
+      "trackEvents": true,
+      "errorCode": "",
+      "reason": "DEFAULT"
     }
   },
   "valid": true

--- a/cmd/relayproxy/testdata/controller/config_flags.yaml
+++ b/cmd/relayproxy/testdata/controller/config_flags.yaml
@@ -71,3 +71,13 @@ array-flag:
     - batmanFalse
     - supermanFalse
     - superherosFalse
+
+targeting-key-rule:
+  variations:
+    true_var: true
+    false_var: false
+  targeting:
+    - query: targetingKey eq "specific-targeting-key"
+      variation: true_var
+  defaultRule:
+    variation: false_var

--- a/cmd/relayproxy/testdata/ofrep/responses/valid_response.json
+++ b/cmd/relayproxy/testdata/ofrep/responses/valid_response.json
@@ -35,6 +35,12 @@
       "variant": "Default"
     },
     {
+      "key": "targeting-key-rule",
+      "value": false,
+      "reason": "DEFAULT",
+      "variant": "false_var"
+    },
+    {
       "key": "test-flag-rule-apply",
       "value": {
         "test": "test"

--- a/cmd/relayproxy/testdata/ofrep/responses/valid_targeting_key_query_response.json
+++ b/cmd/relayproxy/testdata/ofrep/responses/valid_targeting_key_query_response.json
@@ -1,0 +1,6 @@
+{
+  "key": "targeting-key-rule",
+  "value": true,
+  "reason": "TARGETING_MATCH",
+  "variant": "true_var"
+}

--- a/cmd/relayproxy/testdata/ofrep/valid_targeting_key_query_request.json
+++ b/cmd/relayproxy/testdata/ofrep/valid_targeting_key_query_request.json
@@ -1,0 +1,8 @@
+{
+  "context": {
+    "company": "GO Feature Flag",
+    "firstname": "John",
+    "lastname": "Doe",
+    "targetingKey": "specific-targeting-key"
+  }
+}


### PR DESCRIPTION
# Description
When calling the evaluation for OFREP we had an issue writing rules using `targetingKey` as key because it was removed from the evaluation context (in favor of `key`).

In this PR we stop removing `targetingKey` to be able to use both key names.

# Closes issue(s)
Resolve #1898

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
