### PR TITLE
feat: Add Discord Notifier

### DIFF
--- a/notifier/discordnotifier/notifier.go
+++ b/notifier/discordnotifier/notifier.go
@@ -1,0 +1,158 @@
+package discordnotifier
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/luci/go-render/render"
+	"github.com/r3labs/diff/v3"
+	"github.com/thomaspoignant/go-feature-flag/internal"
+	"github.com/thomaspoignant/go-feature-flag/notifier"
+)
+
+const (
+	goFFLogo        = "https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/logo_128.png"
+	colorDeleted    = 15158332  
+	colorUpdated    = 16753920  
+	colorAdded      = 32768     
+	longDiscordField = 35
+)
+
+type Notifier struct {
+	DiscordWebhookURL string
+
+	httpClient internal.HTTPClient
+	init       sync.Once
+}
+
+func (c *Notifier) Notify(diff notifier.DiffCache) error {
+	if c.DiscordWebhookURL == "" {
+		return fmt.Errorf("error: (Discord Notifier) invalid notifier configuration, no DiscordWebhookURL provided")
+	}
+
+	// init the notifier
+	c.init.Do(func() {
+		if c.httpClient == nil {
+			c.httpClient = internal.DefaultHTTPClient()
+		}
+	})
+
+	discordURL, err := url.Parse(c.DiscordWebhookURL)
+	if err != nil {
+		return fmt.Errorf("error: (Discord Notifier) invalid DiscordWebhookURL: %v", c.DiscordWebhookURL)
+	}
+
+	reqBody := convertToDiscordMessage(diff)
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("error: (Discord Notifier) failed to create message payload; %v", err)
+	}
+	request := http.Request{
+		Method: http.MethodPost,
+		URL:    discordURL,
+		Body:   io.NopCloser(bytes.NewReader(payload)),
+		Header: map[string][]string{"Content-Type": {"application/json"}},
+	}
+	response, err := c.httpClient.Do(&request)
+	if err != nil {
+		return fmt.Errorf("error: (Discord Notifier) error calling webhook: %v", err)
+	}
+
+	defer response.Body.Close()
+	if response.StatusCode > 399 {
+		return fmt.Errorf("error: (Discord Notifier) webhook call failed with statusCode = %d", response.StatusCode)
+	}
+
+	return nil
+}
+
+func convertToDiscordMessage(diffCache notifier.DiffCache) discordMessage {
+	hostname, _ := os.Hostname()
+	embeds := convertDeletedFlagsToDiscordEmbed(diffCache)
+	embeds = append(embeds, convertUpdatedFlagsToDiscordEmbed(diffCache)...)
+	embeds = append(embeds, convertAddedFlagsToDiscordEmbed(diffCache)...)
+
+	return discordMessage{
+		Content: fmt.Sprintf("Changes detected in your feature flag file on: **%s**", hostname),
+		Embeds:  embeds,
+	}
+}
+
+func convertDeletedFlagsToDiscordEmbed(diffCache notifier.DiffCache) []embed {
+	embeds := make([]embed, 0)
+	for key := range diffCache.Deleted {
+		embeds = append(embeds, embed{
+			Title: fmt.Sprintf("❌ Flag \"%s\" deleted", key),
+			Color: colorDeleted,
+		})
+	}
+	return embeds
+}
+
+func convertUpdatedFlagsToDiscordEmbed(diffCache notifier.DiffCache) []embed {
+	embeds := make([]embed, 0)
+	for key, value := range diffCache.Updated {
+		fields := []embedField{}
+		changelog, _ := diff.Diff(value.Before, value.After, diff.AllowTypeMismatch(true))
+		for _, change := range changelog {
+			if change.Type == "update" {
+				fieldValue := fmt.Sprintf("%s => %s", render.Render(change.From), render.Render(change.To))
+				short := len(fieldValue) < longDiscordField
+				fields = append(fields, embedField{
+					Name:   strings.Join(change.Path, "."),
+					Value:  fieldValue,
+					Inline: short,
+				})
+			}
+		}
+		sort.Sort(ByTitle(fields))
+		embeds = append(embeds, embed{
+			Title:  fmt.Sprintf("✏️ Flag \"%s\" updated", key),
+			Color:  colorUpdated,
+			Fields: fields,
+		})
+	}
+	return embeds
+}
+
+func convertAddedFlagsToDiscordEmbed(diff notifier.DiffCache) []embed {
+	embeds := make([]embed, 0)
+	for key := range diff.Added {
+		embeds = append(embeds, embed{
+			Title: fmt.Sprintf("🆕 Flag \"%s\" created", key),
+			Color: colorAdded,
+		})
+	}
+	return embeds
+}
+
+type discordMessage struct {
+	Content string  `json:"content"`
+	Embeds  []embed `json:"embeds"`
+}
+
+type embed struct {
+	Title  string       `json:"title"`
+	Color  int          `json:"color"`
+	Fields []embedField `json:"fields,omitempty"`
+}
+
+type embedField struct {
+	Name   string `json:"name"`
+	Value  string `json:"value"`
+	Inline bool   `json:"inline"`
+}
+
+type ByTitle []embedField
+
+func (a ByTitle) Len() int           { return len(a) }
+func (a ByTitle) Less(i, j int) bool { return a[i].Name < a[j].Name }
+func (a ByTitle) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }

