### PR TITLE
feat(relayproxy): allow disable VersionHeader middleware

### DIFF
--- a/cmd/relayproxy/api/middleware/version.go
+++ b/cmd/relayproxy/api/middleware/version.go
@@ -2,15 +2,43 @@ package middleware
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
 )
 
-// VersionHeader is a middleware that adds the version of the relayproxy in the header
-func VersionHeader(config *config.Config) echo.MiddlewareFunc {
+// VersionHeaderConfig defines the configuration for the middleware.
+type VersionHeaderConfig struct {
+	Skipper          middleware.Skipper
+	RelayProxyConfig *config.Config
+}
+
+// VersionHeader is a middleware that adds the version of the relayproxy in the header.
+func VersionHeader(cfg VersionHeaderConfig) echo.MiddlewareFunc {
+	// Use provided skipper or fallback to the default skipper.
+	skipper := cfg.Skipper
+	if skipper == nil {
+		skipper = DefaultVersionHeaderSkipper
+	}
+
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			c.Response().Header().Set("X-GOFEATUREFLAG-VERSION", config.Version)
+			if skipper(c) {
+				return next(c)
+			}
+
+			c.Response().Header().Set("X-GOFEATUREFLAG-VERSION", cfg.RelayProxyConfig.Version)
 			return next(c)
 		}
+	}
+}
+
+func DefaultVersionHeaderSkipper(c echo.Context) bool {
+	return false
+}
+
+// DDisableVersionHeaderSkipper returns a middleware.Skipper function that checks config.
+func DisableVersionHeaderSkipper(relayProxyConfig *config.Config) middleware.Skipper {
+	return func(c echo.Context) bool {
+		return relayProxyConfig.DisableVersionHeader
 	}
 }

--- a/cmd/relayproxy/api/middleware/version.go
+++ b/cmd/relayproxy/api/middleware/version.go
@@ -35,10 +35,3 @@ func VersionHeader(cfg VersionHeaderConfig) echo.MiddlewareFunc {
 func DefaultVersionHeaderSkipper(_ echo.Context) bool {
 	return false
 }
-
-// DDisableVersionHeaderSkipper returns a middleware.Skipper function that checks config.
-func DisableVersionHeaderSkipper(relayProxyConfig *config.Config) middleware.Skipper {
-	return func(_ echo.Context) bool {
-		return relayProxyConfig.DisableVersionHeader
-	}
-}

--- a/cmd/relayproxy/api/middleware/version.go
+++ b/cmd/relayproxy/api/middleware/version.go
@@ -32,13 +32,13 @@ func VersionHeader(cfg VersionHeaderConfig) echo.MiddlewareFunc {
 	}
 }
 
