### PR TITLE
feat(kotlin-provider): Support flag metadata

### DIFF
--- a/openfeature/providers/kotlin-provider/README.md
+++ b/openfeature/providers/kotlin-provider/README.md
@@ -154,14 +154,14 @@ coroutineScope.launch {
 
 ## Features status
 
-| Status | Feature            | Description                                                                          |
-|--------|--------------------|--------------------------------------------------------------------------------------|
-| ✅      | Flag evaluation    | It is possible to evaluate all the type of flags                                     |
-| ✅      | Cache invalidation | Websocket mechanism is in place to refresh the cache in case of configuration change |
-| ❌      | Logging            | Not supported by the SDK                                                             |
-| ❌      | Flag Metadata      | Not supported by the SDK                                                             |
-| ✅      | Event Streaming    | Not implemented                                                                      |
-| ✅      | Unit test          | Not implemented                                                                      |
+| Status | Feature            | Description                                                                                                                                         |
+|--------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| ✅      | Flag evaluation    | It is possible to evaluate all the type of flags                                                                                                    |
+| ✅      | Cache invalidation | A polling mechanism is in place to refresh the cache in case of configuration change                                                                |
+| ❌      | Logging            | Not supported by the SDK                                                                                                                            |
+| ✅      | Flag Metadata      | You have access to your flag metadata                                                                                                               |
+| ✅      | Event Streaming    | You can register to receive some internal event from the provider                                                                                   |
+| ✅      | Unit test          | The test are running one by one, but we still have an [issue open](https://github.com/open-feature/kotlin-sdk/issues/108) to enable fully the tests |
 
 <sub>Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌</sub>
 

--- a/openfeature/providers/kotlin-provider/build.gradle.kts
+++ b/openfeature/providers/kotlin-provider/build.gradle.kts
@@ -1,10 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.5.1" apply false
+    id("com.android.application") version "8.5.2" apply false
     id("org.jetbrains.kotlin.android") version "1.9.0" apply false
-    id("com.android.library") version "8.5.1" apply false
+    id("com.android.library") version "8.5.2" apply false
     id("org.jlleitschuh.gradle.ktlint") version "11.6.1" apply true
-    id("io.github.gradle-nexus.publish-plugin") version "1.3.0" apply true
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0" apply true
 }
 
 allprojects {

--- a/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/build.gradle.kts
+++ b/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/build.gradle.kts
@@ -96,9 +96,9 @@ dependencies {
     api("dev.openfeature:android-sdk:0.3.2")
     api("com.squareup.okhttp3:okhttp:4.12.0")
     api("com.google.code.gson:gson:2.11.0")
-    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
+    api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("org.skyscreamer:jsonassert:1.5.3")
 }

--- a/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/main/java/org/gofeatureflag/openfeature/ofrep/OfrepProvider.kt
+++ b/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/main/java/org/gofeatureflag/openfeature/ofrep/OfrepProvider.kt
@@ -138,14 +138,7 @@ class OfrepProvider(
         defaultValue: Int,
         context: EvaluationContext?
     ): ProviderEvaluation<Int> {
-        val res = genericEvaluation<Int>(key, Int::class)
-        return ProviderEvaluation<Int>(
-            value = res.value,
-            reason = res.reason,
-            variant = res.variant,
-            errorCode = res.errorCode,
-            errorMessage = res.errorMessage
-        )
+        return genericEvaluation<Int>(key, Int::class)
     }
 
     override fun getObjectEvaluation(

--- a/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/test/java/org/gofeatureflag/openfeature/ofrep/OfrepProviderTest.kt
+++ b/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/test/java/org/gofeatureflag/openfeature/ofrep/OfrepProviderTest.kt
@@ -1,6 +1,7 @@
 package org.gofeatureflag.openfeature.ofrep
 
 import dev.openfeature.sdk.EvaluationContext
+import dev.openfeature.sdk.EvaluationMetadata
 import dev.openfeature.sdk.FlagEvaluationDetails
 import dev.openfeature.sdk.ImmutableContext
 import dev.openfeature.sdk.OpenFeatureAPI
@@ -230,6 +231,10 @@ class OfrepProviderTest {
             reason = "DEFAULT",
             errorCode = null,
             errorMessage = null,
+            metadata = EvaluationMetadata.builder()
+                .putString("description", "This flag controls the title of the feature flag")
+                .putString("title", "Feature Flag Title")
+                .build()
         )
         assertEquals(want, got)
     }
@@ -312,7 +317,7 @@ class OfrepProviderTest {
     }
 
     @Test
-    fun `should return a valid evaluation for Boolean`() = runBlocking {
+    fun `should return a valid evaluation for Boolean`(): Unit = runBlocking {
         enqueueMockResponse("org.gofeatureflag.openfeature.ofrep/valid_api_response.json", 200)
         val provider = OfrepProvider(OfrepOptions(endpoint = mockWebServer?.url("/").toString()))
         OpenFeatureAPI.setProviderAndWait(provider, Dispatchers.IO, defaultEvalCtx)
@@ -325,6 +330,11 @@ class OfrepProviderTest {
             reason = "TARGETING_MATCH",
             errorCode = null,
             errorMessage = null,
+            metadata = EvaluationMetadata.builder()
+                .putBoolean("additionalProp1", true)
+                .putString("additionalProp2", "value")
+                .putInt("additionalProp3", 123)
+                .build()
         )
         assertEquals(want, got)
     }
@@ -343,6 +353,11 @@ class OfrepProviderTest {
             reason = "TARGETING_MATCH",
             errorCode = null,
             errorMessage = null,
+            metadata = EvaluationMetadata.builder()
+                .putBoolean("additionalProp1", true)
+                .putString("additionalProp2", "value")
+                .putInt("additionalProp3", 123)
+                .build()
         )
         assertEquals(want, got)
     }
@@ -361,6 +376,11 @@ class OfrepProviderTest {
             reason = "TARGETING_MATCH",
             errorCode = null,
             errorMessage = null,
+            metadata = EvaluationMetadata.builder()
+                .putBoolean("additionalProp1", true)
+                .putString("additionalProp2", "value")
+                .putInt("additionalProp3", 123)
+                .build()
         )
         assertEquals(want, got)
     }
@@ -379,6 +399,11 @@ class OfrepProviderTest {
             reason = "TARGETING_MATCH",
             errorCode = null,
             errorMessage = null,
+            metadata = EvaluationMetadata.builder()
+                .putBoolean("additionalProp1", true)
+                .putString("additionalProp2", "value")
+                .putInt("additionalProp3", 123)
+                .build()
         )
         assertEquals(want, got)
     }
