### PR TITLE
fix: scheduled steps on exact time

### DIFF
--- a/internal/flag/internal_flag.go
+++ b/internal/flag/internal_flag.go
@@ -175,7 +175,7 @@ func (f *InternalFlag) applyScheduledRolloutSteps() {
 	evaluationDate := time.Now()
 	if f.Scheduled != nil {
 		for _, steps := range *f.Scheduled {
-			if steps.Date != nil && steps.Date.Before(evaluationDate) {
+			if steps.Date != nil && (steps.Date.Before(evaluationDate) || steps.Date.Equal(evaluationDate)) {
 				f.Rules = MergeSetOfRules(f.GetRules(), steps.GetRules())
 				if steps.Disable != nil {
 					f.Disable = steps.Disable

--- a/internal/flag/internal_flag_test.go
+++ b/internal/flag/internal_flag_test.go
@@ -639,6 +639,58 @@ func TestInternalFlag_Value(t *testing.T) {
 			},
 		},
 		{
+			name: "Should only apply 1 scheduled step if step at the exact same time",
+			flag: flag.InternalFlag{
+				Variations: &map[string]*interface{}{
+					"variation_A": testconvert.Interface("value_A"),
+					"variation_B": testconvert.Interface("value_B"),
+				},
+				DefaultRule: &flag.Rule{
+					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
+				Scheduled: &[]flag.ScheduledStep{
+					{
+						InternalFlag: flag.InternalFlag{
+							DefaultRule: &flag.Rule{
+								VariationResult: testconvert.String("variation_B"),
+							},
+						},
+						Date: testconvert.Time(time.Date(2022, 1, 1, 12, 12, 12, 12, time.UTC)),
+					},
+					{
+						InternalFlag: flag.InternalFlag{
+							Variations: &map[string]*interface{}{
+								"variation_B": testconvert.Interface("value_QWERTY"),
+							},
+						},
+						Date: testconvert.Time(time.Now().Add(2 * time.Second)),
+					},
+				},
+			},
+			args: args{
+				flagName: "my-flag",
+				user:     ffcontext.NewEvaluationContextBuilder("user-key").AddCustom("gofeatureflag", ffcontext.GoffContextSpecifics{
+					CurrentDateTime: testconvert.Time(time.Date(2022, 1, 1, 12, 12, 12, 12, time.UTC)),
+				}).Build(),
+				flagContext: flag.Context{
+					DefaultSdkValue: "value_default",
+				},
+			},
+			want: "value_B",
+			want1: flag.ResolutionDetails{
+				Variant: "variation_B",
+				Reason:  flag.ReasonStatic,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
+			},
+		},
+		{
 			name: "Should apply all scheduled steps in the past",
 			flag: flag.InternalFlag{
 				Variations: &map[string]*interface{}{


### PR DESCRIPTION
## Description
Scheduled steps are included if we have the exact same date (only after).
This PR accept the steps if it is the exact date.

## Closes issue(s)
Link to this comment: https://github.com/thomaspoignant/go-feature-flag/issues/2054#issuecomment-2246655478

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
