### PR TITLE
chore: reorder imports in a consistent way

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,8 @@ linters:
     - unconvert
     - unparam
     - whitespace
+    - gofmt
+    - gci
 #    - gofumpt
 linters-settings:
   funlen:
@@ -37,6 +39,9 @@ linters-settings:
     checks: ["all","-S1023"]
   gofumpt:
     module-path: github.com/thomaspoignant/go-feature-flag
+  gci:
+    skip-generated: true
+    no-lex-order: true
 issues:
   exclude-dirs:
     - (^|/)bin($|/)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
     rev: v1.59.0
     hooks:
       - id: golangci-lint
+        entry: golangci-lint run --enable-only=gci --fix
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.11.0

--- a/cmd/editor/lamda_adapter.go
+++ b/cmd/editor/lamda_adapter.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	echoadapter "github.com/awslabs/aws-lambda-go-api-proxy/echo"

--- a/cmd/editor/main.go
+++ b/cmd/editor/main.go
@@ -1,11 +1,10 @@
 package main
 
 import (
-	echoadapter "github.com/awslabs/aws-lambda-go-api-proxy/echo"
-	"github.com/thomaspoignant/go-feature-flag/model/dto"
 	"net/http"
 	"os"
 
+	echoadapter "github.com/awslabs/aws-lambda-go-api-proxy/echo"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	custommiddleware "github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api/middleware"
@@ -13,6 +12,7 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/internal/utils"
 	"github.com/thomaspoignant/go-feature-flag/model"
+	"github.com/thomaspoignant/go-feature-flag/model/dto"
 )
 
 // This service is an API used to evaluate a flag with an evaluation context

--- a/cmd/jsonschema-generator/main.go
+++ b/cmd/jsonschema-generator/main.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
+	"os"
+
 	"github.com/invopop/jsonschema"
 	"github.com/jessevdk/go-flags"
 	"github.com/thomaspoignant/go-feature-flag/model/dto"
