### PR TITLE
feat(docker): Bump base distroless image

### DIFF
--- a/cmd/lint/Dockerfile
+++ b/cmd/lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/base-debian11:latest
+FROM gcr.io/distroless/base-debian12:latest
 ENTRYPOINT ["/go-feature-flag-lint"]
 COPY go-feature-flag-lint /

--- a/cmd/migrationcli/Dockerfile
+++ b/cmd/migrationcli/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/base-debian11:latest
+FROM gcr.io/distroless/base-debian12:latest
 ENTRYPOINT ["/go-feature-flag-migration-cli"]
 COPY go-feature-flag-migration-cli /

--- a/cmd/relayproxy/DockerfileGoreleaser
+++ b/cmd/relayproxy/DockerfileGoreleaser
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/base-debian11:latest
+FROM gcr.io/distroless/base-debian12:latest
 COPY ./go-feature-flag /go-feature-flag
 CMD ["/go-feature-flag"]

--- a/cmd/relayproxy/DockerfileGoreleaserRelayProxy
+++ b/cmd/relayproxy/DockerfileGoreleaserRelayProxy
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/base-debian11:latest
+FROM gcr.io/distroless/base-debian12:latest
 COPY ./go-feature-flag-relay-proxy /go-feature-flag-relay-proxy
 CMD ["/go-feature-flag-relay-proxy"]


### PR DESCRIPTION
## Description
This PR is bumping the base distroless docker image to Debian-12 for all the docker image we publish.

## Closes issue(s)
Resolve #1909

## Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
