### PR TITLE
fix: remove unused format verbs in error messages

### DIFF
--- a/feature_flag.go
+++ b/feature_flag.go
@@ -196,7 +196,7 @@ func (g *GoFeatureFlag) startFlagUpdaterDaemon() {
 			if !g.IsOffline() {
 				err := retrieveFlagsAndUpdateCache(g.config, g.cache, g.retrieverManager)
 				if err != nil {
-					g.config.internalLogger.Error("error while updating the cache: %v\n", slog.Any("error", err))
+					g.config.internalLogger.Error("Error while updating the cache.", slog.Any("error", err))
 				}
 			}
 		case <-g.bgUpdater.updaterChan:
@@ -290,7 +290,7 @@ func (g *GoFeatureFlag) ForceRefresh() bool {
 	}
 	err := retrieveFlagsAndUpdateCache(g.config, g.cache, g.retrieverManager)
 	if err != nil {
-		g.config.internalLogger.Error("error while force updating the cache: %v\n", slog.Any("error", err))
+		g.config.internalLogger.Error("Error while force updating the cache.", slog.Any("error", err))
 		return false
 	}
 	return true


### PR DESCRIPTION
## Description
This PR fixes unused format verbs in error messages.
I noticed that there is unused `%v` in the message while GitHub is down.
This should be occurred after 306b11751.
```
{"level":"error","ts":1723678691.5177238,"msg":"error while updating the cache: %v\n","error":{"error":"request to...
```

## Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
There is no reported issues.

## Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)
