### PR TITLE
fix: Update using-openfeature.md - Corrected name of image in dockerhub

### DIFF
--- a/website/versioned_docs/version-v1.29.0/getting_started/using-openfeature.md
+++ b/website/versioned_docs/version-v1.29.0/getting_started/using-openfeature.md
@@ -64,7 +64,7 @@ docker run \
   -p 1031:1031 \
   -v $(pwd)/flag-config.goff.yaml:/goff/flag-config.goff.yaml \
   -v $(pwd)/goff-proxy.yaml:/goff/goff-proxy.yaml \
-  gofeatureflag/go-feature-flag-relay-proxy:latest
+  gofeatureflag/go-feature-flag:latest
 
 ```
 


### PR DESCRIPTION
Corrected name of image in dockerhub

## Description
<!-- 
Please add a description of what your pull request is doing.
 - What was the problem?
   The name of the relay proxy image did not match what was in dockerhub
 - How it is resolved?
   I changed the name to match what is in dockerhub.
 - How can we test the change?
   Try copying the command and running it.
 - If there are breaking changes, please describe them in detail and why we cannot avoid them.
-->

## Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)
