### PR TITLE
fix: Scheduled rollout cause a data race

### DIFF
--- a/internal/flag/internal_flag_test.go
+++ b/internal/flag/internal_flag_test.go
@@ -1663,6 +1663,43 @@ func TestInternalFlag_Value(t *testing.T) {
 				Cacheable: true,
 			},
 		},
+		{
+			name: "Should return sdk default value when we have an error in the deep copy",
+			flag: flag.InternalFlag{
+				Experimentation: &flag.ExperimentationRollout{
+					Start: testconvert.Time(time.Now().Add(-15 * time.Second)),
+					End:   testconvert.Time(time.Now().Add(-5 * time.Second)),
+				},
+				Metadata: &map[string]interface{}{
+					"description": make(chan int),
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
+				Scheduled: &[]flag.ScheduledStep{
+					{
+						Date: testconvert.Time(time.Now().Add(-10 * time.Second)),
+						InternalFlag: flag.InternalFlag{
+							Experimentation: &flag.ExperimentationRollout{
+								Start: testconvert.Time(time.Now().Add(-5 * time.Second)),
+								End:   testconvert.Time(time.Now().Add(5 * time.Second)),
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				flagName: "my-flag",
+				user:     ffcontext.NewEvaluationContext("user-key"),
+				flagContext: flag.Context{
+					DefaultSdkValue: "default-sdk",
+				},
+			},
+			want: "default-sdk",
+			want1: flag.ResolutionDetails{
+				Variant:   "SdkDefault",
+				Reason:    flag.ReasonError,
+				ErrorCode: flag.ErrorCodeGeneral,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description
As reported in issue #2256, in some cases we can have a data race when using a scheduled rollout.

This PR fixes the issue by creating a deep copy of the flag before applying the scheduled steps.

## Closes issue(s)
Resolve #2256

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
