### PR TITLE
fix: Notifier should fire during runtime (if isInit is false)

### DIFF
--- a/feature_flag.go
+++ b/feature_flag.go
@@ -279,7 +279,7 @@ func retrieveFlagsAndUpdateCache(config Config, cache cache.Manager,
 		return err
 	}
 
-	err = cache.UpdateCache(newFlags, config.internalLogger, isInit && !config.DisableNotifierOnInit)
+	err = cache.UpdateCache(newFlags, config.internalLogger, !(isInit && config.DisableNotifierOnInit))
 	if err != nil {
 		log.Printf("error: impossible to update the cache of the flags: %v", err)
 		return err


### PR DESCRIPTION

## Description
This is a bug fix for #2534 

#2534 had an incorrect logic of NOT calling notifier when the status is not set to `isInit` (=upon polling).
It should:
* NOT call notifier only if `isInit`  && `DisableNotifierOnInit` are BOTH true
* call the notifier in any other cases

## Closes issue(s)
