### PR TITLE
feat: Detect undefined variations

### DIFF
--- a/internal/flag/internal_flag.go
+++ b/internal/flag/internal_flag.go
@@ -295,13 +295,13 @@ func (f *InternalFlag) IsValid() error {
 
 	const isDefaultRule = true
 	// Validate rules
-	if err := f.GetDefaultRule().IsValid(isDefaultRule); err != nil {
+	if err := f.GetDefaultRule().IsValid(isDefaultRule, f.GetVariations()); err != nil {
 		return err
 	}
 
 	ruleNames := map[string]interface{}{}
 	for _, rule := range f.GetRules() {
-		if err := rule.IsValid(!isDefaultRule); err != nil {
+		if err := rule.IsValid(!isDefaultRule, f.GetVariations()); err != nil {
 			return err
 		}
 

--- a/internal/flag/internal_flag_test.go
+++ b/internal/flag/internal_flag_test.go
@@ -1993,7 +1993,7 @@ func TestInternalFlag_GetVariationValue(t *testing.T) {
 		want      interface{}
 	}{
 		{
-			name: "Should return nil if variation does not exists",
+			name: "Should return nil if variation does not exist",
 			flag: flag.InternalFlag{
 				Variations: &map[string]*interface{}{
 					"varA": testconvert.Interface("valueA"),
@@ -2379,7 +2379,7 @@ func TestInternalFlag_IsValid(t *testing.T) {
 					VariationResult: testconvert.String("C"),
 				},
 			},
-			errorMsg: "invalid variation: C does not exists",
+			errorMsg: "invalid variation: C does not exist",
 			wantErr:  assert.Error,
 		},
 		{
@@ -2397,7 +2397,7 @@ func TestInternalFlag_IsValid(t *testing.T) {
 					},
 				},
 			},
-			errorMsg: "invalid percentage: variation C does not exists",
+			errorMsg: "invalid percentage: variation C does not exist",
 			wantErr:  assert.Error,
 		},
 		{
@@ -2422,7 +2422,7 @@ func TestInternalFlag_IsValid(t *testing.T) {
 					},
 				},
 			},
-			errorMsg: "invalid progressive rollout, end variation C does not exists",
+			errorMsg: "invalid progressive rollout, end variation C does not exist",
 			wantErr:  assert.Error,
 		},
 		{
@@ -2447,7 +2447,7 @@ func TestInternalFlag_IsValid(t *testing.T) {
 					},
 				},
 			},
-			errorMsg: "invalid progressive rollout, initial variation C does not exists",
+			errorMsg: "invalid progressive rollout, initial variation C does not exist",
 			wantErr:  assert.Error,
 		},
 		{
@@ -2467,7 +2467,7 @@ func TestInternalFlag_IsValid(t *testing.T) {
 					VariationResult: testconvert.String("A"),
 				},
 			},
-			errorMsg: "invalid variation: C does not exists",
+			errorMsg: "invalid variation: C does not exist",
 			wantErr:  assert.Error,
 		},
 		{
@@ -2491,7 +2491,7 @@ func TestInternalFlag_IsValid(t *testing.T) {
 					VariationResult: testconvert.String("A"),
 				},
 			},
-			errorMsg: "invalid percentage: variation C does not exists",
+			errorMsg: "invalid percentage: variation C does not exist",
 			wantErr:  assert.Error,
 		},
 		{
@@ -2522,7 +2522,7 @@ func TestInternalFlag_IsValid(t *testing.T) {
 					VariationResult: testconvert.String("A"),
 				},
 			},
-			errorMsg: "invalid progressive rollout, initial variation C does not exists",
+			errorMsg: "invalid progressive rollout, initial variation C does not exist",
 			wantErr:  assert.Error,
 		},
 		{
@@ -2553,7 +2553,7 @@ func TestInternalFlag_IsValid(t *testing.T) {
 					VariationResult: testconvert.String("A"),
 				},
 			},
-			errorMsg: "invalid progressive rollout, end variation C does not exists",
+			errorMsg: "invalid progressive rollout, end variation C does not exist",
 			wantErr:  assert.Error,
 		},
 	}

--- a/internal/flag/rule.go
+++ b/internal/flag/rule.go
@@ -243,7 +243,7 @@ func (r *Rule) IsValid(defaultRule bool, variations map[string]*interface{}) err
 		for k, p := range r.GetPercentages() {
 			count += p
 			if _, ok := variations[k]; !ok {
-				return fmt.Errorf("invalid percentage: variation %s does not exists", k)
+				return fmt.Errorf("invalid percentage: variation %s does not exist", k)
 			}
 		}
 
@@ -266,19 +266,19 @@ func (r *Rule) IsValid(defaultRule bool, variations map[string]*interface{}) err
 
 		endVar := r.GetProgressiveRollout().End.getVariation()
 		if _, ok := variations[endVar]; !ok {
-			return fmt.Errorf("invalid progressive rollout, end variation %s does not exists", endVar)
+			return fmt.Errorf("invalid progressive rollout, end variation %s does not exist", endVar)
 		}
 
 		initialVar := r.GetProgressiveRollout().Initial.getVariation()
 		if _, ok := variations[initialVar]; !ok {
-			return fmt.Errorf("invalid progressive rollout, initial variation %s does not exists", initialVar)
+			return fmt.Errorf("invalid progressive rollout, initial variation %s does not exist", initialVar)
 		}
 	}
 
 	// Check that the variation exists
 	if r.Percentages == nil && r.ProgressiveRollout == nil && r.VariationResult != nil {
 		if _, ok := variations[r.GetVariationResult()]; !ok {
-			return fmt.Errorf("invalid variation: %s does not exists", r.GetVariationResult())
+			return fmt.Errorf("invalid variation: %s does not exist", r.GetVariationResult())
 		}
 	}
 	return nil

--- a/variation_all_flags_test.go
+++ b/variation_all_flags_test.go
@@ -32,17 +32,6 @@ func TestAllFlagsState(t *testing.T) {
 			initModule: true,
 		},
 		{
-			name: "Error in flag-0",
-			config: Config{
-				Retriever: &fileretriever.Retriever{
-					Path: "./testdata/ffclient/all_flags/config_flag/flag-config-with-error.yaml",
-				},
-			},
-			valid:      false,
-			jsonOutput: "./testdata/ffclient/all_flags/marshal_json/error_in_flag_0.json",
-			initModule: true,
-		},
-		{
 			name: "module not init",
 			config: Config{
 				Retriever: &fileretriever.Retriever{


### PR DESCRIPTION
## Description
In this PR we had a new check when validating a feature flag to check if we reference an undefined variation in one of the rule configuration.

The effect of this PR is double, it will allow the linter to detect those issues and it will discard this flag (and log an error)  for misconfigured flags.

## Closes issue(s)
Resolve #2652

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
