### PR TITLE
docs(website): fix invalid markdown

### DIFF
--- a/website/docs/getting_started/using-openfeature.md
+++ b/website/docs/getting_started/using-openfeature.md
@@ -13,7 +13,7 @@ GO Feature Flag is committed to **opensource** principles and **standardization*
 
 To seamlessly integrate with OpenFeature, we provide a lightweight, self-hosted API server called the **relay proxy**. This proxy leverages the core GO Feature Flag module internally. By deploying the relay proxy in your infrastructure, you can utilize Open Feature SDKs in conjunction with GO Feature Flag providers to evaluate your feature flags.
 
-For a comprehensive understanding of how Open Feature operates, please refer to the official **[Open Feature documentation](https://docs.openfeature.dev)**.tps://docs.openfeature.dev)**.
+For a comprehensive understanding of how Open Feature operates, please refer to the official **[Open Feature documentation](https://docs.openfeature.dev)**.
 
 ## Integration pattern
 

--- a/website/versioned_docs/version-v1.32.0/getting_started/using-openfeature.md
+++ b/website/versioned_docs/version-v1.32.0/getting_started/using-openfeature.md
@@ -13,7 +13,7 @@ GO Feature Flag is committed to **opensource** principles and **standardization*
 
 To seamlessly integrate with OpenFeature, we provide a lightweight, self-hosted API server called the **relay proxy**. This proxy leverages the core GO Feature Flag module internally. By deploying the relay proxy in your infrastructure, you can utilize Open Feature SDKs in conjunction with GO Feature Flag providers to evaluate your feature flags.
 
-For a comprehensive understanding of how Open Feature operates, please refer to the official **[Open Feature documentation](https://docs.openfeature.dev)**.tps://docs.openfeature.dev)**.
+For a comprehensive understanding of how Open Feature operates, please refer to the official **[Open Feature documentation](https://docs.openfeature.dev)**.
 
 ## Integration pattern
 

--- a/website/versioned_docs/version-v1.33.0/getting_started/using-openfeature.md
+++ b/website/versioned_docs/version-v1.33.0/getting_started/using-openfeature.md
@@ -13,7 +13,7 @@ GO Feature Flag is committed to **opensource** principles and **standardization*
 
 To seamlessly integrate with OpenFeature, we provide a lightweight, self-hosted API server called the **relay proxy**. This proxy leverages the core GO Feature Flag module internally. By deploying the relay proxy in your infrastructure, you can utilize Open Feature SDKs in conjunction with GO Feature Flag providers to evaluate your feature flags.
 
-For a comprehensive understanding of how Open Feature operates, please refer to the official **[Open Feature documentation](https://docs.openfeature.dev)**.tps://docs.openfeature.dev)**.
+For a comprehensive understanding of how Open Feature operates, please refer to the official **[Open Feature documentation](https://docs.openfeature.dev)**.
 
 ## Integration pattern
 


### PR DESCRIPTION
## Description

This PR fixes a minor error in the markdown of the "Using Open Feature SDKs" pages.

### Before

<img width="872" alt="image" src="https://github.com/user-attachments/assets/5ac6485a-7eb0-4497-af84-3e4ecf2934a4">


### After

<img width="857" alt="image" src="https://github.com/user-attachments/assets/9bdb60a5-71ec-416f-81d9-9f1ae16bbb69">

## Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
