### PR TITLE
chore(CI): Ignore deprecated notice because unmaintained otelecho

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters:
     - noctx
     - prealloc
     - rowserrcheck
-    - exportloopref
+    - copyloopvar
     - stylecheck
     - unconvert
     - unparam
@@ -58,6 +58,7 @@ issues:
         - staticcheck
         - revive
         - gosec
+        - copyloopvar
     - path: _mock.go
       linters:
         - funlen

--- a/cmd/relayproxy/api/server.go
+++ b/cmd/relayproxy/api/server.go
@@ -17,7 +17,7 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/ofrep"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/service"
-	"go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho" // nolint
 	"go.uber.org/zap"
 )
 

--- a/cmd/relayproxy/service/gofeatureflag.go
+++ b/cmd/relayproxy/service/gofeatureflag.go
@@ -59,7 +59,6 @@ func NewGoFeatureFlagClient(
 	retrievers := make([]retriever.Retriever, 0)
 	if proxyConf.Retrievers != nil {
 		for _, r := range *proxyConf.Retrievers {
-			r := r
 			currentRetriever, err := initRetriever(&r)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Description
CI was breaking the build because of the deprecation notice due to lack of maintenance of `otelecho`.
For now, we've decided to ignore the notice.

## Closes issue(s)
Resolve #2289

## Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