-func DefaultVersionHeaderSkipper(c echo.Context) bool {
+func DefaultVersionHeaderSkipper(_ echo.Context) bool {
 	return false
 }
 
 // DDisableVersionHeaderSkipper returns a middleware.Skipper function that checks config.
 func DisableVersionHeaderSkipper(relayProxyConfig *config.Config) middleware.Skipper {
-	return func(c echo.Context) bool {
+	return func(_ echo.Context) bool {
 		return relayProxyConfig.DisableVersionHeader
 	}
 }

--- a/cmd/relayproxy/api/middleware/version_test.go
+++ b/cmd/relayproxy/api/middleware/version_test.go
@@ -43,7 +43,9 @@ func TestNoVersion(t *testing.T) {
 		DisableVersionHeader: true,
 	}
 	middleware := middleware2.VersionHeader(middleware2.VersionHeaderConfig{
-		Skipper:          middleware2.DisableVersionHeaderSkipper(conf),
+		Skipper: func(c echo.Context) bool {
+			return conf.DisableVersionHeader
+		},
 		RelayProxyConfig: conf,
 	})
 	handler := middleware(func(c echo.Context) error {

--- a/cmd/relayproxy/api/routes_monitoring.go
+++ b/cmd/relayproxy/api/routes_monitoring.go
@@ -18,9 +18,9 @@ func (s *Server) addMonitoringRoutes() {
 		s.monitoringEcho.Debug = s.config.IsDebugEnabled()
 		s.monitoringEcho.Use(custommiddleware.ZapLogger(s.zapLog, s.config))
 		s.monitoringEcho.Use(middleware.CORSWithConfig(middleware.DefaultCORSConfig))
-		if s.config.EnableVersionHeader {
-			s.monitoringEcho.Use(custommiddleware.VersionHeader(s.config))
-		}
+		s.apiEcho.Use(custommiddleware.VersionHeader(custommiddleware.VersionHeaderConfig{
+			RelayProxyConfig: s.config,
+		}))
 		s.monitoringEcho.Use(middleware.Recover())
 		s.initMonitoringEndpoint(s.monitoringEcho)
 	} else {

--- a/cmd/relayproxy/api/routes_monitoring.go
+++ b/cmd/relayproxy/api/routes_monitoring.go
@@ -18,7 +18,9 @@ func (s *Server) addMonitoringRoutes() {
 		s.monitoringEcho.Debug = s.config.IsDebugEnabled()
 		s.monitoringEcho.Use(custommiddleware.ZapLogger(s.zapLog, s.config))
 		s.monitoringEcho.Use(middleware.CORSWithConfig(middleware.DefaultCORSConfig))
-		s.monitoringEcho.Use(custommiddleware.VersionHeader(s.config))
+		if s.config.EnableVersionHeader {
+			s.monitoringEcho.Use(custommiddleware.VersionHeader(s.config))
+		}
 		s.monitoringEcho.Use(middleware.Recover())
 		s.initMonitoringEndpoint(s.monitoringEcho)
 	} else {

--- a/cmd/relayproxy/api/server.go
+++ b/cmd/relayproxy/api/server.go
@@ -71,7 +71,9 @@ func (s *Server) initRoutes() {
 		}))
 	}
 	s.apiEcho.Use(middleware.CORSWithConfig(middleware.DefaultCORSConfig))
-	s.apiEcho.Use(custommiddleware.VersionHeader(s.config))
+	if s.config.EnableVersionHeader {
+		s.apiEcho.Use(custommiddleware.VersionHeader(s.config))
+	}
 	s.apiEcho.Use(middleware.Recover())
 
 	// Init controllers

--- a/cmd/relayproxy/api/server.go
+++ b/cmd/relayproxy/api/server.go
@@ -73,7 +73,9 @@ func (s *Server) initRoutes() {
 	s.apiEcho.Use(middleware.CORSWithConfig(middleware.DefaultCORSConfig))
 
 	s.apiEcho.Use(custommiddleware.VersionHeader(custommiddleware.VersionHeaderConfig{
-		Skipper:          custommiddleware.DisableVersionHeaderSkipper(s.config),
+		Skipper: func(_ echo.Context) bool {
+			return s.config.DisableVersionHeader
+		},
 		RelayProxyConfig: s.config,
 	}))
 

--- a/cmd/relayproxy/api/server.go
+++ b/cmd/relayproxy/api/server.go
@@ -71,9 +71,12 @@ func (s *Server) initRoutes() {
 		}))
 	}
 	s.apiEcho.Use(middleware.CORSWithConfig(middleware.DefaultCORSConfig))
-	if s.config.EnableVersionHeader {
-		s.apiEcho.Use(custommiddleware.VersionHeader(s.config))
-	}
+
+	s.apiEcho.Use(custommiddleware.VersionHeader(custommiddleware.VersionHeaderConfig{
+		Skipper:          custommiddleware.DisableVersionHeaderSkipper(s.config),
+		RelayProxyConfig: s.config,
+	}))
+
 	s.apiEcho.Use(middleware.Recover())
 
 	// Init controllers

--- a/cmd/relayproxy/api/server_test.go
+++ b/cmd/relayproxy/api/server_test.go
@@ -260,8 +260,8 @@ func Test_VersionHeader_Disabled(t *testing.T) {
 			Kind: "file",
 			Path: "../../../testdata/flag-config.yaml",
 		},
-		ListenPort:          11024,
-		EnableVersionHeader: false,
+		ListenPort:           11024,
+		DisableVersionHeader: true,
 	}
 	log := log.InitLogger()
 	defer func() { _ = log.ZapLogger.Sync() }()

