### PR TITLE
feat(relayproxy): Add middleware to add version in response headers

### DIFF
--- a/cmd/relayproxy/api/middleware/version.go
+++ b/cmd/relayproxy/api/middleware/version.go
@@ -1,0 +1,16 @@
+package middleware
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
+)
+
+// VersionHeader is a middleware that adds the version of the relayproxy in the header
+func VersionHeader(config *config.Config) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			c.Response().Header().Set("X-GOFEATUREFLAG-VERSION", config.Version)
+			return next(c)
+		}
+	}
+}

--- a/cmd/relayproxy/api/middleware/version_test.go
+++ b/cmd/relayproxy/api/middleware/version_test.go
@@ -1,0 +1,31 @@
+package middleware_test
+
+import (
+	"github.com/labstack/echo/v4"
+	middleware2 "github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api/middleware"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersion(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/whatever", nil)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	conf := &config.Config{
+		Version: "1.0.0",
+	}
+	middleware := middleware2.VersionHeader(conf)
+	handler := middleware(func(c echo.Context) error {
+		return c.String(http.StatusOK, "Authorized")
+	})
+
+	err := handler(c)
+	assert.NoError(t, err)
+	assert.Equal(t, "1.0.0", rec.Header().Get("X-GOFEATUREFLAG-VERSION"))
+}

--- a/cmd/relayproxy/api/routes_monitoring.go
+++ b/cmd/relayproxy/api/routes_monitoring.go
@@ -17,6 +17,7 @@ func (s *Server) addMonitoringRoutes() {
 		s.monitoringEcho.Debug = s.config.Debug
 		s.monitoringEcho.Use(custommiddleware.ZapLogger(s.zapLog, s.config))
 		s.monitoringEcho.Use(middleware.CORSWithConfig(middleware.DefaultCORSConfig))
+		s.monitoringEcho.Use(custommiddleware.VersionHeader(s.config))
 		s.monitoringEcho.Use(middleware.Recover())
 		s.initMonitoringEndpoint(s.monitoringEcho)
 	} else {

--- a/cmd/relayproxy/api/server.go
+++ b/cmd/relayproxy/api/server.go
@@ -60,6 +60,7 @@ func (s *Server) initRoutes() {
 	s.apiEcho.Use(otelecho.Middleware("go-feature-flag"))
 	s.apiEcho.Use(custommiddleware.ZapLogger(s.zapLog, s.config))
 	s.apiEcho.Use(middleware.CORSWithConfig(middleware.DefaultCORSConfig))
+	s.apiEcho.Use(custommiddleware.VersionHeader(s.config))
 	s.apiEcho.Use(middleware.Recover())
 	s.apiEcho.Use(middleware.TimeoutWithConfig(
 		middleware.TimeoutConfig{


### PR DESCRIPTION
## Description
Add a new header called `X-GOFEATUREFLAG-VERSION` that display the version of GO Feature Flag in the API responses.

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
