### PR TITLE
docs(swagger): remove user field in the context

### DIFF
--- a/cmd/relayproxy/docs/docs.go
+++ b/cmd/relayproxy/docs/docs.go
@@ -729,14 +729,6 @@ const docTemplate = `{
                             "$ref": "#/definitions/model.EvaluationContextRequest"
                         }
                     ]
-                },
-                "user": {
-                    "description": "Deprecated: User The representation of a user for your feature flag system.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/model.UserRequest"
-                        }
-                    ]
                 }
             }
         },
@@ -779,14 +771,6 @@ const docTemplate = `{
                     "allOf": [
                         {
                             "$ref": "#/definitions/model.EvaluationContextRequest"
-                        }
-                    ]
-                },
-                "user": {
-                    "description": "Deprecated: User The representation of a user for your feature flag system.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/model.UserRequest"
                         }
                     ]
                 }
@@ -981,34 +965,6 @@ const docTemplate = `{
                 "value": {},
                 "variant": {
                     "type": "string"
-                }
-            }
-        },
-        "model.UserRequest": {
-            "type": "object",
-            "properties": {
-                "anonymous": {
-                    "description": "Anonymous set if this is a logged-in user or not.",
-                    "type": "boolean",
-                    "example": false
-                },
-                "custom": {
-                    "description": "Custom is a map containing all extra information for this user.",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "example": {
-                        "company": "GO Feature Flag",
-                        "email": "contact@gofeatureflag.org",
-                        "firstname": "John",
-                        "lastname": "Doe"
-                    }
-                },
-                "key": {
-                    "description": "Key is the identifier of the UserRequest.",
-                    "type": "string",
-                    "example": "08b5ffb7-7109-42f4-a6f2-b85560fbd20f"
                 }
             }
         },

--- a/cmd/relayproxy/docs/swagger.json
+++ b/cmd/relayproxy/docs/swagger.json
@@ -721,14 +721,6 @@
                             "$ref": "#/definitions/model.EvaluationContextRequest"
                         }
                     ]
-                },
-                "user": {
-                    "description": "Deprecated: User The representation of a user for your feature flag system.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/model.UserRequest"
-                        }
-                    ]
                 }
             }
         },
@@ -771,14 +763,6 @@
                     "allOf": [
                         {
                             "$ref": "#/definitions/model.EvaluationContextRequest"
-                        }
-                    ]
-                },
-                "user": {
-                    "description": "Deprecated: User The representation of a user for your feature flag system.",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/model.UserRequest"
                         }
                     ]
                 }
@@ -973,34 +957,6 @@
                 "value": {},
                 "variant": {
                     "type": "string"
-                }
-            }
-        },
-        "model.UserRequest": {
-            "type": "object",
-            "properties": {
-                "anonymous": {
-                    "description": "Anonymous set if this is a logged-in user or not.",
-                    "type": "boolean",
-                    "example": false
-                },
-                "custom": {
-                    "description": "Custom is a map containing all extra information for this user.",
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    },
-                    "example": {
-                        "company": "GO Feature Flag",
-                        "email": "contact@gofeatureflag.org",
-                        "firstname": "John",
-                        "lastname": "Doe"
-                    }
-                },
-                "key": {
-                    "description": "Key is the identifier of the UserRequest.",
-                    "type": "string",
-                    "example": "08b5ffb7-7109-42f4-a6f2-b85560fbd20f"
                 }
             }
         },

--- a/cmd/relayproxy/docs/swagger.yaml
+++ b/cmd/relayproxy/docs/swagger.yaml
@@ -112,11 +112,6 @@ definitions:
         - $ref: '#/definitions/model.EvaluationContextRequest'
         description: EvaluationContext The representation of a EvaluationContext for
           your feature flag system.
-      user:
-        allOf:
-        - $ref: '#/definitions/model.UserRequest'
-        description: 'Deprecated: User The representation of a user for your feature
-          flag system.'
     type: object
   model.CollectEvalDataRequest:
     properties:
@@ -148,11 +143,6 @@ definitions:
         - $ref: '#/definitions/model.EvaluationContextRequest'
         description: EvaluationContext The representation of a EvaluationContext for
           your feature flag system.
-      user:
-        allOf:
-        - $ref: '#/definitions/model.UserRequest'
-        description: 'Deprecated: User The representation of a user for your feature
-          flag system.'
     type: object
   model.EvaluationContextRequest:
     properties:
@@ -282,27 +272,6 @@ definitions:
         type: string
       value: {}
       variant:
-        type: string
-    type: object
-  model.UserRequest:
-    properties:
-      anonymous:
-        description: Anonymous set if this is a logged-in user or not.
-        example: false
-        type: boolean
-      custom:
-        additionalProperties:
-          type: string
-        description: Custom is a map containing all extra information for this user.
-        example:
-          company: GO Feature Flag
-          email: contact@gofeatureflag.org
-          firstname: John
-          lastname: Doe
-        type: object
-      key:
-        description: Key is the identifier of the UserRequest.
-        example: 08b5ffb7-7109-42f4-a6f2-b85560fbd20f
         type: string
     type: object
   modeldocs.AllFlags:

--- a/cmd/relayproxy/model/user_request.go
+++ b/cmd/relayproxy/model/user_request.go
@@ -2,7 +2,7 @@ package model
 
 type AllFlagRequest struct {
 	// Deprecated: User The representation of a user for your feature flag system.
-	User *UserRequest `json:"user,omitempty" xml:"user,omitempty" form:"user" query:"user" deprecated:"true"`
+	User *UserRequest `json:"user,omitempty" xml:"user,omitempty" form:"user" query:"user" deprecated:"true" swaggerignore:"true"`
 	// EvaluationContext The representation of a EvaluationContext for your feature flag system.
 	EvaluationContext *EvaluationContextRequest `json:"evaluationContext,omitempty" xml:"evaluationContext,omitempty" form:"evaluationContext" query:"evaluationContext"` // nolint: lll
 }

--- a/cmd/relayproxy/model/user_request.go
+++ b/cmd/relayproxy/model/user_request.go
@@ -2,7 +2,7 @@ package model
 
 type AllFlagRequest struct {
 	// Deprecated: User The representation of a user for your feature flag system.
-	User *UserRequest `json:"user,omitempty" xml:"user,omitempty" form:"user" query:"user" deprecated:"true" swaggerignore:"true"`
+	User *UserRequest `json:"user,omitempty" xml:"user,omitempty" form:"user" query:"user" deprecated:"true" swaggerignore:"true"` // nolint: lll
 	// EvaluationContext The representation of a EvaluationContext for your feature flag system.
 	EvaluationContext *EvaluationContextRequest `json:"evaluationContext,omitempty" xml:"evaluationContext,omitempty" form:"evaluationContext" query:"evaluationContext"` // nolint: lll
 }


### PR DESCRIPTION
## Description
`user` field was here for legacy compatibility, but keeping it in the documentation is misleading.
In this PR we remove `user` from swagger doc.

## Checklist
- [x] I have tested this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