--- a/cmd/relayproxy/config/config.go
+++ b/cmd/relayproxy/config/config.go
@@ -63,11 +63,12 @@ func New(flagSet *pflag.FlagSet, log *zap.Logger, version string) (*Config, erro
 
 	// Default values
 	_ = k.Load(confmap.Provider(map[string]interface{}{
-		"listen":          "1031",
-		"host":            "localhost",
-		"fileFormat":      "yaml",
-		"pollingInterval": 60000,
-		"logLevel":        DefaultLogLevel,
+		"listen":              "1031",
+		"host":                "localhost",
+		"fileFormat":          "yaml",
+		"pollingInterval":     60000,
+		"logLevel":            DefaultLogLevel,
+		"enableVersionHeader": true,
 	}, "."), nil)
 
 	// mapping command line parameters to koanf
@@ -261,6 +262,10 @@ type Config struct {
 
 	// Version is the version of the relay-proxy
 	Version string `mapstructure:"version" koanf:"version"`
+
+	// Enable x-gofeatureflag-version header in the relay-proxy HTTP response
+	// Default: true
+	EnableVersionHeader bool `mapstructure:"enableVersionHeader" koanf:"enableversionheader"`
 
 	// Deprecated: use AuthorizedKeys instead
 	// APIKeys list of API keys that authorized to use endpoints

--- a/cmd/relayproxy/config/config.go
+++ b/cmd/relayproxy/config/config.go
@@ -63,12 +63,11 @@ func New(flagSet *pflag.FlagSet, log *zap.Logger, version string) (*Config, erro
 
 	// Default values
 	_ = k.Load(confmap.Provider(map[string]interface{}{
-		"listen":              "1031",
-		"host":                "localhost",
-		"fileFormat":          "yaml",
-		"pollingInterval":     60000,
-		"logLevel":            DefaultLogLevel,
-		"enableVersionHeader": true,
+		"listen":          "1031",
+		"host":            "localhost",
+		"fileFormat":      "yaml",
+		"pollingInterval": 60000,
+		"logLevel":        DefaultLogLevel,
 	}, "."), nil)
 
 	// mapping command line parameters to koanf
@@ -263,9 +262,9 @@ type Config struct {
 	// Version is the version of the relay-proxy
 	Version string `mapstructure:"version" koanf:"version"`
 
-	// Enable x-gofeatureflag-version header in the relay-proxy HTTP response
-	// Default: true
-	EnableVersionHeader bool `mapstructure:"enableVersionHeader" koanf:"enableversionheader"`
+	// Disable x-gofeatureflag-version header in the relay-proxy HTTP response
+	// Default: false
+	DisableVersionHeader bool `mapstructure:"disableVersionHeader" koanf:"disableversionheader"`
 
 	// Deprecated: use AuthorizedKeys instead
 	// APIKeys list of API keys that authorized to use endpoints

--- a/cmd/relayproxy/config/config_test.go
+++ b/cmd/relayproxy/config/config_test.go
@@ -38,6 +38,7 @@ func TestParseConfig_fileFromPflag(t *testing.T) {
 				},
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
+				EnableVersionHeader:     true,
 				EnableSwagger:           true,
 				AuthorizedKeys: config.APIKeys{
 					Admin: []string{
@@ -75,6 +76,7 @@ func TestParseConfig_fileFromPflag(t *testing.T) {
 				},
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
+				EnableVersionHeader:     true,
 				EnableSwagger:           true,
 				AuthorizedKeys: config.APIKeys{
 					Admin: nil,
@@ -104,6 +106,7 @@ func TestParseConfig_fileFromPflag(t *testing.T) {
 				},
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
+				EnableVersionHeader:     true,
 				EnableSwagger:           true,
 				APIKeys: []string{
 					"apikey1",
@@ -131,6 +134,7 @@ func TestParseConfig_fileFromPflag(t *testing.T) {
 				},
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
+				EnableVersionHeader:     true,
 				EnableSwagger:           true,
 				APIKeys: []string{
 					"apikey1",
@@ -150,6 +154,7 @@ func TestParseConfig_fileFromPflag(t *testing.T) {
 				Host:                    "localhost",
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
+				EnableVersionHeader:     true,
 				LogLevel:                config.DefaultLogLevel,
 			},
 			wantErr: assert.NoError,
@@ -163,12 +168,13 @@ func TestParseConfig_fileFromPflag(t *testing.T) {
 			name:         "Valid YAML with OTel config",
 			fileLocation: "../testdata/config/valid-otel.yaml",
 			want: &config.Config{
-				ListenPort:      1031,
-				PollingInterval: 60000,
-				FileFormat:      "yaml",
-				Host:            "localhost",
-				LogLevel:        config.DefaultLogLevel,
-				Version:         "1.X.X",
+				ListenPort:          1031,
+				PollingInterval:     60000,
+				FileFormat:          "yaml",
+				Host:                "localhost",
+				LogLevel:            config.DefaultLogLevel,
+				Version:             "1.X.X",
+				EnableVersionHeader: true,
 				Retrievers: &[]config.RetrieverConf{
 					{
 						Kind: "file",
@@ -233,6 +239,7 @@ func TestParseConfig_fileFromFolder(t *testing.T) {
 				},
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
+				EnableVersionHeader:     true,
 				EnableSwagger:           true,
 				AuthorizedKeys: config.APIKeys{
 					Admin: []string{
@@ -257,6 +264,7 @@ func TestParseConfig_fileFromFolder(t *testing.T) {
 				Host:                    "localhost",
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
+				EnableVersionHeader:     true,
 				LogLevel:                config.DefaultLogLevel,
 			},
 			wantErr: assert.NoError,
@@ -277,6 +285,7 @@ func TestParseConfig_fileFromFolder(t *testing.T) {
 				Host:                    "localhost",
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
+				EnableVersionHeader:     true,
 				LogLevel:                config.DefaultLogLevel,
 			},
 		},
@@ -291,6 +300,7 @@ func TestParseConfig_fileFromFolder(t *testing.T) {
 				Host:                    "localhost",
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
+				EnableVersionHeader:     true,
 				LogLevel:                config.DefaultLogLevel,
 			},
 		},
@@ -305,6 +315,7 @@ func TestParseConfig_fileFromFolder(t *testing.T) {
 				Host:                    "localhost",
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
+				EnableVersionHeader:     true,
 				LogLevel:                config.DefaultLogLevel,
 			},
 			disableDefaultFileCreation: true,
@@ -827,6 +838,7 @@ func TestMergeConfig_FromOSEnv(t *testing.T) {
 				},
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
+				EnableVersionHeader:     true,
 				EnableSwagger:           true,
 				AuthorizedKeys: config.APIKeys{
 					Admin: []string{
@@ -854,12 +866,13 @@ func TestMergeConfig_FromOSEnv(t *testing.T) {
 			fileLocation:               "../testdata/config/valid-otel.yaml",
 			disableDefaultFileCreation: true,
 			want: &config.Config{
-				ListenPort:      1031,
-				PollingInterval: 60000,
-				FileFormat:      "yaml",
-				Host:            "localhost",
-				LogLevel:        config.DefaultLogLevel,
-				Version:         "1.X.X",
+				ListenPort:          1031,
+				PollingInterval:     60000,
+				FileFormat:          "yaml",
+				Host:                "localhost",
+				LogLevel:            config.DefaultLogLevel,
+				Version:             "1.X.X",
+				EnableVersionHeader: true,
 				Retrievers: &[]config.RetrieverConf{
 					{
 						Kind: "file",

--- a/cmd/relayproxy/config/config_test.go
+++ b/cmd/relayproxy/config/config_test.go
@@ -38,7 +38,6 @@ func TestParseConfig_fileFromPflag(t *testing.T) {
 				},
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
-				EnableVersionHeader:     true,
 				EnableSwagger:           true,
 				AuthorizedKeys: config.APIKeys{
 					Admin: []string{
@@ -76,7 +75,6 @@ func TestParseConfig_fileFromPflag(t *testing.T) {
 				},
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
-				EnableVersionHeader:     true,
 				EnableSwagger:           true,
 				AuthorizedKeys: config.APIKeys{
 					Admin: nil,
@@ -106,7 +104,6 @@ func TestParseConfig_fileFromPflag(t *testing.T) {
 				},
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
-				EnableVersionHeader:     true,
 				EnableSwagger:           true,
 				APIKeys: []string{
 					"apikey1",
@@ -134,7 +131,6 @@ func TestParseConfig_fileFromPflag(t *testing.T) {
 				},
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
-				EnableVersionHeader:     true,
 				EnableSwagger:           true,
 				APIKeys: []string{
 					"apikey1",
@@ -154,7 +150,6 @@ func TestParseConfig_fileFromPflag(t *testing.T) {
 				Host:                    "localhost",
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
-				EnableVersionHeader:     true,
 				LogLevel:                config.DefaultLogLevel,
 			},
 			wantErr: assert.NoError,
@@ -168,13 +163,12 @@ func TestParseConfig_fileFromPflag(t *testing.T) {
 			name:         "Valid YAML with OTel config",
 			fileLocation: "../testdata/config/valid-otel.yaml",
 			want: &config.Config{
-				ListenPort:          1031,
-				PollingInterval:     60000,
-				FileFormat:          "yaml",
-				Host:                "localhost",
-				LogLevel:            config.DefaultLogLevel,
-				Version:             "1.X.X",
-				EnableVersionHeader: true,
+				ListenPort:      1031,
+				PollingInterval: 60000,
+				FileFormat:      "yaml",
+				Host:            "localhost",
+				LogLevel:        config.DefaultLogLevel,
+				Version:         "1.X.X",
 				Retrievers: &[]config.RetrieverConf{
 					{
 						Kind: "file",
@@ -239,7 +233,6 @@ func TestParseConfig_fileFromFolder(t *testing.T) {
 				},
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
-				EnableVersionHeader:     true,
 				EnableSwagger:           true,
 				AuthorizedKeys: config.APIKeys{
 					Admin: []string{
@@ -264,7 +257,6 @@ func TestParseConfig_fileFromFolder(t *testing.T) {
 				Host:                    "localhost",
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
-				EnableVersionHeader:     true,
 				LogLevel:                config.DefaultLogLevel,
 			},
 			wantErr: assert.NoError,
@@ -285,7 +277,6 @@ func TestParseConfig_fileFromFolder(t *testing.T) {
 				Host:                    "localhost",
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
-				EnableVersionHeader:     true,
 				LogLevel:                config.DefaultLogLevel,
 			},
 		},
@@ -300,7 +291,6 @@ func TestParseConfig_fileFromFolder(t *testing.T) {
 				Host:                    "localhost",
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
-				EnableVersionHeader:     true,
 				LogLevel:                config.DefaultLogLevel,
 			},
 		},
@@ -315,7 +305,6 @@ func TestParseConfig_fileFromFolder(t *testing.T) {
 				Host:                    "localhost",
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
-				EnableVersionHeader:     true,
 				LogLevel:                config.DefaultLogLevel,
 			},
 			disableDefaultFileCreation: true,
@@ -838,7 +827,6 @@ func TestMergeConfig_FromOSEnv(t *testing.T) {
 				},
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
-				EnableVersionHeader:     true,
 				EnableSwagger:           true,
 				AuthorizedKeys: config.APIKeys{
 					Admin: []string{
@@ -866,13 +854,12 @@ func TestMergeConfig_FromOSEnv(t *testing.T) {
 			fileLocation:               "../testdata/config/valid-otel.yaml",
 			disableDefaultFileCreation: true,
 			want: &config.Config{
-				ListenPort:          1031,
-				PollingInterval:     60000,
-				FileFormat:          "yaml",
-				Host:                "localhost",
-				LogLevel:            config.DefaultLogLevel,
-				Version:             "1.X.X",
-				EnableVersionHeader: true,
+				ListenPort:      1031,
+				PollingInterval: 60000,
+				FileFormat:      "yaml",
+				Host:            "localhost",
+				LogLevel:        config.DefaultLogLevel,
+				Version:         "1.X.X",
 				Retrievers: &[]config.RetrieverConf{
 					{
 						Kind: "file",

--- a/website/docs/relay-proxy/configure-relay-proxy.mdx
+++ b/website/docs/relay-proxy/configure-relay-proxy.mdx
@@ -251,7 +251,7 @@ Enables Swagger for testing the APIs directly. If you are enabling Swagger you w
 - This field is used by Swagger to query the API at the right place.
 
 ### `disableVersionHeader`
-If `disableVersionHeader` is set to **`true`**, the relay proxy will not add the header `x-gofeatureflag-version` with the GOFF version in the HTTP response.
+If `disableVersionHeader` is set to **`true`**, the relay proxy will not add the header `x-gofeatureflag-version` with the GO Feature Flag version in the HTTP response.
 - option name: `disableVersionHeader`
 - type: **boolean**
 - default: **`false`**

--- a/website/docs/relay-proxy/configure-relay-proxy.mdx
+++ b/website/docs/relay-proxy/configure-relay-proxy.mdx
@@ -250,6 +250,13 @@ Enables Swagger for testing the APIs directly. If you are enabling Swagger you w
 - mandatory: <NotMandatory />
 - This field is used by Swagger to query the API at the right place.
 
+### `disableVersionHeader`
+If `disableVersionHeader` is set to **`true`**, the relay proxy will not add the header `x-gofeatureflag-version` with the GOFF version in the HTTP response.
+- option name: `disableVersionHeader`
+- type: **boolean**
+- default: **`false`**
+- mandatory: <NotMandatory />
+
 ### `authorizedKeys`
 List of authorized API keys.
 :::info


### PR DESCRIPTION
add a boolean EnableVersionHeader in configuration to conditionnally register the VersionHeader custom middleware and disable the header x-gofeatureflag-version

issue: https://github.com/thomaspoignant/go-feature-flag/issues/3140

## Description
<!-- 
Please add a description of what your pull request is doing.
 - What was the problem?
 - How it is resolved?
 - How can we test the change?
 - If there are breaking changes, please describe them in detail and why we cannot avoid them.
-->
Add a new boolean named `EnableVersionHeader` in documentation with default value set to `true` in order to not change initial behavior.

The idea behind this is to allow end user to disable `VersionHeader` custom middleware to remove `x-gofeatureflag-version` header.

## Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #3140

## Checklist
- [X] I have tested this code
- [X] I have added unit test to cover this code
- [X] I have updated the documentation (`README.md` and `/website/docs`)
- [X] I have followed the [contributing guide](CONTRIBUTING.md)