-	"log"
-	"os"
 )
 
 func main() {

--- a/cmd/lint/linter.go
+++ b/cmd/lint/linter.go
@@ -3,11 +3,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/model/dto"
 	"os"
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/thomaspoignant/go-feature-flag/model/dto"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 

--- a/cmd/lint/linter_test.go
+++ b/cmd/lint/linter_test.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
-import "testing"
 
 func TestLinter_Lint(t *testing.T) {
 	tests := []struct {

--- a/cmd/lint/main_test.go
+++ b/cmd/lint/main_test.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_Invalid_input_file(t *testing.T) {

--- a/cmd/migrationcli/converter/converter.go
+++ b/cmd/migrationcli/converter/converter.go
@@ -4,13 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/model/dto"
 	"os"
 	"strings"
 
 	"github.com/BurntSushi/toml"
-
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
+	"github.com/thomaspoignant/go-feature-flag/model/dto"
 	"gopkg.in/yaml.v3"
 )
 

--- a/cmd/migrationcli/converter/converter_test.go
+++ b/cmd/migrationcli/converter/converter_test.go
@@ -6,9 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
 	"github.com/stretchr/testify/assert"
-
 	"github.com/thomaspoignant/go-feature-flag/cmd/migrationcli/converter"
 )
 

--- a/cmd/migrationcli/main.go
+++ b/cmd/migrationcli/main.go
@@ -5,9 +5,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/thomaspoignant/go-feature-flag/cmd/migrationcli/converter"
-
 	"github.com/jessevdk/go-flags"
+	"github.com/thomaspoignant/go-feature-flag/cmd/migrationcli/converter"
 )
 
 func main() {

--- a/cmd/migrationcli/main_test.go
+++ b/cmd/migrationcli/main_test.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_OutputResult_stdout(t *testing.T) {

--- a/cmd/relayproxy/api/lambda_handler.go
+++ b/cmd/relayproxy/api/lambda_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	echoadapter "github.com/awslabs/aws-lambda-go-api-proxy/echo"

--- a/cmd/relayproxy/api/middleware/version_test.go
+++ b/cmd/relayproxy/api/middleware/version_test.go
@@ -1,14 +1,14 @@
 package middleware_test
 
 import (
-	"github.com/labstack/echo/v4"
-	middleware2 "github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api/middleware"
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	middleware2 "github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api/middleware"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
 )
 
 func TestVersion(t *testing.T) {

--- a/cmd/relayproxy/api/middleware/websocket_authorizer_test.go
+++ b/cmd/relayproxy/api/middleware/websocket_authorizer_test.go
@@ -2,14 +2,14 @@ package middleware_test
 
 import (
 	"fmt"
-	middleware2 "github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api/middleware"
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	middleware2 "github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api/middleware"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
 )
 
 func TestWebsocketAuthorizer(t *testing.T) {

--- a/cmd/relayproxy/api/middleware/zap_test.go
+++ b/cmd/relayproxy/api/middleware/zap_test.go
@@ -5,11 +5,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api/middleware"
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
-
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api/middleware"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )

--- a/cmd/relayproxy/api/opentelemetry/otel.go
+++ b/cmd/relayproxy/api/opentelemetry/otel.go
@@ -2,6 +2,8 @@ package opentelemetry
 
 import (
 	"context"
+	"net/url"
+
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -9,7 +11,6 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"net/url"
 )
 
 type OtelService struct {

--- a/cmd/relayproxy/config/config_test.go
+++ b/cmd/relayproxy/config/config_test.go
@@ -2,13 +2,13 @@ package config_test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"testing"
 
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -750,35 +750,35 @@ func TestMergeConfig_FromOSEnv(t *testing.T) {
 				FileFormat:      "yaml",
 				Host:            "localhost",
 				Retrievers: &[]config.RetrieverConf{
-					config.RetrieverConf{
+					{
 						Kind: "http",
 						URL:  "https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/examples/retriever_file/flags.goff.yaml",
 						HTTPHeaders: map[string][]string{
-							"authorization": []string{
+							"authorization": {
 								"test",
 							},
-							"token": []string{"token"},
+							"token": {"token"},
 						},
 					},
-					config.RetrieverConf{
+					{
 						Kind: "file",
 						Path: "examples/retriever_file/flags.goff.yaml",
 						HTTPHeaders: map[string][]string{
-							"token": []string{
+							"token": {
 								"11213123",
 							},
-							"authorization": []string{
+							"authorization": {
 								"test1",
 							},
 						},
 					},
-					config.RetrieverConf{
+					{
 						HTTPHeaders: map[string][]string{
 
-							"authorization": []string{
+							"authorization": {
 								"test1",
 							},
-							"x-goff-custom": []string{
+							"x-goff-custom": {
 								"custom",
 							},
 						},

--- a/cmd/relayproxy/config/retriever.go
+++ b/cmd/relayproxy/config/retriever.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+
 	"github.com/redis/go-redis/v9"
 )
 

--- a/cmd/relayproxy/controller/all_flags.go
+++ b/cmd/relayproxy/controller/all_flags.go
@@ -1,16 +1,16 @@
 package controller
 
 import (
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
-	"github.com/thomaspoignant/go-feature-flag/internal/flagstate"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/model"
+	"github.com/thomaspoignant/go-feature-flag/internal/flagstate"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type allFlags struct {

--- a/cmd/relayproxy/controller/all_flags_test.go
+++ b/cmd/relayproxy/controller/all_flags_test.go
@@ -2,7 +2,6 @@ package controller_test
 
 import (
 	"context"
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
 	"io"
 	"log/slog"
 	"net/http"
@@ -17,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/controller"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
 	"github.com/thomaspoignant/go-feature-flag/exporter/logsexporter"
 	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
 )

--- a/cmd/relayproxy/controller/collect_eval_data.go
+++ b/cmd/relayproxy/controller/collect_eval_data.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
@@ -9,7 +11,6 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/model"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"net/http"
 )
 
 type collectEvalData struct {

--- a/cmd/relayproxy/controller/flag_change.go
+++ b/cmd/relayproxy/controller/flag_change.go
@@ -2,11 +2,12 @@ package controller
 
 import (
 	"encoding/json"
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
 	"github.com/thomaspoignant/go-feature-flag/internal/utils"
-	http "net/http"
 )
 
 type FlagChangeAPICtrl struct {

--- a/cmd/relayproxy/controller/flag_change_test.go
+++ b/cmd/relayproxy/controller/flag_change_test.go
@@ -1,6 +1,12 @@
 package controller_test
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
@@ -8,11 +14,6 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
 	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
 	"golang.org/x/net/context"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"testing"
-	"time"
 )
 
 func TestPIFlagChange_WithConfigChange(t *testing.T) {

--- a/cmd/relayproxy/controller/flag_eval.go
+++ b/cmd/relayproxy/controller/flag_eval.go
@@ -2,15 +2,15 @@ package controller
 
 import (
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/model"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type flagEval struct {

--- a/cmd/relayproxy/controller/flag_eval_test.go
+++ b/cmd/relayproxy/controller/flag_eval_test.go
@@ -2,7 +2,6 @@ package controller_test
 
 import (
 	"context"
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
 	"io"
 	"io/ioutil"
 	"log/slog"
@@ -17,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/controller"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
 	"github.com/thomaspoignant/go-feature-flag/exporter/logsexporter"
 	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
 )

--- a/cmd/relayproxy/controller/retriever_refresh.go
+++ b/cmd/relayproxy/controller/retriever_refresh.go
@@ -1,13 +1,14 @@
 package controller
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"net/http"
 )
 
 type forceFlagsRefresh struct {

--- a/cmd/relayproxy/controller/retriever_refresh_test.go
+++ b/cmd/relayproxy/controller/retriever_refresh_test.go
@@ -1,15 +1,16 @@
 package controller_test
 
 import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/controller"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
 	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
-	"net/http/httptest"
-	"testing"
-	"time"
 )
 
 func Test_retriever_refresh_Handler_no_goff(t *testing.T) {

--- a/cmd/relayproxy/controller/utils.go
+++ b/cmd/relayproxy/controller/utils.go
@@ -2,12 +2,12 @@ package controller
 
 import (
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/ffcontext"
-	"github.com/thomaspoignant/go-feature-flag/internal/utils"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/model"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
+	"github.com/thomaspoignant/go-feature-flag/internal/utils"
 )
 
 // assertRequest is the function which validates the request, if not valid an echo.HTTPError is return.

--- a/cmd/relayproxy/controller/utils_test.go
+++ b/cmd/relayproxy/controller/utils_test.go
@@ -2,12 +2,13 @@ package controller
 
 import (
 	"fmt"
+	"net/http"
+	"testing"
+
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/model"
 	"github.com/thomaspoignant/go-feature-flag/ffcontext"
-	"net/http"
-	"testing"
 )
 
 func Test_assertRequest(t *testing.T) {

--- a/cmd/relayproxy/controller/ws_flag_change.go
+++ b/cmd/relayproxy/controller/ws_flag_change.go
@@ -1,12 +1,13 @@
 package controller
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/service"
 	"go.uber.org/zap"
-	"net/http"
-	"time"
 )
 
 // NewWsFlagChange is the constructor to create a new controller to handle websocket

--- a/cmd/relayproxy/controller/ws_flag_change_test.go
+++ b/cmd/relayproxy/controller/ws_flag_change_test.go
@@ -2,6 +2,10 @@ package controller_test
 
 import (
 	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -11,9 +15,6 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/notifier"
 	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
 	"go.uber.org/zap"
-	"net/http/httptest"
-	"strings"
-	"testing"
 )
 
 func Test_websocket_flag_change(t *testing.T) {
@@ -27,7 +28,7 @@ func Test_websocket_flag_change(t *testing.T) {
 				Deleted: nil,
 				Added:   nil,
 				Updated: map[string]notifier.DiffUpdated{
-					"my-flag": notifier.DiffUpdated{
+					"my-flag": {
 						Before: &flag.InternalFlag{
 							Variations: &map[string]*interface{}{
 								"A": testconvert.Interface(true),
@@ -76,7 +77,7 @@ func Test_websocket_flag_change(t *testing.T) {
 					},
 				},
 				Updated: map[string]notifier.DiffUpdated{
-					"my-flag": notifier.DiffUpdated{
+					"my-flag": {
 						Before: &flag.InternalFlag{
 							Variations: &map[string]*interface{}{
 								"A": testconvert.Interface(true),

--- a/cmd/relayproxy/log/logger_test.go
+++ b/cmd/relayproxy/log/logger_test.go
@@ -3,9 +3,8 @@ package log_test
 import (
 	"testing"
 
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/log"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/log"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )

--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -4,15 +4,14 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
-	"github.com/thomaspoignant/go-feature-flag/notifier"
-
 	"github.com/spf13/pflag"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/docs"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/log"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/service"
+	"github.com/thomaspoignant/go-feature-flag/notifier"
 	"go.uber.org/zap"
 )
 

--- a/cmd/relayproxy/metric/metrics_test.go
+++ b/cmd/relayproxy/metric/metrics_test.go
@@ -1,9 +1,10 @@
 package metric
 
 import (
+	"testing"
+
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestMetrics_IncAllFlag(t *testing.T) {

--- a/cmd/relayproxy/metric/notifier_prometheus_test.go
+++ b/cmd/relayproxy/metric/notifier_prometheus_test.go
@@ -1,11 +1,12 @@
 package metric
 
 import (
+	"testing"
+
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/notifier"
-	"testing"
 )
 
 func TestPrometheusNotifier_with_diff(t *testing.T) {

--- a/cmd/relayproxy/model/ofrep_error_response.go
+++ b/cmd/relayproxy/model/ofrep_error_response.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 )
 

--- a/cmd/relayproxy/ofrep/configuration.go
+++ b/cmd/relayproxy/ofrep/configuration.go
@@ -1,9 +1,10 @@
 package ofrep
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/model"
-	"net/http"
 )
 
 // Configuration is the entry point to get the configuration for OFREP.

--- a/cmd/relayproxy/ofrep/configuration_test.go
+++ b/cmd/relayproxy/ofrep/configuration_test.go
@@ -1,6 +1,11 @@
 package ofrep_test
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
@@ -8,10 +13,6 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/ofrep"
 	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
 	"golang.org/x/net/context"
-	"net/http"
-	"net/http/httptest"
-	"testing"
-	"time"
 )
 
 func Test_Configuration(t *testing.T) {

--- a/cmd/relayproxy/ofrep/evaluate.go
+++ b/cmd/relayproxy/ofrep/evaluate.go
@@ -2,6 +2,9 @@ package ofrep
 
 import (
 	"fmt"
+	"net/http"
+	"sort"
+
 	"github.com/labstack/echo/v4"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
@@ -13,8 +16,6 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/internal/utils"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	http "net/http"
-	"sort"
 )
 
 type EvaluateCtrl struct {

--- a/cmd/relayproxy/ofrep/evaluate_test.go
+++ b/cmd/relayproxy/ofrep/evaluate_test.go
@@ -2,8 +2,6 @@ package ofrep_test
 
 import (
 	"context"
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/ofrep"
 	"io"
 	"log/slog"
 	"net/http"
@@ -16,6 +14,8 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/ofrep"
 	"github.com/thomaspoignant/go-feature-flag/exporter/logsexporter"
 	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
 )

--- a/cmd/relayproxy/service/monitoring_test.go
+++ b/cmd/relayproxy/service/monitoring_test.go
@@ -2,13 +2,13 @@ package service_test
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
-	ffclient "github.com/thomaspoignant/go-feature-flag"
-	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	ffclient "github.com/thomaspoignant/go-feature-flag"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/service"
+	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
 )
 
 // Mock implementation of GoFeatureFlag for testing

--- a/cmd/relayproxy/service/notifier_websocket_test.go
+++ b/cmd/relayproxy/service/notifier_websocket_test.go
@@ -1,14 +1,13 @@
 package service_test
 
 import (
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/service"
-	"github.com/thomaspoignant/go-feature-flag/internal/flag"
-	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/service"
+	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/notifier"
+	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
 )
 
 type mockWebsocketService struct {
@@ -64,7 +63,7 @@ func TestNotify(t *testing.T) {
 			},
 		},
 		Updated: map[string]notifier.DiffUpdated{
-			"my-flag": notifier.DiffUpdated{
+			"my-flag": {
 				Before: &flag.InternalFlag{
 					Variations: &map[string]*interface{}{
 						"A": testconvert.Interface(true),

--- a/cmd/relayproxy/service/websocket.go
+++ b/cmd/relayproxy/service/websocket.go
@@ -1,8 +1,9 @@
 package service
 
 import (
-	"github.com/thomaspoignant/go-feature-flag/notifier"
 	"sync"
+
+	"github.com/thomaspoignant/go-feature-flag/notifier"
 )
 
 // WebsocketConn is an interface to be able to mock websocket.Conn

--- a/cmd/relayproxy/service/websocket_test.go
+++ b/cmd/relayproxy/service/websocket_test.go
@@ -1,12 +1,11 @@
 package service_test
 
 import (
-	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/service"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/service"
 	"github.com/thomaspoignant/go-feature-flag/notifier"
 )
 

--- a/config.go
+++ b/config.go
@@ -3,15 +3,14 @@ package ffclient
 import (
 	"context"
 	"errors"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log"
 	"log/slog"
 	"sync"
 	"time"
 
-	"github.com/thomaspoignant/go-feature-flag/retriever"
-
 	"github.com/thomaspoignant/go-feature-flag/notifier"
+	"github.com/thomaspoignant/go-feature-flag/retriever"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 // Config is the configuration of go-feature-flag.

--- a/config_collector.go
+++ b/config_collector.go
@@ -1,8 +1,9 @@
 package ffclient
 
 import (
-	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"time"
+
+	"github.com/thomaspoignant/go-feature-flag/exporter"
 )
 
 // DataExporter is the configuration of your export target.

--- a/config_test.go
+++ b/config_test.go
@@ -7,16 +7,14 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+	ffClient "github.com/thomaspoignant/go-feature-flag"
 	"github.com/thomaspoignant/go-feature-flag/retriever"
 	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
 	"github.com/thomaspoignant/go-feature-flag/retriever/githubretriever"
 	"github.com/thomaspoignant/go-feature-flag/retriever/gitlabretriever"
 	"github.com/thomaspoignant/go-feature-flag/retriever/httpretriever"
 	"github.com/thomaspoignant/go-feature-flag/retriever/s3retriever"
-
-	"github.com/stretchr/testify/assert"
-
-	ffClient "github.com/thomaspoignant/go-feature-flag"
 )
 
 func TestConfig_GetRetrievers(t *testing.T) {

--- a/exporter/common_test.go
+++ b/exporter/common_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/thomaspoignant/go-feature-flag/exporter"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/exporter"
 )
 
 func Test_ParseTemplate(t *testing.T) {

--- a/exporter/data_exporter.go
+++ b/exporter/data_exporter.go
@@ -2,11 +2,12 @@ package exporter
 
 import (
 	"context"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log"
 	"log/slog"
 	"sync"
 	"time"
+
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 const (

--- a/exporter/data_exporter_test.go
+++ b/exporter/data_exporter_test.go
@@ -3,17 +3,17 @@ package exporter_test
 import (
 	"context"
 	"errors"
-	"github.com/thejerf/slogassert"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/thejerf/slogassert"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/testutils/mock"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 func TestDataExporterScheduler_flushWithTime(t *testing.T) {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -2,8 +2,9 @@ package exporter
 
 import (
 	"context"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log"
+
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 // DeprecatedExporter is an interface to describe how an exporter looks like.

--- a/exporter/feature_event_test.go
+++ b/exporter/feature_event_test.go
@@ -4,10 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/thomaspoignant/go-feature-flag/ffcontext"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 )
 
 func TestNewFeatureEvent(t *testing.T) {

--- a/exporter/fileexporter/exporter.go
+++ b/exporter/fileexporter/exporter.go
@@ -3,7 +3,6 @@ package fileexporter
 import (
 	"context"
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"os"
 	"runtime"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"text/template"
 
 	"github.com/thomaspoignant/go-feature-flag/exporter"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"github.com/xitongsys/parquet-go-source/local"
 	"github.com/xitongsys/parquet-go/parquet"
 	"github.com/xitongsys/parquet-go/writer"

--- a/exporter/fileexporter/exporter_test.go
+++ b/exporter/fileexporter/exporter_test.go
@@ -2,7 +2,6 @@ package fileexporter_test
 
 import (
 	"context"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"os"
 	"runtime"
 	"testing"
@@ -10,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/exporter/fileexporter"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"github.com/xitongsys/parquet-go-source/local"
 	"github.com/xitongsys/parquet-go/parquet"
 	"github.com/xitongsys/parquet-go/reader"

--- a/exporter/gcstorageexporter/exporter.go
+++ b/exporter/gcstorageexporter/exporter.go
@@ -3,16 +3,14 @@ package gcstorageexporter
 import (
 	"context"
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"io"
 	"log/slog"
 	"os"
 
+	"cloud.google.com/go/storage"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/exporter/fileexporter"
-
-	"cloud.google.com/go/storage"
-
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"google.golang.org/api/option"
 )
 

--- a/exporter/gcstorageexporter/exporter_test.go
+++ b/exporter/gcstorageexporter/exporter_test.go
@@ -3,18 +3,17 @@ package gcstorageexporter_test
 import (
 	"context"
 	"crypto/tls"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 
-	"github.com/thomaspoignant/go-feature-flag/exporter/gcstorageexporter"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
+	"github.com/thomaspoignant/go-feature-flag/exporter/gcstorageexporter"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"google.golang.org/api/option"
 )
 

--- a/exporter/kafkaexporter/exporter.go
+++ b/exporter/kafkaexporter/exporter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/IBM/sarama"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"

--- a/exporter/kafkaexporter/exporter_test.go
+++ b/exporter/kafkaexporter/exporter_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
 	"testing"
 
 	"github.com/IBM/sarama"
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 type messageSenderMock struct {

--- a/exporter/logsexporter/exporter.go
+++ b/exporter/logsexporter/exporter.go
@@ -3,12 +3,12 @@ package logsexporter
 import (
 	"bytes"
 	"context"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"sync"
 	"text/template"
 	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/exporter"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 const defaultLoggerFormat = "[{{ .FormattedDate}}] user=\"{{ .UserKey}}\", flag=\"{{ .Key}}\", value=\"{{ .Value}}\""

--- a/exporter/logsexporter/exporter_test.go
+++ b/exporter/logsexporter/exporter_test.go
@@ -2,18 +2,16 @@ package logsexporter_test
 
 import (
 	"context"
-	"github.com/thomaspoignant/go-feature-flag/testutils/slogutil"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
 	"os"
 	"testing"
 
-	"github.com/thomaspoignant/go-feature-flag/exporter/logsexporter"
-
 	"github.com/stretchr/testify/assert"
-
 	"github.com/thomaspoignant/go-feature-flag/exporter"
+	"github.com/thomaspoignant/go-feature-flag/exporter/logsexporter"
 	"github.com/thomaspoignant/go-feature-flag/testutils"
+	"github.com/thomaspoignant/go-feature-flag/testutils/slogutil"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 func TestLog_Export(t *testing.T) {

--- a/exporter/pubsubexporter/exporter.go
+++ b/exporter/pubsubexporter/exporter.go
@@ -1,9 +1,10 @@
 package pubsubexporter
 
 import (
-	"cloud.google.com/go/pubsub"
 	"context"
 	"encoding/json"
+
+	"cloud.google.com/go/pubsub"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"google.golang.org/api/option"

--- a/exporter/pubsubexporter/exporter_test.go
+++ b/exporter/pubsubexporter/exporter_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
 	"testing"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"

--- a/exporter/s3exporter/exporter.go
+++ b/exporter/s3exporter/exporter.go
@@ -2,18 +2,17 @@ package s3exporter
 
 import (
 	"context"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
 	"os"
 	"sync"
-
-	"github.com/thomaspoignant/go-feature-flag/exporter"
-	"github.com/thomaspoignant/go-feature-flag/exporter/fileexporter"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
+	"github.com/thomaspoignant/go-feature-flag/exporter"
+	"github.com/thomaspoignant/go-feature-flag/exporter/fileexporter"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 // Deprecated: Please use s3exporterv2.DeprecatedExporter instead, it will use the go-aws-sdk-v2.

--- a/exporter/s3exporter/exporter_test.go
+++ b/exporter/s3exporter/exporter_test.go
@@ -2,17 +2,15 @@ package s3exporter
 
 import (
 	"context"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
 	"os"
 	"testing"
 
-	"github.com/thomaspoignant/go-feature-flag/exporter"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
-
+	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/testutils"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 func TestS3_Export(t *testing.T) {

--- a/exporter/s3exporterv2/exporter.go
+++ b/exporter/s3exporterv2/exporter.go
@@ -3,6 +3,10 @@ package s3exporterv2
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
@@ -10,9 +14,6 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/exporter/fileexporter"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
-	"log/slog"
-	"os"
-	"sync"
 )
 
 type Exporter struct {

--- a/exporter/s3exporterv2/exporter_test.go
+++ b/exporter/s3exporterv2/exporter_test.go
@@ -2,18 +2,15 @@ package s3exporterv2
 
 import (
 	"context"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
 	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-
-	"github.com/thomaspoignant/go-feature-flag/exporter"
-
 	"github.com/stretchr/testify/assert"
-
+	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/testutils"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 func TestS3_Export(t *testing.T) {

--- a/exporter/s3exporterv2/uploader_api.go
+++ b/exporter/s3exporterv2/uploader_api.go
@@ -2,6 +2,7 @@ package s3exporterv2
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )

--- a/exporter/sqsexporter/exporter.go
+++ b/exporter/sqsexporter/exporter.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
-	"sync"
 )
 
 type Exporter struct {
@@ -55,7 +56,7 @@ func (f *Exporter) Export(ctx context.Context, _ *fflog.FFLogger, featureEvents 
 			MessageBody: aws.String(string(messageBody)),
 			QueueUrl:    aws.String(f.QueueURL),
 			MessageAttributes: map[string]types.MessageAttributeValue{
-				"emitter": types.MessageAttributeValue{
+				"emitter": {
 					DataType:    aws.String("String"),
 					StringValue: aws.String("GO Feature Flag"),
 				},

--- a/exporter/sqsexporter/exporter_test.go
+++ b/exporter/sqsexporter/exporter_test.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
-	"log/slog"
-	"strings"
-	"testing"
 )
 
 type SQSSendMessageAPIMock struct {
@@ -121,7 +122,7 @@ func TestExporter_Export(t *testing.T) {
 					QueueUrl:     aws.String(tt.fields.QueueURL),
 					DelaySeconds: 0,
 					MessageAttributes: map[string]types.MessageAttributeValue{
-						"emitter": types.MessageAttributeValue{
+						"emitter": {
 							DataType:    aws.String("String"),
 							StringValue: aws.String("GO Feature Flag"),
 						},

--- a/exporter/webhookexporter/exporter.go
+++ b/exporter/webhookexporter/exporter.go
@@ -5,16 +5,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"io"
 	"net/http"
 	"os"
 	"sync"
 
 	"github.com/thomaspoignant/go-feature-flag/exporter"
-
 	"github.com/thomaspoignant/go-feature-flag/internal"
 	"github.com/thomaspoignant/go-feature-flag/internal/signer"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 // Exporter is the exporter of your data to a webhook.

--- a/exporter/webhookexporter/exporter_test.go
+++ b/exporter/webhookexporter/exporter_test.go
@@ -2,16 +2,14 @@ package webhookexporter
 
 import (
 	"context"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
 	"os"
 	"testing"
 
-	"github.com/thomaspoignant/go-feature-flag/exporter"
-
 	"github.com/stretchr/testify/assert"
-
+	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/testutils"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 func TestWebhook_IsBulk(t *testing.T) {

--- a/feature_flag.go
+++ b/feature_flag.go
@@ -3,8 +3,6 @@ package ffclient
 import (
 	"context"
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/model/dto"
-	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
 	"log"
 	"log/slog"
 	"os"
@@ -12,12 +10,12 @@ import (
 	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/exporter"
-	"github.com/thomaspoignant/go-feature-flag/retriever"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
-
-	"github.com/thomaspoignant/go-feature-flag/notifier/logsnotifier"
-
 	"github.com/thomaspoignant/go-feature-flag/internal/cache"
+	"github.com/thomaspoignant/go-feature-flag/model/dto"
+	"github.com/thomaspoignant/go-feature-flag/notifier/logsnotifier"
+	"github.com/thomaspoignant/go-feature-flag/retriever"
+	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 // Init the feature flag component with the configuration of ffclient.Config

--- a/feature_flag_bench_test.go
+++ b/feature_flag_bench_test.go
@@ -3,15 +3,14 @@ package ffclient_test
 import (
 	"bytes"
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"os"
 	"testing"
 	"text/template"
 	"time"
 
-	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
-
 	ffclient "github.com/thomaspoignant/go-feature-flag"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
+	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
 )
 
 var client *ffclient.GoFeatureFlag

--- a/ffcontext/context_test.go
+++ b/ffcontext/context_test.go
@@ -1,11 +1,12 @@
 package ffcontext_test
 
 import (
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
-	"testing"
-	"time"
 )
 
 func TestUser_AddCustomAttribute(t *testing.T) {

--- a/ffuser/user_test.go
+++ b/ffuser/user_test.go
@@ -1,9 +1,10 @@
 package ffuser_test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/ffuser"
-	"testing"
 )
 
 func TestUser_AddCustomAttribute(t *testing.T) {

--- a/internal/cache/cache_manager.go
+++ b/internal/cache/cache_manager.go
@@ -3,9 +3,6 @@ package cache
 import (
 	"encoding/json"
 	"errors"
-	"github.com/google/go-cmp/cmp"
-	"github.com/thomaspoignant/go-feature-flag/model/dto"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
 	"os"
 	"strings"
@@ -13,8 +10,10 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-
+	"github.com/google/go-cmp/cmp"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
+	"github.com/thomaspoignant/go-feature-flag/model/dto"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/cache/cache_manager_test.go
+++ b/internal/cache/cache_manager_test.go
@@ -1,20 +1,19 @@
 package cache_test
 
 import (
-	"github.com/thomaspoignant/go-feature-flag/model/dto"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
-	"gopkg.in/yaml.v3"
 	"log/slog"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/thomaspoignant/go-feature-flag/internal/flag"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/internal/cache"
+	"github.com/thomaspoignant/go-feature-flag/internal/flag"
+	"github.com/thomaspoignant/go-feature-flag/model/dto"
 	"github.com/thomaspoignant/go-feature-flag/notifier"
 	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
+	"gopkg.in/yaml.v3"
 )
 
 func Test_FlagCacheNotInit(t *testing.T) {

--- a/internal/cache/in_memory_cache.go
+++ b/internal/cache/in_memory_cache.go
@@ -2,11 +2,11 @@ package cache
 
 import (
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/model/dto"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
 
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
+	"github.com/thomaspoignant/go-feature-flag/model/dto"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 type InMemoryCache struct {

--- a/internal/cache/in_memory_cache_test.go
+++ b/internal/cache/in_memory_cache_test.go
@@ -1,12 +1,12 @@
 package cache_test
 
 import (
-	"github.com/thomaspoignant/go-feature-flag/model/dto"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/internal/cache"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
+	"github.com/thomaspoignant/go-feature-flag/model/dto"
 	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
 )
 

--- a/internal/cache/notification_service.go
+++ b/internal/cache/notification_service.go
@@ -1,13 +1,13 @@
 package cache
 
 import (
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
 	"sync"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/notifier"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 type Service interface {

--- a/internal/cache/notification_service_priv_test.go
+++ b/internal/cache/notification_service_priv_test.go
@@ -4,6 +4,10 @@ package cache_test
 
 import (
 	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/thejerf/slogassert"
 	"github.com/thomaspoignant/go-feature-flag/internal/cache"
@@ -11,9 +15,6 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/notifier"
 	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
-	"log/slog"
-	"testing"
-	"time"
 )
 
 func Test_notificationService_callNotifier(t *testing.T) {

--- a/internal/cache/notification_service_test.go
+++ b/internal/cache/notification_service_test.go
@@ -1,12 +1,13 @@
 package cache
 
 import (
+	"sync"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/notifier"
 	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
-	"sync"
-	"testing"
 )
 
 func Test_notificationService_getDifferences(t *testing.T) {

--- a/internal/flag/context_test.go
+++ b/internal/flag/context_test.go
@@ -1,9 +1,10 @@
 package flag_test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
-	"testing"
 )
 
 func TestContext_AddIntoEvaluationContextEnrichment(t *testing.T) {

--- a/internal/flag/internal_flag.go
+++ b/internal/flag/internal_flag.go
@@ -3,10 +3,10 @@ package flag
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"maps"
 	"time"
 
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/internal/internalerror"
 	"github.com/thomaspoignant/go-feature-flag/internal/utils"
 )

--- a/internal/flag/internal_flag_test.go
+++ b/internal/flag/internal_flag_test.go
@@ -5,10 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/thomaspoignant/go-feature-flag/ffcontext"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
 )

--- a/internal/flag/rule.go
+++ b/internal/flag/rule.go
@@ -6,9 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/thomaspoignant/go-feature-flag/ffcontext"
-
 	"github.com/nikunjy/rules/parser"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/internal/internalerror"
 	"github.com/thomaspoignant/go-feature-flag/internal/utils"
 )

--- a/internal/flag/rule_test.go
+++ b/internal/flag/rule_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/thomaspoignant/go-feature-flag/ffcontext"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
 )

--- a/internal/flagstate/flag_state.go
+++ b/internal/flagstate/flag_state.go
@@ -1,9 +1,10 @@
 package flagstate
 
 import (
+	"time"
+
 	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
-	"time"
 )
 
 // FlagState represents the state of an individual feature flag, with regard to a specific user, when it was called.

--- a/internal/internalerror/targeting_not_apply.go
+++ b/internal/internalerror/targeting_not_apply.go
@@ -2,6 +2,7 @@ package internalerror
 
 import (
 	"fmt"
+
 	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 )
 

--- a/internal/internalerror/targeting_not_apply_test.go
+++ b/internal/internalerror/targeting_not_apply_test.go
@@ -1,9 +1,10 @@
 package internalerror
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/ffcontext"
-	"testing"
 )
 
 func TestRuleNotApply_Error(t *testing.T) {

--- a/internal/utils/evaluation_ctx_converter_test.go
+++ b/internal/utils/evaluation_ctx_converter_test.go
@@ -1,10 +1,11 @@
 package utils_test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/internal/utils"
-	"testing"
 )
 
 func Test_ConvertEvaluationCtxFromReq(t *testing.T) {

--- a/internal/utils/hash_test.go
+++ b/internal/utils/hash_test.go
@@ -1,9 +1,10 @@
 package utils_test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/internal/utils"
-	"testing"
 )
 
 func TestHash(t *testing.T) {

--- a/internal/utils/json_type_extractor_test.go
+++ b/internal/utils/json_type_extractor_test.go
@@ -1,9 +1,10 @@
 package utils_test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/internal/utils"
-	"testing"
 )
 
 func Test_JSONTypeExtractor(t *testing.T) {

--- a/internal/utils/number_utils_test.go
+++ b/internal/utils/number_utils_test.go
@@ -1,9 +1,10 @@
 package utils_test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/internal/utils"
-	"testing"
 )
 
 func TestIsIntegral(t *testing.T) {

--- a/internal/utils/serializer_test.go
+++ b/internal/utils/serializer_test.go
@@ -3,9 +3,8 @@ package utils_test
 import (
 	"testing"
 
-	"github.com/thomaspoignant/go-feature-flag/ffcontext"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/internal/utils"
 )
 

--- a/model/dto/converter_test.go
+++ b/model/dto/converter_test.go
@@ -1,17 +1,15 @@
 package dto_test
 
 import (
-	"github.com/thomaspoignant/go-feature-flag/ffcontext"
-	"github.com/thomaspoignant/go-feature-flag/model/dto"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-
-	"github.com/thomaspoignant/go-feature-flag/testutils/flagv1"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
+	"github.com/thomaspoignant/go-feature-flag/model/dto"
+	"github.com/thomaspoignant/go-feature-flag/testutils/flagv1"
 	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
 )
 

--- a/notifier/logsnotifier/notifier.go
+++ b/notifier/logsnotifier/notifier.go
@@ -1,9 +1,10 @@
 package logsnotifier
 
 import (
+	"log/slog"
+
 	"github.com/thomaspoignant/go-feature-flag/notifier"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
-	"log/slog"
 )
 
 type Notifier struct {

--- a/notifier/logsnotifier/notifier_test.go
+++ b/notifier/logsnotifier/notifier_test.go
@@ -1,14 +1,14 @@
 package logsnotifier
 
 import (
-	"github.com/thejerf/slogassert"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
 	"testing"
 
+	"github.com/thejerf/slogassert"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/notifier"
 	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 func TestLogNotifier_Notify(t *testing.T) {

--- a/notifier/slacknotifier/notifier.go
+++ b/notifier/slacknotifier/notifier.go
@@ -12,11 +12,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/thomaspoignant/go-feature-flag/notifier"
-
 	"github.com/gdexlab/go-render/render"
 	"github.com/r3labs/diff/v3"
 	"github.com/thomaspoignant/go-feature-flag/internal"
+	"github.com/thomaspoignant/go-feature-flag/notifier"
 )
 
 const (

--- a/notifier/slacknotifier/notifier_test.go
+++ b/notifier/slacknotifier/notifier_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/notifier"
-
 	"github.com/thomaspoignant/go-feature-flag/testutils"
 	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
 )

--- a/notifier/webhooknotifier/notifier.go
+++ b/notifier/webhooknotifier/notifier.go
@@ -10,10 +10,9 @@ import (
 	"os"
 	"sync"
 
-	"github.com/thomaspoignant/go-feature-flag/notifier"
-
 	"github.com/thomaspoignant/go-feature-flag/internal"
 	"github.com/thomaspoignant/go-feature-flag/internal/signer"
+	"github.com/thomaspoignant/go-feature-flag/notifier"
 )
 
 // webhookReqBody is the format we are sending to the webhook

--- a/notifier/webhooknotifier/notifier_test.go
+++ b/notifier/webhooknotifier/notifier_test.go
@@ -10,9 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/notifier"
-	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
-
 	"github.com/thomaspoignant/go-feature-flag/testutils"
+	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
 )
 
 func Test_webhookNotifier_Notify(t *testing.T) {

--- a/retriever/fileretriever/retriever_test.go
+++ b/retriever/fileretriever/retriever_test.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
 )
 
 var expectedFile = `test-flag:

--- a/retriever/gcstorageretriever/retriever.go
+++ b/retriever/gcstorageretriever/retriever.go
@@ -8,7 +8,6 @@ import (
 	"io"
 
 	"cloud.google.com/go/storage"
-
 	"google.golang.org/api/option"
 )
 

--- a/retriever/githubretriever/retriever.go
+++ b/retriever/githubretriever/retriever.go
@@ -3,7 +3,6 @@ package githubretriever
 import (
 	"context"
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/retriever/shared"
 	"io"
 	"net/http"
 	"strconv"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/internal"
+	"github.com/thomaspoignant/go-feature-flag/retriever/shared"
 )
 
 // Retriever is a configuration struct for a GitHub retriever.

--- a/retriever/githubretriever/retriever_test.go
+++ b/retriever/githubretriever/retriever_test.go
@@ -7,10 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/retriever/githubretriever"
 	"github.com/thomaspoignant/go-feature-flag/testutils/mock"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_github_Retrieve(t *testing.T) {

--- a/retriever/gitlabretriever/retriever.go
+++ b/retriever/gitlabretriever/retriever.go
@@ -8,9 +8,8 @@ import (
 	"strings"
 	"time"
 
-	httpretriever "github.com/thomaspoignant/go-feature-flag/retriever/httpretriever"
-
 	"github.com/thomaspoignant/go-feature-flag/internal"
+	httpretriever "github.com/thomaspoignant/go-feature-flag/retriever/httpretriever"
 )
 
 // Retriever is a configuration struct for a GitHub retriever.

--- a/retriever/gitlabretriever/retriever_test.go
+++ b/retriever/gitlabretriever/retriever_test.go
@@ -6,10 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/retriever/gitlabretriever"
 	"github.com/thomaspoignant/go-feature-flag/testutils/mock"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func sampleText() string {

--- a/retriever/httpretriever/retriever.go
+++ b/retriever/httpretriever/retriever.go
@@ -3,12 +3,12 @@ package httpretriever
 import (
 	"context"
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/retriever/shared"
 	"io"
 	"net/http"
 	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/internal"
+	"github.com/thomaspoignant/go-feature-flag/retriever/shared"
 )
 
 // Retriever is a configuration struct for an HTTP endpoint retriever.

--- a/retriever/httpretriever/retriever_test.go
+++ b/retriever/httpretriever/retriever_test.go
@@ -5,10 +5,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/retriever/httpretriever"
 	"github.com/thomaspoignant/go-feature-flag/testutils/mock"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_httpRetriever_Retrieve(t *testing.T) {

--- a/retriever/manager.go
+++ b/retriever/manager.go
@@ -3,8 +3,9 @@ package retriever
 import (
 	"context"
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log/slog"
+
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 // Manager is a struct that managed the retrievers.

--- a/retriever/mongodbretriever/retriever.go
+++ b/retriever/mongodbretriever/retriever.go
@@ -3,6 +3,7 @@ package mongodbretriever
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/thomaspoignant/go-feature-flag/retriever"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"go.mongodb.org/mongo-driver/bson"

--- a/retriever/mongodbretriever/retriever_test.go
+++ b/retriever/mongodbretriever/retriever_test.go
@@ -3,11 +3,11 @@ package mongodbretriever
 import (
 	"context"
 	"encoding/json"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/testutils"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
 

--- a/retriever/redisretriever/retriever.go
+++ b/retriever/redisretriever/retriever.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	redis "github.com/redis/go-redis/v9"
 	"github.com/thomaspoignant/go-feature-flag/retriever"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
-	"strings"
 )
 
 type Retriever struct {

--- a/retriever/retriever.go
+++ b/retriever/retriever.go
@@ -2,8 +2,9 @@ package retriever
 
 import (
 	"context"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log"
+
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 // Retriever is the interface to create a Retriever to load you flags.

--- a/retriever/retriever_test.go
+++ b/retriever/retriever_test.go
@@ -1,14 +1,15 @@
 package retriever_test
 
 import (
+	"log"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
 	"github.com/thomaspoignant/go-feature-flag/retriever"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"golang.org/x/net/context"
-	"log"
-	"testing"
-	"time"
 )
 
 func TestMixLegacyTypesOfRetrievers(t *testing.T) {

--- a/retriever/s3retriever/retriever_test.go
+++ b/retriever/s3retriever/retriever_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/thomaspoignant/go-feature-flag/testutils"
 )
 

--- a/retriever/s3retrieverv2/downloader_api.go
+++ b/retriever/s3retrieverv2/downloader_api.go
@@ -2,9 +2,10 @@ package s3retrieverv2
 
 import (
 	"context"
+	"io"
+
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"io"
 )
 
 // DownloaderAPI provides methods to manage downloads to an S3 bucket.

--- a/retriever/s3retrieverv2/retriever.go
+++ b/retriever/s3retrieverv2/retriever.go
@@ -3,13 +3,13 @@ package s3retrieverv2
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
-
 	"github.com/thomaspoignant/go-feature-flag/retriever"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 // Retriever is a configuration struct for a S3 retriever.

--- a/retriever/s3retrieverv2/retriever_test.go
+++ b/retriever/s3retrieverv2/retriever_test.go
@@ -2,12 +2,13 @@ package s3retrieverv2
 
 import (
 	"context"
+	"os"
+	"testing"
+
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/retriever"
 	"github.com/thomaspoignant/go-feature-flag/testutils"
-	"os"
-	"testing"
 )
 
 func Test_s3Retriever_Retrieve(t *testing.T) {

--- a/retriever/shared/http.go
+++ b/retriever/shared/http.go
@@ -2,11 +2,12 @@ package shared
 
 import (
 	"errors"
-	"github.com/thomaspoignant/go-feature-flag/internal"
-	"golang.org/x/net/context"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/thomaspoignant/go-feature-flag/internal"
+	"golang.org/x/net/context"
 )
 
 func CallHTTPAPI(

--- a/testutils/flagv1/flag_data.go
+++ b/testutils/flagv1/flag_data.go
@@ -7,11 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/thomaspoignant/go-feature-flag/ffcontext"
-
-	"github.com/thomaspoignant/go-feature-flag/internal/flag"
-
 	"github.com/nikunjy/rules/parser"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
+	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/internal/utils"
 )
 

--- a/testutils/initializableretriever/retriever.go
+++ b/testutils/initializableretriever/retriever.go
@@ -2,9 +2,10 @@ package initializableretriever
 
 import (
 	"context"
+	"os"
+
 	"github.com/thomaspoignant/go-feature-flag/retriever"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
-	"os"
 )
 
 func NewMockInitializableRetriever(path string, status retriever.Status) Retriever {

--- a/testutils/s3managerv2_mock.go
+++ b/testutils/s3managerv2_mock.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"io"
 	"os"
 	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
 type S3ManagerV2Mock struct {

--- a/testutils/slogutil/message_only_handler.go
+++ b/testutils/slogutil/message_only_handler.go
@@ -1,9 +1,10 @@
 package slogutil
 
 import (
-	"golang.org/x/net/context"
 	"log/slog"
 	"os"
+
+	"golang.org/x/net/context"
 )
 
 type MessageOnlyHandler struct {

--- a/utils/fflog/log_test.go
+++ b/utils/fflog/log_test.go
@@ -1,12 +1,13 @@
 package fflog_test
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 	"log"
 	"log/slog"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
 )
 
 func TestFFLogger_Error(t *testing.T) {

--- a/variation.go
+++ b/variation.go
@@ -2,10 +2,10 @@ package ffclient
 
 import (
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/exporter"
-	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"maps"
 
+	"github.com/thomaspoignant/go-feature-flag/exporter"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/model"
 )

--- a/variation_all_flags_test.go
+++ b/variation_all_flags_test.go
@@ -2,13 +2,14 @@ package ffclient
 
 import (
 	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/exporter/fileexporter"
 	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/retriever/fileretriever"
-	"os"
-	"testing"
-	"time"
 )
 
 func TestAllFlagsState(t *testing.T) {

--- a/variation_test.go
+++ b/variation_test.go
@@ -4,6 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thejerf/slogassert"
@@ -19,12 +26,6 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/testutils/flagv1"
 	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
-	"log/slog"
-	"os"
-	"runtime"
-	"strings"
-	"testing"
-	"time"
 )
 
 type cacheMock struct {


### PR DESCRIPTION
## Description
The project had no safe guards in how the order of imports.
In this PR:
- Adds `gofmt` and `gci` in the linter.
- Reorder all the imports in a consistent way.
- Add auto-fix for `pre-commit` to be sure that we have the right order all the time.

## Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
