### PR TITLE
fix: Use fflog for Exporters

### DIFF
--- a/cmd/relayproxy/service/gofeatureflag.go
+++ b/cmd/relayproxy/service/gofeatureflag.go
@@ -200,7 +200,7 @@ func initDataExporter(c *config.ExporterConf) (ffclient.DataExporter, error) {
 }
 
 // nolint: funlen
-func createExporter(c *config.ExporterConf) (exporter.Exporter, error) {
+func createExporter(c *config.ExporterConf) (exporter.CommonExporter, error) {
 	format := config.DefaultExporter.Format
 	if c.Format != "" {
 		format = c.Format

--- a/cmd/relayproxy/service/gofeatureflag_test.go
+++ b/cmd/relayproxy/service/gofeatureflag_test.go
@@ -205,7 +205,7 @@ func Test_initExporter(t *testing.T) {
 		skipCompleteValidation bool
 	}{
 		{
-			name:    "Convert unknown DeprecatedExporter",
+			name:    "Convert unknown Exporter",
 			wantErr: assert.Error,
 			conf: &config.ExporterConf{
 				Kind: "unknown",

--- a/cmd/relayproxy/service/gofeatureflag_test.go
+++ b/cmd/relayproxy/service/gofeatureflag_test.go
@@ -201,11 +201,11 @@ func Test_initExporter(t *testing.T) {
 		conf                   *config.ExporterConf
 		want                   ffclient.DataExporter
 		wantErr                assert.ErrorAssertionFunc
-		wantType               exporter.Exporter
+		wantType               exporter.CommonExporter
 		skipCompleteValidation bool
 	}{
 		{
-			name:    "Convert unknown Exporter",
+			name:    "Convert unknown DeprecatedExporter",
 			wantErr: assert.Error,
 			conf: &config.ExporterConf{
 				Kind: "unknown",

--- a/config_collector.go
+++ b/config_collector.go
@@ -20,5 +20,5 @@ type DataExporter struct {
 
 	// Exporter is the configuration of your exporter.
 	// You can see all available exporter in the exporter package.
-	Exporter exporter.Exporter
+	Exporter exporter.CommonExporter
 }

--- a/exporter/data_exporter.go
+++ b/exporter/data_exporter.go
@@ -16,7 +16,7 @@ const (
 
 // NewScheduler allows creating a new instance of Scheduler ready to be used to export data.
 func NewScheduler(ctx context.Context, flushInterval time.Duration, maxEventInMemory int64,
-	exp Exporter, logger *fflog.FFLogger,
+	exp CommonExporter, logger *fflog.FFLogger,
 ) *Scheduler {
 	if ctx == nil {
 		ctx = context.Background()
@@ -49,7 +49,7 @@ type Scheduler struct {
 	daemonChan      chan struct{}
 	ticker          *time.Ticker
 	maxEventInCache int64
-	exporter        Exporter
+	exporter        CommonExporter
 	logger          *fflog.FFLogger
 	ctx             context.Context
 }
@@ -116,9 +116,28 @@ func (dc *Scheduler) GetLogger(level slog.Level) *log.Logger {
 // flush will call the data exporter and clear the cache
 func (dc *Scheduler) flush() {
 	if len(dc.localCache) > 0 {
-		err := dc.exporter.Export(dc.ctx, dc.GetLogger(slog.LevelError), dc.localCache)
-		if err != nil {
-			dc.logger.Error("error while exporting data", slog.Any("err", err))
+
+		switch exp := dc.exporter.(type) {
+		case DeprecatedExporter:
+			// use dc exporter as a DeprecatedExporter
+			err := exp.Export(dc.ctx, dc.GetLogger(slog.LevelError), dc.localCache)
+			slog.Warn("You are using an exporter with the old logger."+
+				"Please update your custom exporter to comply to the new Exporter interface.",
+				slog.Any("err", err))
+			if err != nil {
+				dc.logger.Error("error while exporting data", slog.Any("err", err))
+				return
+			}
+			break
+		case Exporter:
+			err := exp.Export(dc.ctx, dc.logger, dc.localCache)
+			if err != nil {
+				dc.logger.Error("error while exporting data", slog.Any("err", err))
+				return
+			}
+			break
+		default:
+			dc.logger.Error("this is not a valid exporter")
 			return
 		}
 	}

--- a/exporter/data_exporter.go
+++ b/exporter/data_exporter.go
@@ -116,7 +116,6 @@ func (dc *Scheduler) GetLogger(level slog.Level) *log.Logger {
 // flush will call the data exporter and clear the cache
 func (dc *Scheduler) flush() {
 	if len(dc.localCache) > 0 {
-
 		switch exp := dc.exporter.(type) {
 		case DeprecatedExporter:
 			// use dc exporter as a DeprecatedExporter

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -2,14 +2,24 @@ package exporter
 
 import (
 	"context"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log"
 )
 
-// Exporter is an interface to describe how an exporter looks like.
-type Exporter interface {
+// DeprecatedExporter is an interface to describe how an exporter looks like.
+// Deprecated: use Exporter instead.
+type DeprecatedExporter interface {
+	CommonExporter
 	// Export will send the data to the exporter.
 	Export(context.Context, *log.Logger, []FeatureEvent) error
+}
 
+type Exporter interface {
+	CommonExporter
+	Export(context.Context, *fflog.FFLogger, []FeatureEvent) error
+}
+
+type CommonExporter interface {
 	// IsBulk return false if we should directly send the data as soon as it is produce
 	// and true if we collect the data to send them in bulk.
 	IsBulk() bool

--- a/exporter/fileexporter/exporter.go
+++ b/exporter/fileexporter/exporter.go
@@ -3,7 +3,7 @@ package fileexporter
 import (
 	"context"
 	"fmt"
-	"log"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"os"
 	"runtime"
 	"strings"
@@ -53,7 +53,7 @@ type Exporter struct {
 }
 
 // Export is saving a collection of events in a file.
-func (f *Exporter) Export(_ context.Context, _ *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (f *Exporter) Export(_ context.Context, _ *fflog.FFLogger, featureEvents []exporter.FeatureEvent) error {
 	// Parse the template only once
 	f.initTemplates.Do(func() {
 		f.csvTemplate = exporter.ParseTemplate("csvFormat", f.CsvTemplate, exporter.DefaultCsvTemplate)

--- a/exporter/fileexporter/exporter_test.go
+++ b/exporter/fileexporter/exporter_test.go
@@ -2,7 +2,7 @@ package fileexporter_test
 
 import (
 	"context"
-	"log"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"os"
 	"runtime"
 	"testing"
@@ -25,7 +25,7 @@ func TestFile_Export(t *testing.T) {
 		ParquetCompressionCodec string
 	}
 	type args struct {
-		logger        *log.Logger
+		logger        *fflog.FFLogger
 		featureEvents []exporter.FeatureEvent
 	}
 	type expected struct {
@@ -348,5 +348,5 @@ func TestFile_Export(t *testing.T) {
 
 func TestFile_IsBulk(t *testing.T) {
 	exporter := fileexporter.Exporter{}
-	assert.True(t, exporter.IsBulk(), "Exporter is a bulk exporter")
+	assert.True(t, exporter.IsBulk(), "DeprecatedExporter is a bulk exporter")
 }

--- a/exporter/gcstorageexporter/exporter.go
+++ b/exporter/gcstorageexporter/exporter.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"io"
-	"log"
 	"log/slog"
 	"os"
 
@@ -57,7 +56,7 @@ func (f *Exporter) IsBulk() bool {
 }
 
 // Export is saving a collection of events in a file.
-func (f *Exporter) Export(ctx context.Context, logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (f *Exporter) Export(ctx context.Context, logger *fflog.FFLogger, featureEvents []exporter.FeatureEvent) error {
 	// Init google storage client
 	client, err := storage.NewClient(ctx, f.Options...)
 	if err != nil {
@@ -98,7 +97,7 @@ func (f *Exporter) Export(ctx context.Context, logger *log.Logger, featureEvents
 	for _, file := range files {
 		of, err := os.Open(outputDir + "/" + file.Name())
 		if err != nil {
-			fflog.ConvertToFFLogger(logger).Error("[GCP Exporter] impossible to open the file",
+			logger.Error("[GCP DeprecatedExporter] impossible to open the file",
 				slog.String("path", outputDir+"/"+file.Name()))
 			continue
 		}
@@ -114,7 +113,7 @@ func (f *Exporter) Export(ctx context.Context, logger *log.Logger, featureEvents
 		_, err = io.Copy(wc, of)
 		_ = wc.Close()
 		if err != nil {
-			return fmt.Errorf("error: [Exporter] impossible to copy the file from %s to bucket %s: %v",
+			return fmt.Errorf("error: [DeprecatedExporter] impossible to copy the file from %s to bucket %s: %v",
 				source, f.Bucket, err)
 		}
 	}

--- a/exporter/gcstorageexporter/exporter_test.go
+++ b/exporter/gcstorageexporter/exporter_test.go
@@ -3,7 +3,8 @@ package gcstorageexporter_test
 import (
 	"context"
 	"crypto/tls"
-	"log"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -176,7 +177,7 @@ func TestGoogleStorage_Export(t *testing.T) {
 				},
 			}
 
-			// init Exporter
+			// init DeprecatedExporter
 			f := gcstorageexporter.Exporter{
 				Bucket: tt.fields.Bucket,
 				Options: []option.ClientOption{
@@ -190,7 +191,7 @@ func TestGoogleStorage_Export(t *testing.T) {
 				CsvTemplate: tt.fields.CsvTemplate,
 			}
 
-			err := f.Export(context.Background(), log.New(os.Stdout, "", 0), tt.events)
+			err := f.Export(context.Background(), &fflog.FFLogger{LeveledLogger: slog.Default()}, tt.events)
 			if tt.wantErr {
 				assert.Error(t, err, "Export should error")
 				return

--- a/exporter/kafkaexporter/exporter.go
+++ b/exporter/kafkaexporter/exporter.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/IBM/sarama"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
-	"log"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 const (
@@ -44,7 +44,7 @@ type Exporter struct {
 
 // Export will produce a message to the Kafka topic. The message's value will contain the event encoded in the
 // selected format. Messages are published synchronously and will error immediately on failure.
-func (e *Exporter) Export(_ context.Context, _ *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (e *Exporter) Export(_ context.Context, _ *fflog.FFLogger, featureEvents []exporter.FeatureEvent) error {
 	if e.sender == nil {
 		err := e.initializeProducer()
 		if err != nil {

--- a/exporter/kafkaexporter/exporter_test.go
+++ b/exporter/kafkaexporter/exporter_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
-	"os"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
+	"log/slog"
 	"testing"
 
 	"github.com/IBM/sarama"
@@ -25,7 +25,7 @@ func (s *messageSenderMock) SendMessages(msgs []*sarama.ProducerMessage) error {
 
 func TestExporter_IsBulk(t *testing.T) {
 	exp := Exporter{}
-	assert.False(t, exp.IsBulk(), "Exporter is not a bulk exporter")
+	assert.False(t, exp.IsBulk(), "DeprecatedExporter is not a bulk exporter")
 }
 
 func TestExporter_Export(t *testing.T) {
@@ -143,7 +143,7 @@ func TestExporter_Export(t *testing.T) {
 				dialer:   tt.dialer,
 			}
 
-			logger := log.New(os.Stdout, "", 0)
+			logger := &fflog.FFLogger{LeveledLogger: slog.Default()}
 			err := exp.Export(context.Background(), logger, tt.featureEvents)
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/exporter/logsexporter/exporter.go
+++ b/exporter/logsexporter/exporter.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
-	"log"
 	"sync"
 	"text/template"
 	"time"
@@ -32,7 +31,7 @@ type Exporter struct {
 }
 
 // Export is saving a collection of events in a file.
-func (f *Exporter) Export(_ context.Context, logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (f *Exporter) Export(_ context.Context, logger *fflog.FFLogger, featureEvents []exporter.FeatureEvent) error {
 	f.initTemplates.Do(func() {
 		// Remove below after deprecation of Format
 		if f.LogFormat == "" && f.Format != "" {
@@ -49,7 +48,7 @@ func (f *Exporter) Export(_ context.Context, logger *log.Logger, featureEvents [
 			FormattedDate string
 		}{FeatureEvent: event, FormattedDate: time.Unix(event.CreationDate, 0).Format(time.RFC3339)})
 
-		fflog.ConvertToFFLogger(logger).Info(log.String())
+		logger.Info(log.String())
 		if err != nil {
 			return err
 		}

--- a/exporter/package_info.go
+++ b/exporter/package_info.go
@@ -7,7 +7,7 @@
 //	  DataExporter: ffclient.DataExporter{
 //	   FlushInterval:   10 * time.Second,
 //	   MaxEventInMemory: 1000,
-//	   Exporter: &fileexporter.Exporter{
+//	   DeprecatedExporter: &fileexporter.DeprecatedExporter{
 //	     OutputDir: "/output-data/",
 //	   },
 //	 },

--- a/exporter/pubsubexporter/exporter.go
+++ b/exporter/pubsubexporter/exporter.go
@@ -1,12 +1,11 @@
 package pubsubexporter
 
 import (
+	"cloud.google.com/go/pubsub"
 	"context"
 	"encoding/json"
-	"log"
-
-	"cloud.google.com/go/pubsub"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"google.golang.org/api/option"
 )
 
@@ -36,7 +35,7 @@ type Exporter struct {
 }
 
 // Export publishes a PubSub message for each exporter.FeatureEvent received.
-func (e *Exporter) Export(ctx context.Context, _ *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (e *Exporter) Export(ctx context.Context, _ *fflog.FFLogger, featureEvents []exporter.FeatureEvent) error {
 	if e.publisher == nil {
 		if err := e.initPublisher(ctx); err != nil {
 			return err

--- a/exporter/pubsubexporter/exporter_test.go
+++ b/exporter/pubsubexporter/exporter_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
-	"os"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
+	"log/slog"
 	"testing"
 
 	"cloud.google.com/go/pubsub"
@@ -25,7 +25,7 @@ func TestExporter_Export(t *testing.T) {
 	)
 
 	ctx := context.TODO()
-	logger := log.New(os.Stdout, "", 0)
+	logger := &fflog.FFLogger{LeveledLogger: slog.Default()}
 
 	server := pstest.NewServer()
 	t.Cleanup(func() { server.Close() })

--- a/exporter/s3exporter/exporter_test.go
+++ b/exporter/s3exporter/exporter_test.go
@@ -2,7 +2,8 @@ package s3exporter
 
 import (
 	"context"
-	"log"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
+	"log/slog"
 	"os"
 	"testing"
 
@@ -48,7 +49,7 @@ func TestS3_Export(t *testing.T) {
 			expectedName: "^/flag-variation-" + hostname + "-[0-9]*\\.json$",
 		},
 		{
-			name: "With Exporter Path",
+			name: "With DeprecatedExporter Path",
 			fields: fields{
 				S3Path: "random/path",
 				Bucket: "test",
@@ -178,7 +179,7 @@ func TestS3_Export(t *testing.T) {
 				CsvTemplate: tt.fields.CsvTemplate,
 				s3Uploader:  &s3ManagerMock,
 			}
-			err := f.Export(context.Background(), log.New(os.Stdout, "", 0), tt.events)
+			err := f.Export(context.Background(), &fflog.FFLogger{LeveledLogger: slog.Default()}, tt.events)
 			if tt.wantErr {
 				assert.Error(t, err, "Export should error")
 				return
@@ -200,7 +201,7 @@ func Test_errSDK(t *testing.T) {
 		Bucket:    "empty",
 		AwsConfig: &aws.Config{},
 	}
-	err := f.Export(context.Background(), log.New(os.Stdout, "", 0), []exporter.FeatureEvent{})
+	err := f.Export(context.Background(), &fflog.FFLogger{LeveledLogger: slog.Default()}, []exporter.FeatureEvent{})
 	assert.Error(t, err, "Empty AWS config should failed")
 }
 

--- a/exporter/s3exporterv2/exporter.go
+++ b/exporter/s3exporterv2/exporter.go
@@ -10,7 +10,6 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/exporter/fileexporter"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
-	"log"
 	"log/slog"
 	"os"
 	"sync"
@@ -75,14 +74,13 @@ func (f *Exporter) initializeUploader(ctx context.Context) error {
 }
 
 // Export is saving a collection of events in a file.
-func (f *Exporter) Export(ctx context.Context, logger *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (f *Exporter) Export(ctx context.Context, logger *fflog.FFLogger, featureEvents []exporter.FeatureEvent) error {
 	if f.s3Uploader == nil {
 		initErr := f.initializeUploader(ctx)
 		if initErr != nil {
 			return initErr
 		}
 	}
-	f.ffLogger = fflog.ConvertToFFLogger(logger)
 
 	// Create a temp directory to store the file we will produce
 	outputDir, err := os.MkdirTemp("", "go_feature_flag_s3_export")
@@ -92,7 +90,7 @@ func (f *Exporter) Export(ctx context.Context, logger *log.Logger, featureEvents
 	defer func() { _ = os.Remove(outputDir) }()
 
 	// We call the File data exporter to get the file in the right format.
-	// Files will be put in the temp directory, so we will be able to upload them to Exporter from there.
+	// Files will be put in the temp directory, so we will be able to upload them to DeprecatedExporter from there.
 	fileExporter := fileexporter.Exporter{
 		Format:                  f.Format,
 		OutputDir:               outputDir,
@@ -105,7 +103,7 @@ func (f *Exporter) Export(ctx context.Context, logger *log.Logger, featureEvents
 		return err
 	}
 
-	// Upload all the files in the folder to Exporter
+	// Upload all the files in the folder to DeprecatedExporter
 	files, err := os.ReadDir(outputDir)
 	if err != nil {
 		return err

--- a/exporter/s3exporterv2/exporter_test.go
+++ b/exporter/s3exporterv2/exporter_test.go
@@ -2,7 +2,8 @@ package s3exporterv2
 
 import (
 	"context"
-	"log"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
+	"log/slog"
 	"os"
 	"testing"
 
@@ -49,7 +50,7 @@ func TestS3_Export(t *testing.T) {
 			expectedName: "^/flag-variation-" + hostname + "-[0-9]*\\.json$",
 		},
 		{
-			name: "With Exporter Path",
+			name: "With DeprecatedExporter Path",
 			fields: fields{
 				S3Path: "random/path",
 				Bucket: "test",
@@ -179,7 +180,7 @@ func TestS3_Export(t *testing.T) {
 				CsvTemplate: tt.fields.CsvTemplate,
 				s3Uploader:  &s3ManagerMock,
 			}
-			err := f.Export(context.Background(), log.New(os.Stdout, "", 0), tt.events)
+			err := f.Export(context.Background(), &fflog.FFLogger{LeveledLogger: slog.Default()}, tt.events)
 			if tt.wantErr {
 				assert.Error(t, err, "Export should error")
 				return
@@ -201,11 +202,11 @@ func Test_errSDK(t *testing.T) {
 		Bucket:    "empty",
 		AwsConfig: &aws.Config{},
 	}
-	err := f.Export(context.Background(), log.New(os.Stdout, "", 0), []exporter.FeatureEvent{})
+	err := f.Export(context.Background(), &fflog.FFLogger{LeveledLogger: slog.Default()}, []exporter.FeatureEvent{})
 	assert.Error(t, err, "Empty AWS config should failed")
 }
 
 func TestS3_IsBulk(t *testing.T) {
 	exporter := Exporter{}
-	assert.True(t, exporter.IsBulk(), "Exporter is a bulk exporter")
+	assert.True(t, exporter.IsBulk(), "DeprecatedExporter is a bulk exporter")
 }

--- a/exporter/sqsexporter/exporter.go
+++ b/exporter/sqsexporter/exporter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
-	"log"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"sync"
 )
 
@@ -27,7 +27,7 @@ type Exporter struct {
 }
 
 // Export is sending SQS event for each featureEvents received.
-func (f *Exporter) Export(ctx context.Context, _ *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (f *Exporter) Export(ctx context.Context, _ *fflog.FFLogger, featureEvents []exporter.FeatureEvent) error {
 	if f.AwsConfig == nil {
 		cfg, err := config.LoadDefaultConfig(ctx)
 		if err != nil {

--- a/exporter/sqsexporter/exporter_test.go
+++ b/exporter/sqsexporter/exporter_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
-	"log"
-	"os"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
+	"log/slog"
 	"strings"
 	"testing"
 )
@@ -31,7 +31,7 @@ func (s *SQSSendMessageAPIMock) SendMessage(ctx context.Context,
 
 func TestSQS_IsBulk(t *testing.T) {
 	exporter := Exporter{}
-	assert.False(t, exporter.IsBulk(), "Exporter is not a bulk exporter")
+	assert.False(t, exporter.IsBulk(), "DeprecatedExporter is not a bulk exporter")
 }
 
 func TestExporter_Export(t *testing.T) {
@@ -105,7 +105,7 @@ func TestExporter_Export(t *testing.T) {
 				sqsService: &tt.fields.sqsService,
 			}
 
-			logger := log.New(os.Stdout, "", 0)
+			logger := &fflog.FFLogger{LeveledLogger: slog.Default()}
 			err := f.Export(context.TODO(), logger, tt.featureEvents)
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/exporter/webhookexporter/exporter.go
+++ b/exporter/webhookexporter/exporter.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"sync"
@@ -61,7 +61,7 @@ type webhookPayload struct {
 }
 
 // Export is sending a collection of events in a webhook call.
-func (f *Exporter) Export(ctx context.Context, _ *log.Logger, featureEvents []exporter.FeatureEvent) error {
+func (f *Exporter) Export(ctx context.Context, _ *fflog.FFLogger, featureEvents []exporter.FeatureEvent) error {
 	f.init.Do(func() {
 		if f.httpClient == nil {
 			f.httpClient = internal.DefaultHTTPClient()

--- a/exporter/webhookexporter/exporter_test.go
+++ b/exporter/webhookexporter/exporter_test.go
@@ -2,7 +2,8 @@ package webhookexporter
 
 import (
 	"context"
-	"log"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
+	"log/slog"
 	"os"
 	"testing"
 
@@ -15,11 +16,11 @@ import (
 
 func TestWebhook_IsBulk(t *testing.T) {
 	exporter := Exporter{}
-	assert.True(t, exporter.IsBulk(), "Exporter is a bulk exporter")
+	assert.True(t, exporter.IsBulk(), "DeprecatedExporter is a bulk exporter")
 }
 
 func TestWebhook_Export(t *testing.T) {
-	logger := log.New(os.Stdout, "", 0)
+	logger := &fflog.FFLogger{LeveledLogger: slog.Default()}
 	type fields struct {
 		EndpointURL string
 		Secret      string
@@ -28,7 +29,7 @@ func TestWebhook_Export(t *testing.T) {
 		Headers     map[string][]string
 	}
 	type args struct {
-		logger        *log.Logger
+		logger        *fflog.FFLogger
 		featureEvents []exporter.FeatureEvent
 	}
 	type expected struct {
@@ -218,6 +219,6 @@ func TestWebhook_Export_impossibleToParse(t *testing.T) {
 		EndpointURL: " http://invalid.com/",
 	}
 
-	err := f.Export(context.Background(), log.New(os.Stdout, "", 0), []exporter.FeatureEvent{})
+	err := f.Export(context.Background(), &fflog.FFLogger{LeveledLogger: slog.Default()}, []exporter.FeatureEvent{})
 	assert.EqualError(t, err, "parse \" http://invalid.com/\": first path segment in URL cannot contain colon")
 }

--- a/testutils/slogutil/message_only_handler.go
+++ b/testutils/slogutil/message_only_handler.go
@@ -1,0 +1,32 @@
+package slogutil
+
+import (
+	"golang.org/x/net/context"
+	"log/slog"
+	"os"
+)
+
+type MessageOnlyHandler struct {
+	Writer *os.File
+}
+
+// Handle implements the slog.Handler interface.
+func (h *MessageOnlyHandler) Handle(_ context.Context, r slog.Record) error {
+	_, err := h.Writer.WriteString(r.Message + "\n")
+	return err
+}
+
+// Enabled implements the slog.Handler interface.
+func (h *MessageOnlyHandler) Enabled(_ context.Context, _ slog.Level) bool {
+	return true
+}
+
+// WithAttrs implements the slog.Handler interface.
+func (h *MessageOnlyHandler) WithAttrs(_ []slog.Attr) slog.Handler {
+	return h
+}
+
+// WithGroup implements the slog.Handler interface.
+func (h *MessageOnlyHandler) WithGroup(_ string) slog.Handler {
+	return h
+}

--- a/website/docs/go_module/data_collection/custom.md
+++ b/website/docs/go_module/data_collection/custom.md
@@ -9,7 +9,7 @@ To create a custom exporter you must have a `struct` that implements the [`expor
 ```go
 type Exporter interface {
   // Export will send the data to the exporter.
-  Export(context.Context, *log.Logger, []exporter.FeatureEvent) error
+  Export(context.Context, *fflog.FFLogger, []exporter.FeatureEvent) error
 
 	// IsBulk return false if we should directly send the data as soon as it is produced
 	// and true if we collect the data to send them in bulk.


### PR DESCRIPTION
## Description
The changes in the log have broken the log exporter by setting the log level to `ERROR` rather than `INFO`.

On this PR we have introduce a new exporter interface to use the new logger so we will be able to set the level of the logs (and back to `INFO` for the exporter).


## Closes issue(s)
Resolve #2053

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
