### PR TITLE
fix(exporter): Don't lock for non bulk exporter

### DIFF
--- a/exporter/data_exporter_test.go
+++ b/exporter/data_exporter_test.go
@@ -103,7 +103,7 @@ func TestDataExporterScheduler_exporterReturnError(t *testing.T) {
 		dc.AddEvent(event)
 	}
 	assert.Equal(t, inputEvents[:201], mockExporter.GetExportedEvents())
-	handler.AssertMessage("error while exporting data")
+	handler.AssertMessage("error while exporting data: random err")
 }
 
 func TestDataExporterScheduler_nonBulkExporter(t *testing.T) {


### PR DESCRIPTION
## Description
In this PR we stop using the slice storing the events for non-bulk exporter.
This is not needed because we call `Export` directly when we receive a `featureEvent` and it was causing delay when waiting on the `Lock` function of the mutex.

## Closes issue(s)
Resolve #2792 

## Checklist
- [x] I have tested this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