@@ -401,6 +426,11 @@ class OfrepProviderTest {
             reason = "TARGETING_MATCH",
             errorCode = null,
             errorMessage = null,
+            metadata = EvaluationMetadata.builder()
+                .putBoolean("additionalProp1", true)
+                .putString("additionalProp2", "value")
+                .putInt("additionalProp3", 123)
+                .build()
         )
         assertEquals(want, got)
     }
@@ -435,6 +465,11 @@ class OfrepProviderTest {
             reason = "TARGETING_MATCH",
             errorCode = null,
             errorMessage = null,
+            metadata = EvaluationMetadata.builder()
+                .putBoolean("additionalProp1", true)
+                .putString("additionalProp2", "value")
+                .putInt("additionalProp3", 123)
+                .build()
         )
         assertEquals(want, got)
     }

--- a/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/test/java/org/gofeatureflag/openfeature/ofrep/controller/OfrepApiTest.kt
+++ b/openfeature/providers/kotlin-provider/gofeatureflag-kotlin-provider/src/test/java/org/gofeatureflag/openfeature/ofrep/controller/OfrepApiTest.kt
@@ -59,6 +59,7 @@ class OfrepApiTest {
         )
         val res = ofrepApi.postBulkEvaluateFlags(ctx)
         assertEquals(200, res.httpResponse.code)
+
         val expected = OfrepApiResponse(
             flags = listOf(
                 FlagDto(
@@ -67,7 +68,8 @@ class OfrepApiTest {
                     reason = "DEFAULT",
                     variant = "nocolor",
                     errorCode = null,
-                    errorDetails = null
+                    errorDetails = null,
+                    metadata = null
                 ),
                 FlagDto(
                     key = "hide-logo",
@@ -75,7 +77,8 @@ class OfrepApiTest {
                     reason = "STATIC",
                     variant = "var_false",
                     errorCode = null,
-                    errorDetails = null
+                    errorDetails = null,
+                    metadata = null
                 ),
                 FlagDto(
                     key = "title-flag",
@@ -83,7 +86,11 @@ class OfrepApiTest {
                     reason = "DEFAULT",
                     variant = "default_title",
                     errorCode = null,
-                    errorDetails = null
+                    errorDetails = null,
+                    metadata = hashMapOf<String, Any>(
+                        "description" to "This flag controls the title of the feature flag",
+                        "title" to "Feature Flag Title"
+                    )
                 )
             ), null, null
         )

--- a/website/docs/openfeature_sdk/client_providers/openfeature_android.mdx
+++ b/website/docs/openfeature_sdk/client_providers/openfeature_android.mdx
@@ -197,13 +197,14 @@ coroutineScope.launch {
 
 ## Features status
 
-| Status | Feature            | Description                                                                          |
-|--------|--------------------|--------------------------------------------------------------------------------------|
-| ✅      | Flag evaluation    | It is possible to evaluate all the type of flags                                     |
-| ✅      | Cache invalidation | Websocket mechanism is in place to refresh the cache in case of configuration change |
-| ❌      | Logging            | Not supported by the SDK                                                             |
-| ❌      | Flag Metadata      | Not supported by the SDK                                                             |
-| ✅      | Event Streaming    | Not implemented                                                                      |
-| ✅      | Unit test          | Not implemented                                                                      |
+
+| Status | Feature            | Description                                                                                                                                         |
+|--------|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| ✅      | Flag evaluation    | It is possible to evaluate all the type of flags                                                                                                    |
+| ✅      | Cache invalidation | A polling mechanism is in place to refresh the cache in case of configuration change                                                                |
+| ❌      | Logging            | Not supported by the SDK                                                                                                                            |
+| ✅      | Flag Metadata      | You have access to your flag metadata                                                                                                               |
+| ✅      | Event Streaming    | You can register to receive some internal event from the provider                                                                                   |
+| ✅      | Unit test          | The test are running one by one, but we still have an [issue open](https://github.com/open-feature/kotlin-sdk/issues/108) to enable fully the tests |
 
 <sub>Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌</sub>


### PR DESCRIPTION
## Description
In this PR we add support of the flag metadata in the `kotlin` provider.

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
