### PR TITLE
fix: Handle errors in flagState conversion

### DIFF
--- a/gofferror/empty_bucketing_key.go
+++ b/gofferror/empty_bucketing_key.go
@@ -1,0 +1,12 @@
+package gofferror
+
+import "fmt"
+
+type EmptyBucketingKeyError struct {
+	Message string
+}
+
+// Implement the Error() method for the custom error type
+func (e *EmptyBucketingKeyError) Error() string {
+	return fmt.Sprintf("Error: %s", e.Message)
+}

--- a/internal/flag/internal_flag.go
+++ b/internal/flag/internal_flag.go
@@ -3,11 +3,11 @@ package flag
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/thomaspoignant/go-feature-flag/gofferror"
 	"maps"
 	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/ffcontext"
+	"github.com/thomaspoignant/go-feature-flag/gofferror"
 	"github.com/thomaspoignant/go-feature-flag/internal/internalerror"
 	"github.com/thomaspoignant/go-feature-flag/internal/utils"
 )
@@ -407,7 +407,7 @@ func (f *InternalFlag) GetBucketingKeyValue(ctx ffcontext.Context) (string, erro
 	}
 
 	if ctx.GetKey() == "" {
-		return "", &gofferror.EmptyBucketingKeyError{Message: "Empty bucketing key"}
+		return "", &gofferror.EmptyBucketingKeyError{Message: "Empty targeting key"}
 	}
 
 	return ctx.GetKey(), nil

--- a/internal/flag/internal_flag_test.go
+++ b/internal/flag/internal_flag_test.go
@@ -1700,6 +1700,77 @@ func TestInternalFlag_Value(t *testing.T) {
 				ErrorCode: flag.ErrorCodeGeneral,
 			},
 		},
