### PR TITLE
fix: OpenTelemetry trace propagation

### DIFF
--- a/cmd/relayproxy/api/opentelemetry/otel.go
+++ b/cmd/relayproxy/api/opentelemetry/otel.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/contrib/samplers/jaegerremote"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -79,6 +80,9 @@ func (s *OtelService) Init(ctx context.Context, zapLog *zap.Logger, config confi
 	otel.SetErrorHandler(otelErrHandler(func(err error) {
 		zapLog.Error("OTel error", zap.Error(err))
 	}))
+
+	propagator := propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{})
+	otel.SetTextMapPropagator(propagator)
 
 	return nil
 }


### PR DESCRIPTION
## Description
As reported by @ybasket, there is an issue in propagating the traces across different services.

This PR configure the propagation for Otel in order to follow the traces across multiple span.


![Screenshot 2025-02-10 at 18 50 55](https://github.com/user-attachments/assets/16aaa656-7c05-4125-94e2-0467825c9f0e)

## Closes issue(s)
Resolve #3042

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
