### PR TITLE
docs: Update getting_started.md

### DIFF
--- a/website/versioned_docs/version-v1.41.0/relay-proxy/getting_started.md
+++ b/website/versioned_docs/version-v1.41.0/relay-proxy/getting_started.md
@@ -40,7 +40,7 @@ docker run -v $(pwd)/goff-proxy.yaml:/goff/goff-proxy.yaml -p 1031:1031 gofeatur
 
 What is happening?
 - The **relay proxy** will read the configuration file and use the github retriever to load the flags from the configuration file.
-- The relay-proxy is also starting to poll the file regurarly to check if any changes are happening.
+- The relay-proxy is also starting to poll the file regularly to check if any changes are happening.
 - A set of APIs are available to evaluate the flags
 
 ## Evaluate a flag


### PR DESCRIPTION
typo fix

## Description
 - typo
 - spelling fixed
 - verify in the readme

## Closes issue(s)

## Checklist
- [X] I have updated the documentation (`README.md` and `/website/docs`)
