### PR TITLE
chore: remove unused symlink

### DIFF
--- a/cmd/server
+++ b/cmd/server
@@ -1,1 +1,0 @@
-relayproxy


### PR DESCRIPTION
## Description
Remove `cmd/server` symlink that is un-used.

> [!NOTE]  
> At some point we wanted to get rid of the name relay-proxy and rather call it go-feature-flag server.
> But now the name is well adopted now, so I think it is ok to remove the symlink.

## Closes issue(s)
Resolve #2484 

## Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
