### PR TITLE
perf: Separate goroutine for exporter flow

### DIFF
--- a/exporter/even_store_test.go
+++ b/exporter/even_store_test.go
@@ -149,7 +149,6 @@ func Test_MultipleConsumersMultipleGORoutines(t *testing.T) {
 	wg := &sync.WaitGroup{}
 
 	consumFunc := func(eventStore exporter.EventStore[string], consumerName string) {
-		wg.Add(1)
 		defer wg.Done()
 
 		err := eventStore.ProcessPendingEvents(consumerName, func(ctx context.Context, events []string) error {
@@ -166,6 +165,7 @@ func Test_MultipleConsumersMultipleGORoutines(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
+	wg.Add(2)
 	go consumFunc(eventStore, consumerNames[0])
 	go consumFunc(eventStore, consumerNames[1])
 	wg.Wait()

--- a/feature_flag.go
+++ b/feature_flag.go
@@ -354,5 +354,6 @@ func ForceRefresh() bool {
 // Close the component by stopping the background refresh and clean the cache.
 func Close() {
 	onceFF = sync.Once{}
+	wg.Wait()
 	ff.Close()
 }

--- a/feature_flag.go
+++ b/feature_flag.go
@@ -48,6 +48,7 @@ type GoFeatureFlag struct {
 	bgUpdater        backgroundUpdater
 	dataExporter     exporter.Manager[exporter.FeatureEvent]
 	retrieverManager *retriever.Manager
+	exporterWg       sync.WaitGroup
 }
 
 // ff is the default object for go-feature-flag
@@ -354,6 +355,6 @@ func ForceRefresh() bool {
 // Close the component by stopping the background refresh and clean the cache.
 func Close() {
 	onceFF = sync.Once{}
-	wg.Wait()
+	ff.exporterWg.Wait()
 	ff.Close()
 }

--- a/variation.go
+++ b/variation.go
@@ -3,7 +3,6 @@ package ffclient
 import (
 	"fmt"
 	"maps"
-	"sync"
 
 	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/ffcontext"
@@ -15,8 +14,6 @@ const (
 	errorFlagNotAvailable = "flag %v is not present or disabled"
 	errorWrongVariation   = "wrong variation used for flag %v"
 )
-
-var wg = sync.WaitGroup{}
 
 // BoolVariation return the value of the flag in boolean.
 // An error is return if you don't have init the library before calling the function.
@@ -274,9 +271,9 @@ func notifyVariation[T model.JSONType](
 	if result.TrackEvents {
 		event := exporter.NewFeatureEvent(ctx, flagKey, result.Value, result.VariationType, result.Failed, result.Version,
 			"SERVER", ctx.ExtractGOFFProtectedFields().ExporterMetadata)
-		wg.Add(1)
+		g.exporterWg.Add(1)
 		go func() {
-			defer wg.Done()
+			defer g.exporterWg.Done()
 			g.CollectEventData(event)
 		}()
 	}

--- a/variation.go
+++ b/variation.go
@@ -256,7 +256,7 @@ func (g *GoFeatureFlag) getFlagFromCache(flagKey string) (flag.Flag, error) {
 func (g *GoFeatureFlag) CollectEventData(event exporter.FeatureEvent) {
 	if g != nil && g.dataExporter != nil {
 		// Add event in the exporter
-		g.dataExporter.AddEvent(event)
+		go g.dataExporter.AddEvent(event)
 	}
 }
 


### PR DESCRIPTION
## Description

 - What was the problem? It was getting too much time to flush/send events from exporter and doing it synchronously doesn't make a lot of sense, while heavily increasing response times.
 - How it is resolved?
 Whole events exporter now runs in different goroutine
 - How can we test the change?
 - If there are breaking changes, please describe them in detail and why we cannot avoid them.

Tested with 1000rps, traced for 1 minute 

Before
![image](https://github.com/user-attachments/assets/18aa5235-8fdd-489e-a971-de195cbd9b84)
<img width="1397" alt="image" src="https://github.com/user-attachments/assets/9e3e90bd-417e-4a58-8c79-cc789b6e0ea3" />

After
![image](https://github.com/user-attachments/assets/4787e23e-a365-4898-8aad-21a21abd5cab)
<img width="1446" alt="image" src="https://github.com/user-attachments/assets/b4ea99f6-c125-45b1-8aee-5b73d55e6b71" />


This duration was saved during the trace (60seconds)
![image](https://github.com/user-attachments/assets/36c468bc-9d22-4a24-a7ed-c3e0808da0c5)


full pprof traces: 
https://drive.google.com/file/d/1ZpxxOnk1CQ3bXRMYUCowwXgrebO3HAcF/view?usp=sharing
https://drive.google.com/file/d/1KyFWdtl6LXDV03EKkaLIs5ipV3Aar7nP/view?usp=sharing

## Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #

## Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
