### PR TITLE
fix(python): Fix URL formatting + authorized key

### DIFF
--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/data_collector_hook.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/data_collector_hook.py
@@ -109,10 +109,14 @@ class DataCollectorHook(Hook):
                     meta={"provider": "open-feature-python-sdk"},
                     events=self._event_queue,
                 )
+                headers = {"Content-Type": "application/json"}
+                if self._options.api_key:
+                    headers["Authorization"] = "Bearer {}".format(self._options.api_key)
+
                 response = self._http_client.request(
                     method="POST",
                     url=urljoin(str(self._options.endpoint), "/v1/data/collector"),
-                    headers={"Content-Type": "application/json"},
+                    headers=headers,
                     body=goff_request.model_dump_json(),
                 )
 

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/options.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/options.py
@@ -45,3 +45,8 @@ class GoFeatureFlagOptions(BaseModel):
     # config changes.
     # default: false
     disable_cache_invalidation: typing.Optional[bool] = False
+
+    # api_key (optional) If the relay proxy is configured to authenticate the requests, you should provide
+    # an API Key to the provider. Please ask the administrator of the relay proxy to provide an API Key.
+    # Default: None
+    api_key: typing.Optional[str] = None

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/provider.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/provider.py
@@ -191,13 +191,14 @@ class GoFeatureFlagProvider(BaseModel, AbstractProvider, metaclass=CombinedMetac
                 headers = {"Content-Type": "application/json"}
                 if self.options.api_key is not None:
                     headers["Authorization"] = "Bearer {}".format(self.options.api_key)
+                url = "{}{}".format(
+                    str(self.options.endpoint).rstrip("/"),
+                    "/v1/feature/{}/eval".format(flag_key),
+                )
 
                 response = self._http_client.request(
                     method="POST",
-                    url=urljoin(
-                        str(self.options.endpoint),
-                        "/v1/feature/{}/eval".format(flag_key),
-                    ),
+                    url=url,
                     headers=headers,
                     body=goff_request.model_dump_json(),
                 )
@@ -269,10 +270,11 @@ class GoFeatureFlagProvider(BaseModel, AbstractProvider, metaclass=CombinedMetac
         if self.options.api_key is not None:
             url = "{}?apiKey={}".format(url, self.options.api_key)
 
-        http_uri = urljoin(
-            str(self.options.endpoint),
+        http_uri = "{}{}".format(
+            str(self.options.endpoint).rstrip("/"),
             url,
         )
+
         http_uri = http_uri.replace("http", "ws")
         http_uri = http_uri.replace("https", "wss")
         return http_uri

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/provider.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/provider.py
@@ -188,13 +188,17 @@ class GoFeatureFlagProvider(BaseModel, AbstractProvider, metaclass=CombinedMetac
                 response_body = self._cache[evaluation_context_hash]
                 is_from_cache = True
             else:
+                headers = {"Content-Type": "application/json"}
+                if self.options.api_key is not None:
+                    headers["Authorization"] = "Bearer {}".format(self.options.api_key)
+
                 response = self._http_client.request(
                     method="POST",
                     url=urljoin(
                         str(self.options.endpoint),
                         "/v1/feature/{}/eval".format(flag_key),
                     ),
-                    headers={"Content-Type": "application/json"},
+                    headers=headers,
                     body=goff_request.model_dump_json(),
                 )
 
@@ -261,9 +265,13 @@ class GoFeatureFlagProvider(BaseModel, AbstractProvider, metaclass=CombinedMetac
         _build_websocket_uri is a helper to build the websocket uri to connect to the GO Feature Flag relay proxy.
         :return: a string representing the websocket uri
         """
+        url = "/ws/v1/flag/change"
+        if self.options.api_key is not None:
+            url = "{}?apiKey={}".format(url, self.options.api_key)
+
         http_uri = urljoin(
             str(self.options.endpoint),
-            "/ws/v1/flag/change",
+            url,
         )
         http_uri = http_uri.replace("http", "ws")
         http_uri = http_uri.replace("https", "wss")

--- a/openfeature/providers/python-provider/tests/docker-compose.yml
+++ b/openfeature/providers/python-provider/tests/docker-compose.yml
@@ -9,5 +9,6 @@ services:
         - POLLINGINTERVAL=1000
         - RETRIEVER_KIND=file
         - RETRIEVER_PATH=/config.goff.yaml
+        - AUTHORIZEDKEYS_EVALUATION=apikey1
     volumes:
       - ./config.goff.yaml:/config.goff.yaml

--- a/openfeature/providers/python-provider/tests/test_gofeatureflag_python_provider.py
+++ b/openfeature/providers/python-provider/tests/test_gofeatureflag_python_provider.py
@@ -40,6 +40,7 @@ def _generic_test(
                 endpoint="https://gofeatureflag.org/",
                 data_flush_interval=100,
                 disable_cache_invalidation=True,
+                api_key="apikey1",
             ),
         )
         api.set_provider(goff_provider)

--- a/openfeature/providers/python-provider/tests/test_gofeatureflag_python_provider.py
+++ b/openfeature/providers/python-provider/tests/test_gofeatureflag_python_provider.py
@@ -611,6 +611,31 @@ def test_hook_error():
     assert len(hook._event_queue) == 1
 
 
+@patch("urllib3.poolmanager.PoolManager.request")
+def test_url_parsing(mock_request):
+    flag_key = "bool_targeting_match"
+    mock_request.return_value = Mock(status="200", data=_read_mock_file(flag_key))
+    default_value = False
+    goff_provider = GoFeatureFlagProvider(
+        options=GoFeatureFlagOptions(
+            endpoint="https://gofeatureflag.org/ff/",
+            data_flush_interval=100,
+            disable_cache_invalidation=True,
+            api_key="apikey1",
+        ),
+    )
+    api.set_provider(goff_provider)
+    client = api.get_client(domain="test-client")
+    t = client.get_boolean_details(
+        flag_key=flag_key,
+        default_value=default_value,
+        evaluation_context=_default_evaluation_ctx,
+    )
+    got = mock_request.call_args[1]["url"]
+    want = "https://gofeatureflag.org/ff/v1/feature/bool_targeting_match/eval"
+    assert got == want
+
+
 def _read_mock_file(flag_key: str) -> str:
     # This hacky if is here to make test run inside pycharm and from the root of the project
     if os.getcwd().endswith("/tests"):

--- a/openfeature/providers/python-provider/tests/test_websocket_cache_invalidation.py
+++ b/openfeature/providers/python-provider/tests/test_websocket_cache_invalidation.py
@@ -50,6 +50,7 @@ def test_test_websocket_cache_invalidation(goff):
             endpoint=goff,
             data_flush_interval=100,
             disable_data_collection=True,
+            api_key="apikey1",
         )
     )
     api.set_provider(goff_provider)


### PR DESCRIPTION
## Description
This PR fixes 2 things:
- Allow to set authorized key in the option if you use an authenticated version of GO Feature Flag
- Fix URL formatting when GOFF is not on the root level of the path.

## Closes issue(s)

Resolve #2690 #2671

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
