### PR TITLE
docs(website): fix openfeature_python.md documentation

### DIFF
--- a/website/versioned_docs/version-v1.39.1/openfeature_sdk/server_providers/openfeature_python.md
+++ b/website/versioned_docs/version-v1.39.1/openfeature_sdk/server_providers/openfeature_python.md
@@ -34,7 +34,7 @@ goff_provider = GoFeatureFlagProvider(
     options=GoFeatureFlagOptions(endpoint="https://gofeatureflag.org/")
 )
 api.set_provider(goff_provider)
-client = api.get_client(name="test-client")
+client = api.get_client(domain="test-client")
 ```
 
 ## Evaluate your flag


### PR DESCRIPTION
In new versions of the OpenFeature SDK there are no names but domains

See https://github.com/open-feature/python-sdk/commit/ed6a42f264a6efc149642181bfc4c6de0eb83ce1

## Checklist
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