+		{
+			name: "Empty targeting key",
+			flag: flag.InternalFlag{
+				Variations: &map[string]*interface{}{
+					"variation_A": testconvert.Interface(true),
+					"variation_B": testconvert.Interface(false),
+				},
+				DefaultRule: &flag.Rule{
+					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
+			},
+			args: args{
+				flagName: "my-flag",
+				user:     ffcontext.NewEvaluationContext(""),
+				flagContext: flag.Context{
+					DefaultSdkValue: false,
+				},
+			},
+			want: false,
+			want1: flag.ResolutionDetails{
+				Variant:      "SdkDefault",
+				Reason:       flag.ReasonError,
+				ErrorCode:    flag.ErrorCodeTargetingKeyMissing,
+				ErrorMessage: "Error: Empty targeting key",
+				Cacheable:    false,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
+			},
+		},
+		{
+			name: "Empty bucketing key",
+			flag: flag.InternalFlag{
+				Variations: &map[string]*interface{}{
+					"variation_A": testconvert.Interface(true),
+					"variation_B": testconvert.Interface(false),
+				},
+				DefaultRule: &flag.Rule{
+					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
+				BucketingKey: testconvert.String("teamId"),
+			},
+			args: args{
+				flagName: "my-flag",
+				user:     ffcontext.NewEvaluationContextBuilder("toto").AddCustom("teamId", "").Build(),
+				flagContext: flag.Context{
+					DefaultSdkValue: false,
+				},
+			},
+			want: false,
+			want1: flag.ResolutionDetails{
+				Variant:      "SdkDefault",
+				Reason:       flag.ReasonError,
+				ErrorCode:    flag.ErrorCodeTargetingKeyMissing,
+				ErrorMessage: "Error: Empty bucketing key",
+				Cacheable:    false,
+				Metadata: map[string]interface{}{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/flagstate/flag_state.go
+++ b/internal/flagstate/flag_state.go
@@ -37,6 +37,18 @@ func FromFlagEvaluation(key string, evaluationCtx ffcontext.Context,
 		}
 	}
 
+	if resolutionDetails.Reason == flag.ReasonError {
+		return FlagState{
+			Timestamp:    time.Now().Unix(),
+			TrackEvents:  currentFlag.IsTrackEvents(),
+			Failed:       resolutionDetails.ErrorCode != "",
+			ErrorCode:    resolutionDetails.ErrorCode,
+			ErrorDetails: resolutionDetails.ErrorMessage,
+			Reason:       resolutionDetails.Reason,
+			Metadata:     resolutionDetails.Metadata,
+		}
+	}
+
 	switch v := flagValue; v.(type) {
 	case int, float64, bool, string, []interface{}, map[string]interface{}:
 		return FlagState{

--- a/internal/flagstate/flag_state_test.go
+++ b/internal/flagstate/flag_state_test.go
@@ -63,6 +63,56 @@ func TestFromFlagEvaluation(t *testing.T) {
 				Metadata:     nil,
 			},
 		},
+		{
+			name:          "Flag evaluation valid type",
+			key:           "test-key",
+			evaluationCtx: ffcontext.NewEvaluationContext("my-key"),
+			flagCtx:       flag.Context{},
+			currentFlag: &flag.InternalFlag{
+				Disable: testconvert.Bool(false),
+				Variations: &map[string]*interface{}{
+					"var1": testconvert.Interface(1),
+					"var2": testconvert.Interface(2),
+				},
+				DefaultRule: &flag.Rule{
+					VariationResult: testconvert.String("var1"),
+				},
+			},
+			expected: flagstate.FlagState{
+				Value:         1,
+				VariationType: "var1",
+				Timestamp:     time.Now().Unix(),
+				TrackEvents:   true,
+				Failed:        false,
+				Reason:        flag.ReasonStatic,
+				Metadata:      nil,
+			},
+		},
+		{
+			name:          "Flag evaluation invalid type",
+			key:           "test-key",
+			evaluationCtx: ffcontext.NewEvaluationContext("my-key"),
+			flagCtx:       flag.Context{},
+			currentFlag: &flag.InternalFlag{
+				Disable: testconvert.Bool(false),
+				Variations: &map[string]*interface{}{
+					"var1": testconvert.Interface(map[bool]*interface{}{true: testconvert.Interface(1)}),
+					"var2": testconvert.Interface(map[bool]*interface{}{true: testconvert.Interface(2)}),
+				},
+				DefaultRule: &flag.Rule{
+					VariationResult: testconvert.String("var1"),
+				},
+			},
+			expected: flagstate.FlagState{
+				VariationType: "SdkDefault",
+				Timestamp:     time.Now().Unix(),
+				TrackEvents:   true,
+				Failed:        true,
+				Reason:        flag.ReasonError,
+				ErrorCode:     flag.ErrorCodeTypeMismatch,
+				Metadata:      nil,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/flagstate/flag_state_test.go
+++ b/internal/flagstate/flag_state_test.go
@@ -1,7 +1,6 @@
 package flagstate_test
 
 import (
-	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
 	"testing"
 	"time"
 
@@ -9,6 +8,7 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/ffcontext"
 	"github.com/thomaspoignant/go-feature-flag/internal/flag"
 	"github.com/thomaspoignant/go-feature-flag/internal/flagstate"
+	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
 )
 
 func TestFromFlagEvaluation(t *testing.T) {
@@ -58,7 +58,7 @@ func TestFromFlagEvaluation(t *testing.T) {
 				TrackEvents:  true,
 				Failed:       true,
 				ErrorCode:    flag.ErrorCodeTargetingKeyMissing,
-				ErrorDetails: "Error: Empty bucketing key",
+				ErrorDetails: "Error: Empty targeting key",
 				Reason:       flag.ReasonError,
 				Metadata:     nil,
 			},

--- a/internal/flagstate/flag_state_test.go
+++ b/internal/flagstate/flag_state_test.go
@@ -1,0 +1,74 @@
+package flagstate_test
+
+import (
+	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/ffcontext"
+	"github.com/thomaspoignant/go-feature-flag/internal/flag"
+	"github.com/thomaspoignant/go-feature-flag/internal/flagstate"
+)
+
+func TestFromFlagEvaluation(t *testing.T) {
+	tests := []struct {
+		name          string
+		key           string
+		evaluationCtx ffcontext.Context
+		flagCtx       flag.Context
+		currentFlag   flag.Flag
+		expected      flagstate.FlagState
+	}{
+		{
+			name:          "Flag is disabled",
+			key:           "test-key",
+			evaluationCtx: ffcontext.NewEvaluationContext("user-key"),
+			flagCtx:       flag.Context{},
+			currentFlag: &flag.InternalFlag{
+				Disable: testconvert.Bool(true),
+			},
+			expected: flagstate.FlagState{
+				Timestamp:    time.Now().Unix(),
+				TrackEvents:  true,
+				Failed:       false,
+				ErrorCode:    "",
+				ErrorDetails: "",
+				Reason:       flag.ReasonDisabled,
+				Metadata:     nil,
+			},
+		},
+		{
+			name:          "Flag evaluation error",
+			key:           "test-key",
+			evaluationCtx: ffcontext.NewEvaluationContext(""),
+			flagCtx:       flag.Context{},
+			currentFlag: &flag.InternalFlag{
+				Disable: testconvert.Bool(false),
+				Variations: &map[string]*interface{}{
+					"var1": testconvert.Interface(1),
+					"var2": testconvert.Interface(2),
+				},
+				DefaultRule: &flag.Rule{
+					VariationResult: testconvert.String("var1"),
+				},
+			},
+			expected: flagstate.FlagState{
+				Timestamp:    time.Now().Unix(),
+				TrackEvents:  true,
+				Failed:       true,
+				ErrorCode:    flag.ErrorCodeTargetingKeyMissing,
+				ErrorDetails: "Error: Empty bucketing key",
+				Reason:       flag.ReasonError,
+				Metadata:     nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := flagstate.FromFlagEvaluation(tt.key, tt.evaluationCtx, tt.flagCtx, tt.currentFlag)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
## Description
When not setting a `targetingKey` and calling `allFlagState` we had an error saying that the `TYPE_MISMATCH` which was not explicit enough to understand the issue.

Not we are returning `TARGETING_KEY_MISSING` which is more explicit.

## Closes issue(s)
Resolve #2453

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
