### PR TITLE
fix: DataCollectorHook event time converted to seconds

### DIFF
--- a/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/main/java/org/gofeatureflag/openfeature/hook/DataCollectorHook.kt
+++ b/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/main/java/org/gofeatureflag/openfeature/hook/DataCollectorHook.kt
@@ -4,7 +4,7 @@ import dev.openfeature.sdk.FlagEvaluationDetails
 import dev.openfeature.sdk.Hook
 import dev.openfeature.sdk.HookContext
 import org.gofeatureflag.openfeature.controller.DataCollectorManager
-import java.time.Instant
+import java.util.Date
 
 class DataCollectorHook<T>(private val collectorManager: DataCollectorManager) : Hook<T> {
     override fun after(
@@ -14,7 +14,7 @@ class DataCollectorHook<T>(private val collectorManager: DataCollectorManager) :
     ) {
         val event = Event(
             contextKind = "user",
-            creationDate = Instant.now().epochSecond,
+            creationDate = Date().time / 1000L,
             key = ctx.flagKey,
             kind = "feature",
             userKey = ctx.ctx?.getTargetingKey(),
@@ -29,7 +29,7 @@ class DataCollectorHook<T>(private val collectorManager: DataCollectorManager) :
     override fun error(ctx: HookContext<T>, error: Exception, hints: Map<String, Any>) {
         val event = Event(
             contextKind = "user",
-            creationDate = Instant.now().epochSecond,
+            creationDate = Date().time / 1000L,
             key = ctx.flagKey,
             kind = "feature",
             userKey = ctx.ctx?.getTargetingKey(),

--- a/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/main/java/org/gofeatureflag/openfeature/hook/DataCollectorHook.kt
+++ b/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/main/java/org/gofeatureflag/openfeature/hook/DataCollectorHook.kt
@@ -29,7 +29,7 @@ class DataCollectorHook<T>(private val collectorManager: DataCollectorManager) :
     override fun error(ctx: HookContext<T>, error: Exception, hints: Map<String, Any>) {
         val event = Event(
             contextKind = "user",
-            creationDate = Date().time,
+            creationDate = Instant.now().epochSecond,
             key = ctx.flagKey,
             kind = "feature",
             userKey = ctx.ctx?.getTargetingKey(),

--- a/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/main/java/org/gofeatureflag/openfeature/hook/DataCollectorHook.kt
+++ b/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/main/java/org/gofeatureflag/openfeature/hook/DataCollectorHook.kt
@@ -4,7 +4,7 @@ import dev.openfeature.sdk.FlagEvaluationDetails
 import dev.openfeature.sdk.Hook
 import dev.openfeature.sdk.HookContext
 import org.gofeatureflag.openfeature.controller.DataCollectorManager
-import java.util.Date
+import java.time.Instant
 
 class DataCollectorHook<T>(private val collectorManager: DataCollectorManager) : Hook<T> {
     override fun after(
@@ -14,7 +14,7 @@ class DataCollectorHook<T>(private val collectorManager: DataCollectorManager) :
     ) {
         val event = Event(
             contextKind = "user",
-            creationDate = Date().time,
+            creationDate = Instant.now().epochSecond,
             key = ctx.flagKey,
             kind = "feature",
             userKey = ctx.ctx?.getTargetingKey(),

--- a/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/test/java/org/gofeatureflag/openfeature/controller/GoFeatureFlagApiTest.kt
+++ b/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/test/java/org/gofeatureflag/openfeature/controller/GoFeatureFlagApiTest.kt
@@ -21,7 +21,7 @@ class GoFeatureFlagApiTest {
     private var defaultEventList: List<Event> = listOf(
         Event(
             contextKind = "contextKind",
-            creationDate = 1721650841108,
+            creationDate = 1721650841,
             key = "flag-1",
             kind = "feature",
             userKey = "981f2662-1fb4-4732-ac6d-8399d9205aa9",

--- a/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/test/resources/org/gofeatureflag/openfeature/hook/valid_result.json
+++ b/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/test/resources/org/gofeatureflag/openfeature/hook/valid_result.json
@@ -2,7 +2,7 @@
   "events": [
     {
       "contextKind": "contextKind",
-      "creationDate": 1721650841108,
+      "creationDate": 1721650841,
       "key": "flag-1",
       "kind": "feature",
       "userKey": "981f2662-1fb4-4732-ac6d-8399d9205aa9",

--- a/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/test/resources/org/gofeatureflag/openfeature/hook/valid_result.json
+++ b/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/test/resources/org/gofeatureflag/openfeature/hook/valid_result.json
@@ -11,7 +11,7 @@
       "variation": "enabled"
     }
   ],
-  "metadata": {
+  "meta": {
     "provider": "android",
     "openfeature": "true"
   }


### PR DESCRIPTION
## Description
<!-- 
Please add a description of what your pull request is doing.
 - What was the problem?
 - How it is resolved?
 - How can we test the change?
 - If there are breaking changes, please describe them in detail and why we cannot avoid them.
-->
Currently dataCollector pass events in ms, and it suppose to be in seconds. Now I changed the way it constructed so it would be in seconds.

## Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
