### PR TITLE
fix: add BucketingKey to DTO converter functions

### DIFF
--- a/cmd/migrationcli/converter/converter.go
+++ b/cmd/migrationcli/converter/converter.go
@@ -94,6 +94,7 @@ func convertToDto(internalFlag flag.InternalFlag) dto.DTO {
 		Disable:     internalFlag.Disable,
 		Version:     internalFlag.Version,
 		DTOv1: dto.DTOv1{
+			BucketingKey:    internalFlag.BucketingKey,
 			Variations:      internalFlag.Variations,
 			Rules:           internalFlag.Rules,
 			DefaultRule:     internalFlag.DefaultRule,

--- a/model/dto/convert_v1.go
+++ b/model/dto/convert_v1.go
@@ -13,6 +13,7 @@ func ConvertV1DtoToInternalFlag(dto DTO) flag.InternalFlag {
 	}
 
 	return flag.InternalFlag{
+		BucketingKey:    dto.BucketingKey,
 		Variations:      dto.Variations,
 		Rules:           dto.Rules,
 		DefaultRule:     dto.DefaultRule,


### PR DESCRIPTION
## Description

Was pulling my hair trying to figure out why the new bucketing didn't work on the server. Turns out we forgot to add it to the converters, so it gets lost in the cache initialization phase.

Tests don't cover this, should they?

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
