### PR TITLE
fix(relayproxy): deadlock when releasing client of the websocket

### DIFF
--- a/cmd/relayproxy/service/websocket.go
+++ b/cmd/relayproxy/service/websocket.go
@@ -45,7 +45,9 @@ func (w *websocketServiceImpl) BroadcastFlagChanges(diff notifier.DiffCache) {
 	for c := range w.clients {
 		err := c.WriteJSON(diff)
 		if err != nil {
+			w.mutex.RUnlock()
 			w.Deregister(c)
+			w.mutex.RLock()
 		}
 	}
 }


### PR DESCRIPTION
## Description
Fixing a potential deadlock when deregistering the client when broadcasting the changes in the websocket.

## Closes issue(s)
Resolve #3144 

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
