### PR TITLE
fix: allow to override authorized keys with env variables

### DIFF
--- a/cmd/relayproxy/config/config.go
+++ b/cmd/relayproxy/config/config.go
@@ -100,7 +100,8 @@ func New(flagSet *pflag.FlagSet, log *zap.Logger, version string) (*Config, erro
 	}
 	// Map environment variables
 	_ = k.Load(env.ProviderWithValue("", ".", func(s string, v string) (string, interface{}) {
-		if strings.HasPrefix(s, "RETRIEVERS") || strings.HasPrefix(s, "NOTIFIERS") {
+		if strings.HasPrefix(s, "RETRIEVERS") ||
+			strings.HasPrefix(s, "NOTIFIERS") {
 			configMap := k.Raw()
 			err := loadArrayEnv(s, v, configMap)
 			if err != nil {
@@ -109,6 +110,14 @@ func New(flagSet *pflag.FlagSet, log *zap.Logger, version string) (*Config, erro
 			}
 			return s, v
 		}
+
+		if strings.HasPrefix(s, "AUTHORIZEDKEYS_EVALUATION") {
+			return "authorizedKeys.evaluation", strings.Split(v, ",")
+		}
+		if strings.HasPrefix(s, "AUTHORIZEDKEYS_ADMIN") {
+			return "authorizedKeys.admin", strings.Split(v, ",")
+		}
+
 		return strings.ReplaceAll(strings.ToLower(s), "_", "."), v
 	}), nil)
 

--- a/cmd/relayproxy/config/config_test.go
+++ b/cmd/relayproxy/config/config_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"testing"
@@ -832,6 +833,21 @@ func TestMergeConfig_FromOSEnv(t *testing.T) {
 			assert.Equal(t, tt.want, got, "Config not matching")
 		})
 	}
+}
+
+func TestSetAPIKeysFromEnv(t *testing.T) {
+	os.Setenv("AUTHORIZEDKEYS_EVALUATION", "key1,key2,key 3")
+	os.Setenv("AUTHORIZEDKEYS_ADMIN", "key4,key5")
+
+	fileLocation := "../testdata/config/valid-file.yaml"
+	f := pflag.NewFlagSet("config", pflag.ContinueOnError)
+	f.String("config", "", "Location of your config file")
+	_ = f.Parse([]string{fmt.Sprintf("--config=%s", fileLocation)})
+
+	got, err := config.New(f, zap.L(), "1.X.X")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"key1", "key2", "key 3"}, got.AuthorizedKeys.Evaluation)
+	assert.Equal(t, []string{"key4", "key5"}, got.AuthorizedKeys.Admin)
 }
 
 func TestConfig_LogLevel(t *testing.T) {

--- a/website/docs/relay_proxy/configure_relay_proxy.md
+++ b/website/docs/relay_proxy/configure_relay_proxy.md
@@ -24,6 +24,8 @@ You can override file configurations using environment variables.
 
 Note that all environment variables should be uppercase.
 If you want to replace a nested fields, please use `_` to separate each field _(ex: `RETRIEVER_KIND`)_.
+
+In case of an array of string, you can add multiple values separated by a comma _(ex: `AUTHORIZEDKEYS_EVALUATION=my-first-key,my-second-key`)_.
 :::
 
 


### PR DESCRIPTION
## Description
allow to override authorized keys with env variables


## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
