### PR TITLE
chore(goreleaser): deprecation snapshot.name_template

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -665,4 +665,4 @@ scoops:
     license: MIT
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"


### PR DESCRIPTION
## Description
Address the goreleaser deprecation https://goreleaser.com/deprecations/#snapshotname_template