### PR TITLE
docs(website): update relay proxy image name

### DIFF
--- a/website/docs/getting_started/using-openfeature.md
+++ b/website/docs/getting_started/using-openfeature.md
@@ -64,7 +64,7 @@ docker run \
   -p 1031:1031 \
   -v $(pwd)/flag-config.goff.yaml:/goff/flag-config.goff.yaml \
   -v $(pwd)/goff-proxy.yaml:/goff/goff-proxy.yaml \
-  gofeatureflag/go-feature-flag-relay-proxy:latest
+  gofeatureflag/go-feature-flag:latest
 
 ```
 

--- a/website/versioned_docs/version-v1.27.0/getting_started/using-openfeature.md
+++ b/website/versioned_docs/version-v1.27.0/getting_started/using-openfeature.md
@@ -64,7 +64,7 @@ docker run \
   -p 1031:1031 \
   -v $(pwd)/flag-config.goff.yaml:/goff/flag-config.goff.yaml \
   -v $(pwd)/goff-proxy.yaml:/goff/goff-proxy.yaml \
-  gofeatureflag/go-feature-flag-relay-proxy:latest
+  gofeatureflag/go-feature-flag:latest
 
 ```
 

--- a/website/versioned_docs/version-v1.28.0/getting_started/using-openfeature.md
+++ b/website/versioned_docs/version-v1.28.0/getting_started/using-openfeature.md
@@ -64,7 +64,7 @@ docker run \
   -p 1031:1031 \
   -v $(pwd)/flag-config.goff.yaml:/goff/flag-config.goff.yaml \
   -v $(pwd)/goff-proxy.yaml:/goff/goff-proxy.yaml \
-  gofeatureflag/go-feature-flag-relay-proxy:latest
+  gofeatureflag/go-feature-flag:latest
 
 ```
 

--- a/website/versioned_docs/version-v1.28.1/getting_started/using-openfeature.md
+++ b/website/versioned_docs/version-v1.28.1/getting_started/using-openfeature.md
@@ -64,7 +64,7 @@ docker run \
   -p 1031:1031 \
   -v $(pwd)/flag-config.goff.yaml:/goff/flag-config.goff.yaml \
   -v $(pwd)/goff-proxy.yaml:/goff/goff-proxy.yaml \
-  gofeatureflag/go-feature-flag-relay-proxy:latest
+  gofeatureflag/go-feature-flag:latest
 
 ```
 

--- a/website/versioned_docs/version-v1.28.2/getting_started/using-openfeature.md
+++ b/website/versioned_docs/version-v1.28.2/getting_started/using-openfeature.md
@@ -64,7 +64,7 @@ docker run \
   -p 1031:1031 \
   -v $(pwd)/flag-config.goff.yaml:/goff/flag-config.goff.yaml \
   -v $(pwd)/goff-proxy.yaml:/goff/goff-proxy.yaml \
-  gofeatureflag/go-feature-flag-relay-proxy:latest
+  gofeatureflag/go-feature-flag:latest
 
 ```
 

--- a/website/versioned_docs/version-v1.30.0/getting_started/using-openfeature.md
+++ b/website/versioned_docs/version-v1.30.0/getting_started/using-openfeature.md
@@ -64,7 +64,7 @@ docker run \
   -p 1031:1031 \
   -v $(pwd)/flag-config.goff.yaml:/goff/flag-config.goff.yaml \
   -v $(pwd)/goff-proxy.yaml:/goff/goff-proxy.yaml \
-  gofeatureflag/go-feature-flag-relay-proxy:latest
+  gofeatureflag/go-feature-flag:latest
 
 ```
 


### PR DESCRIPTION
## Description
I noticed that the [Getting Started](https://gofeatureflag.org/docs/getting_started/using-openfeature#install-the-relay-proxy) documentation was pointing to a non-existent Docker Hub image, so I corrected it.

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
