### PR TITLE
fix(s3): Use a default context if not provided in retriever and exporter

### DIFF
--- a/exporter/s3exporterv2/exporter.go
+++ b/exporter/s3exporterv2/exporter.go
@@ -83,6 +83,9 @@ func (f *Exporter) initializeUploader(ctx context.Context) error {
 
 // Export is saving a collection of events in a file.
 func (f *Exporter) Export(ctx context.Context, logger *fflog.FFLogger, featureEvents []exporter.FeatureEvent) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if f.s3Uploader == nil {
 		initErr := f.initializeUploader(ctx)
 		if initErr != nil {

--- a/retriever/s3retrieverv2/retriever.go
+++ b/retriever/s3retrieverv2/retriever.go
@@ -37,6 +37,9 @@ type Retriever struct {
 }
 
 func (s *Retriever) Init(ctx context.Context, _ *fflog.FFLogger) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	s.status = retriever.RetrieverNotReady
 	if s.downloader == nil {
 		if s.AwsConfig == nil {
@@ -63,6 +66,9 @@ func (s *Retriever) Status() retriever.Status {
 }
 
 func (s *Retriever) Retrieve(ctx context.Context) ([]byte, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if s.downloader == nil {
 		s.status = retriever.RetrieverError
 		return nil, fmt.Errorf("downloader is not initialized")

--- a/retriever/s3retrieverv2/retriever_test.go
+++ b/retriever/s3retrieverv2/retriever_test.go
@@ -32,9 +32,24 @@ func Test_s3Retriever_Retrieve(t *testing.T) {
 				downloader: &testutils.S3ManagerV2Mock{
 					TestDataLocation: "./testdata",
 				},
-				bucket: "Bucket",
-				item:   "valid",
+				bucket:  "Bucket",
+				item:    "valid",
+				context: context.TODO(),
 			},
+			want:    "./testdata/flag-config.yaml",
+			wantErr: false,
+		},
+		{
+			name: "File on S3 context nil",
+			fields: fields{
+				downloader: &testutils.S3ManagerV2Mock{
+					TestDataLocation: "./testdata",
+				},
+				bucket:  "Bucket",
+				item:    "valid",
+				context: nil,
+			},
+
 			want:    "./testdata/flag-config.yaml",
 			wantErr: false,
 		},
@@ -75,6 +90,7 @@ func Test_s3Retriever_Retrieve(t *testing.T) {
 						o.UseAccelerate = true
 					},
 				},
+				context: context.TODO(),
 			},
 			want:    "./testdata/flag-config.yaml",
 			wantErr: false,
@@ -82,7 +98,7 @@ func Test_s3Retriever_Retrieve(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			awsConf, _ := config.LoadDefaultConfig(context.TODO())
+			awsConf, _ := config.LoadDefaultConfig(tt.fields.context)
 			s := Retriever{
 				Bucket:          tt.fields.bucket,
 				Item:            tt.fields.item,
@@ -90,10 +106,10 @@ func Test_s3Retriever_Retrieve(t *testing.T) {
 				downloader:      tt.fields.downloader,
 				S3ClientOptions: tt.fields.S3ClientOptions,
 			}
-			err := s.Init(context.Background(), nil)
+			err := s.Init(tt.fields.context, nil)
 			assert.NoError(t, err)
 			defer func() {
-				err := s.Shutdown(context.Background())
+				err := s.Shutdown(tt.fields.context)
 				assert.NoError(t, err)
 			}()
 

--- a/testutils/s3managerv2_mock.go
+++ b/testutils/s3managerv2_mock.go
@@ -18,6 +18,9 @@ type S3ManagerV2Mock struct {
 }
 
 func (s *S3ManagerV2Mock) Upload(ctx context.Context, uploadInput *s3.PutObjectInput, opts ...func(uploader *manager.Uploader)) (*manager.UploadOutput, error) {
+	if ctx == nil {
+		return nil, errors.New("cannot create context from nil parent")
+	}
 	if uploadInput.Bucket == nil || *uploadInput.Bucket == "" {
 		return nil, errors.New("invalid bucket")
 	}
@@ -39,6 +42,10 @@ func (s *S3ManagerV2Mock) Upload(ctx context.Context, uploadInput *s3.PutObjectI
 }
 
 func (s *S3ManagerV2Mock) Download(ctx context.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*manager.Downloader)) (n int64, err error) {
+	if ctx == nil {
+		return -1, errors.New("cannot create context from nil parent")
+	}
+
 	if *input.Key == "valid" {
 		res, _ := os.ReadFile(s.TestDataLocation + "/flag-config.yaml")
 		_, _ = w.WriteAt(res, 0)


### PR DESCRIPTION
## Description
As mentioned in #3142, there is some issue when initialiasing the aws-sdk with a `nil` context.
In this PR we ensure that we always have a `context.Context` set when calling the s3 retriever but also the s3 exporter.

## Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #3142 

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