--- a/notifier/discordnotifier/notifier_test.go
+++ b/notifier/discordnotifier/notifier_test.go
@@ -1,0 +1,214 @@
+package discordnotifier
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/internal/flag"
+	"github.com/thomaspoignant/go-feature-flag/notifier"
+	"github.com/thomaspoignant/go-feature-flag/testutils"
+	"github.com/thomaspoignant/go-feature-flag/testutils/testconvert"
+)
+
+func TestDiscordNotifier_Notify(t *testing.T) {
+	type args struct {
+		diff       notifier.DiffCache
+		statusCode int
+		forceError bool
+		url        string
+	}
+	type expected struct {
+		err       bool
+		errMsg    string
+		bodyPath  string
+		signature string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected expected
+	}{
+		{
+			name: "should call webhook and have valid results",
+			expected: expected{
+				bodyPath: "./testdata/should_call_webhook_and_have_valid_results.json",
+			},
+			args: args{
+				url:        "https://discord.com/api/webhooks/000000000000000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				statusCode: http.StatusOK,
+				diff: notifier.DiffCache{
+					Added: map[string]flag.Flag{
+						"test-flag3": &flag.InternalFlag{
+							Rules: &[]flag.Rule{
+								{
+									Name:  testconvert.String("rule1"),
+									Query: testconvert.String("key eq \"random-key\""),
+									Percentages: &map[string]float64{
+										"False": 95,
+										"True":  5,
+									},
+								},
+							},
+							Variations: &map[string]*interface{}{
+								"Default": testconvert.Interface("default"),
+								"False":   testconvert.Interface("false"),
+								"True":    testconvert.Interface("test"),
+							},
+							DefaultRule: &flag.Rule{
+								Name:            testconvert.String("defaultRule"),
+								VariationResult: testconvert.String("Default"),
+							},
+							TrackEvents: testconvert.Bool(true),
+							Disable:     testconvert.Bool(false),
+							Version:     testconvert.String("1.1"),
+						},
+					},
+					Deleted: map[string]flag.Flag{
+						"test-flag": &flag.InternalFlag{
+							Rules: &[]flag.Rule{
+								{
+									Name:  testconvert.String("rule1"),
+									Query: testconvert.String("key eq \"random-key\""),
+									Percentages: &map[string]float64{
+										"False": 0,
+										"True":  100,
+									},
+								},
+							},
+							Variations: &map[string]*interface{}{
+								"Default": testconvert.Interface(false),
+								"False":   testconvert.Interface(false),
+								"True":    testconvert.Interface(true),
+							},
+							DefaultRule: &flag.Rule{
+								Name:            testconvert.String("defaultRule"),
+								VariationResult: testconvert.String("Default"),
+							},
+						},
+					},
+					Updated: map[string]notifier.DiffUpdated{
+						"test-flag2": {
+							Before: &flag.InternalFlag{
+								Variations: &map[string]*interface{}{
+									"Default": testconvert.Interface(false),
+									"False":   testconvert.Interface(false),
+									"True":    testconvert.Interface(true),
+								},
+								DefaultRule: &flag.Rule{
+									Name: testconvert.String("defaultRule"),
+									Percentages: &map[string]float64{
+										"False": 0,
+										"True":  100,
+									},
+								},
+								Experimentation: &flag.ExperimentationRollout{
+									Start: testconvert.Time(time.Unix(1095379400, 0)),
+									End:   testconvert.Time(time.Unix(1095371000, 0)),
+								},
+							},
+							After: &flag.InternalFlag{
+								Variations: &map[string]*interface{}{
+									"Default": testconvert.Interface("strDefault"),
+									"False":   testconvert.Interface("strFalse"),
+									"True":    testconvert.Interface("strTrue"),
+								},
+								Rules: &[]flag.Rule{
+									{
+										Name:  testconvert.String("rule1"),
+										Query: testconvert.String("key eq \"not-a-ke\""),
+										Percentages: &map[string]float64{
+											"False": 20,
+											"True":  80,
+										},
+									},
+								},
+								DefaultRule: &flag.Rule{
+									Name:            testconvert.String("defaultRule"),
+									VariationResult: testconvert.String("Default"),
+								},
+								Disable:     testconvert.Bool(true),
+								TrackEvents: testconvert.Bool(false),
+								Version:     testconvert.String("1.1"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "should err if http code is superior to 399",
+			expected: expected{
+				err:    true,
+				errMsg: "error: (Discord Notifier) while calling discord webhook, statusCode = 400",
+			},
+			args: args{
+				url:        "https://discord.com/api/webhooks/000000000000000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				statusCode: http.StatusBadRequest,
+				diff:       notifier.DiffCache{},
+			},
+		},
+		{
+			name: "should err if error while calling webhook",
+			expected: expected{
+				err:    true,
+				errMsg: "error: (Discord Notifier) error: while calling webhook: random error",
+			},
+			args: args{
+				url:        "https://discord.com/api/webhooks/000000000000000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				statusCode: http.StatusOK,
+				diff:       notifier.DiffCache{},
+				forceError: true,
+			},
+		},
+		{
+			name: "missing discord url",
+			expected: expected{
+				err:    true,
+				errMsg: "error: (Discord Notifier) invalid notifier configuration, no DiscordWebhookURL provided",
+			},
+			args: args{
+				statusCode: http.StatusOK,
+				diff:       notifier.DiffCache{},
+			},
+		},
+		{
+			name: "invalid discord url",
+			expected: expected{
+				err:    true,
+				errMsg: "error: (Discord Notifier) invalid DiscordWebhookURL: https://{}discord.com/api/webhooks/000000000000000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+			},
+			args: args{
+				url:        "https://{}discord.com/api/webhooks/000000000000000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+				statusCode: http.StatusOK,
+				diff:       notifier.DiffCache{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockHTTPClient := &testutils.HTTPClientMock{StatusCode: tt.args.statusCode, ForceError: tt.args.forceError}
+
+			c := Notifier{
+				DiscordWebhookURL: tt.args.url,
+				httpClient:        mockHTTPClient,
+			}
+
+			err := c.Notify(tt.args.diff)
+
+			if tt.expected.err {
+				assert.ErrorContains(t, err, tt.expected.errMsg)
+			} else {
+				assert.NoError(t, err)
+				hostname, _ := os.Hostname()
+				content, _ := os.ReadFile(tt.expected.bodyPath)
+				expectedContent := strings.ReplaceAll(string(content), "{{hostname}}", hostname)
+				assert.JSONEq(t, expectedContent, mockHTTPClient.Body)
+				assert.Equal(t, tt.expected.signature, mockHTTPClient.Signature)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

This pull request adds a new discordnotifier to the project, allowing feature flag changes to be sent to Discord channels using Discord webhooks. The discordnotifier package replicates the behavior of the existing slacknotifier, but it has been adapted to meet the Discord API requirements, including:

Converting message structures to use Discord's embeds format instead of Slack attachments.
Updating color values from hexadecimal to decimal format as required by Discord.
Adjusting field and footer structures to match Discord’s webhook specifications.

## Closes issue(s)
Resolve #2564

## Checklist
- [✅] I have tested this code
- [✅] I have added unit test to cover this code
- [✅] I have updated the documentation (`README.md` and `/website/docs`)
- [✅] I have followed the [contributing guide](CONTRIBUTING.md)
