### PR TITLE
Add Minder OpenSSF project to adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -2,13 +2,14 @@
 
 Thank you for trusting the `go-feature-flag` and using it in your organization.
 
-| **Organizartion**    | **Website / Contact**                                 | **Description of use**                         |
-|----------------------|-------------------------------------------------------|------------------------------------------------|
+| **Organization**     | **Website / Contact**                                 | **Description of use**                         |
+| -------------------- | ----------------------------------------------------- | ---------------------------------------------- |
 | Cast.ai              | https://cast.ai/                                      |                                                |
 | Chapati systems      | https://chapati.systems/                              |                                                |
 | Lyft                 | https://github.com/lyft/atlantis                      | Inside the Atlantis fork used by Lyft.         |
 | Tencent              | https://github.com/TencentBlueKing/bkmonitor-datalink | Used inside BKMONITOR-DATALINK.                |
 | Agentero             | https://agentero.com/                                 | FF tool within Agentero platform               |
-| Stacklok             | https://github.com/stacklok/minder                    |                                                |
-| HelloWorldCS         | https://helloworldcs.org                              | Feature flags for internal tools + app         | 
+| Minder (OpenSSF)     | https://github.com/mindersec/minder                   | Feature flags using OpenFeature                |
+| Stacklok             | https://github.com/stacklok/                          | Feature flags (looking at using relay)         |
+| HelloWorldCS         | https://helloworldcs.org                              | Feature flags for internal tools + app         |
 | Alternative Payments | https://www.alternativepayments.io                    | Feature Flagging for frontend and backend apps |


### PR DESCRIPTION
## Description
Updates link to Minder, which has been donated to the OpenSSF.  Stacklok is also using Go Feature Flag internally, and may be using the relay soon.

## Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
