### PR TITLE
ci: fixed version for golangci-lint to 1.64.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ bench: ## Launch the benchmark test
 ## Lint:
 lint: ## Use golintci-lint on your project
 	mkdir -p ./bin
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s latest # Install linters
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.64.6 # Install linters
 	./bin/golangci-lint run --timeout=5m --timeout=5m ./... # Run linters
 
 ## Help:


### PR DESCRIPTION
## Description
`golanglint-ci` v2 is out and needs to rework the configuration file.
Since CI is taking latest it blocks all the pipelines, this PR is to ensure we can still release things while waiting to migrate to v2 #3244.

## Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
