### PR TITLE
feat(relay-proxy): Add log when Github API in error

### DIFF
--- a/retriever/shared/http.go
+++ b/retriever/shared/http.go
@@ -1,0 +1,51 @@
+package shared
+
+import (
+	"errors"
+	"github.com/thomaspoignant/go-feature-flag/internal"
+	"golang.org/x/net/context"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func CallHTTPAPI(
+	ctx context.Context,
+	url string, method string,
+	body string,
+	timeout time.Duration,
+	header http.Header,
+	httpClient internal.HTTPClient) (*http.Response, error) {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+
+	if url == "" {
+		return nil, errors.New("URL is a mandatory parameter when using httpretriever.Retriever")
+	}
+
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	// Add header if some are passed
+	if len(header) > 0 {
+		req.Header = header
+	}
+
+	if httpClient == nil {
+		httpClient = internal.HTTPClientWithTimeout(timeout)
+	}
+
+	// API call
+	return httpClient.Do(req)
+}

--- a/testutils/mock/http_mock.go
+++ b/testutils/mock/http_mock.go
@@ -9,7 +9,8 @@ import (
 )
 
 type HTTP struct {
-	Req http.Request
+	Req       http.Request
+	RateLimit bool
 }
 
 func (m *HTTP) Do(req *http.Request) (*http.Response, error) {
@@ -37,8 +38,28 @@ func (m *HTTP) Do(req *http.Request) (*http.Response, error) {
 		Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 	}
 
+	rateLimit := &http.Response{
+		Status:     "Rate Limit",
+		StatusCode: http.StatusTooManyRequests,
+		Body:       io.NopCloser(bytes.NewReader([]byte(""))),
+		Header: map[string][]string{
+			"X-Content-Type-Options": {"nosniff"},
+			"X-Frame-Options":        {"deny"},
+			"X-Github-Media-Type":    {"github.v3; format=json"},
+			"X-Github-Request-Id":    {"F82D:37B98C:232EF263:235C93BD:6650BDC6"},
+			"X-Ratelimit-Limit":      {"60"},
+			"X-Ratelimit-Remaining":  {"0"},
+			"X-Ratelimit-Reset":      {"1716568424"},
+			"X-Ratelimit-Resource":   {"core"},
+			"X-Ratelimit-Used":       {"60"},
+			"X-Xss-Protection":       {"1; mode=block"},
+		},
+	}
+
 	if strings.Contains(req.URL.String(), "error") {
 		return nil, errors.New("http error")
+	} else if m.RateLimit {
+		return rateLimit, nil
 	} else if strings.HasSuffix(req.URL.String(), "httpError") {
 		return error, nil
 	}

--- a/testutils/mock/http_mock.go
+++ b/testutils/mock/http_mock.go
@@ -55,11 +55,12 @@ func (m *HTTP) Do(req *http.Request) (*http.Response, error) {
 			"X-Xss-Protection":       {"1; mode=block"},
 		},
 	}
+	if m.RateLimit {
+		return rateLimit, nil
+	}
 
 	if strings.Contains(req.URL.String(), "error") {
 		return nil, errors.New("http error")
-	} else if m.RateLimit {
-		return rateLimit, nil
 	} else if strings.HasSuffix(req.URL.String(), "httpError") {
 		return error, nil
 	}


### PR DESCRIPTION
## Description
Following the discussion in #1334, this PR logs all the GitHub headers in the error response to understand better if some rate-limiting errors can be the source of the issue.


## Closes issue(s)
Resolve #1917

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
