### PR TITLE
feat(release): Add an AWS Lambda ready archive in the releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -124,6 +124,19 @@ builds:
         goarch: arm
         goarm: 6
 
+  # Build an AWS lambda compatible binary
+  - id: go-feature-flag-lambda
+    main: ./cmd/relayproxy
+    binary: bootstrap
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - arm64
+    goarm:
+      - "7"
+
 archives:
   - id: go-feature-flag-migration-cli
     name_template: "go-feature-flag-migration-cli_\
@@ -189,6 +202,12 @@ archives:
       {{- if not (eq .Amd64 \"v1\") }}{{ .Amd64 }}{{ end }}"
     builds:
       - go-feature-flag-lint
+
+  - id: goff-lambda
+    name_template: "go-feature-flag-aws-lambda_{{ .Version }}"
+    format: zip
+    builds:
+      - go-feature-flag-lambda
 
 checksum:
   name_template: 'checksums.txt'

--- a/website/docs/relay_proxy/deploy_relay_proxy.md
+++ b/website/docs/relay_proxy/deploy_relay_proxy.md
@@ -58,3 +58,9 @@ your Lambda function.
 By configuring your GO Feature Flag relay proxy to run as an AWS Lambda function, you can take advantage of many
 benefits of serverless computing, including automatic scaling, reduced infrastructure costs, and simplified 
 deployment and management.
+
+:::info
+As part of our release process, we are building an archive ready to be deployed as AWS lambda.  
+You can find it in the [GitHub release page](https://github.com/thomaspoignant/go-feature-flag/releases),and you can use the assets named `go-feature-flag-aws-lambda_<version>.zip`.
+:::
+


### PR DESCRIPTION
## Description
When releasing GO Feature Flag we will now build and put as an archive a ready-to-be-used AWS lambda binary.

**Why is ready for AWS Lambda?**
- The archive is a zip.
- The binary name inside the zip is `bootstrap`.
- It has been build as `linux arm64` target.

## Closes issue(s)
Resolve #2405

## Checklist
- [x] I have tested this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
