### PR TITLE
fix: Bump to go1.22.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thomaspoignant/go-feature-flag
 
-go 1.22.0
+go 1.22.5
 
 require (
 	cloud.google.com/go/pubsub v1.40.0

--- a/website/.ci/go.mod
+++ b/website/.ci/go.mod
@@ -1,3 +1,3 @@
 module github.com/thomaspoignant/go-feature-flag/website/.ci
 
-go 1.22.0
+go 1.22.5


### PR DESCRIPTION
## Description
There is a major CVE-2024-24790 in go stdlib, bumping GO will solve it.

## Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
