### PR TITLE
fix(relayproxy): configure kafka addresses with env variables

### DIFF
--- a/cmd/relayproxy/config/config.go
+++ b/cmd/relayproxy/config/config.go
@@ -115,6 +115,10 @@ func New(flagSet *pflag.FlagSet, log *zap.Logger, version string) (*Config, erro
 			return s, v
 		}
 
+		if strings.HasPrefix(s, "EXPORTER_KAFKA_ADDRESSES") {
+			return "exporter.kafka.addresses", strings.Split(v, ",")
+		}
+
 		if strings.HasPrefix(s, "AUTHORIZEDKEYS_EVALUATION") {
 			return "authorizedKeys.evaluation", strings.Split(v, ",")
 		}
@@ -138,6 +142,12 @@ func New(flagSet *pflag.FlagSet, log *zap.Logger, version string) (*Config, erro
 		return nil, errUnmarshal
 	}
 
+	if proxyConf.Exporters != nil {
+		for i := range *proxyConf.Exporters {
+			(*proxyConf.Exporters)[i].Kafka.Addresses = stringToArray((*proxyConf.Exporters)[i].Kafka.Addresses)
+		}
+	}
+
 	if proxyConf.Debug {
 		log.Warn(
 			"Option Debug that you are using in your configuration file is deprecated" +
@@ -146,6 +156,13 @@ func New(flagSet *pflag.FlagSet, log *zap.Logger, version string) (*Config, erro
 	}
 
 	return proxyConf, nil
+}
+
+func stringToArray(item []string) []string {
+	if item != nil && len(item) > 0 {
+		return strings.Split(item[0], ",")
+	}
+	return item
 }
 
 func parseOtelResourceAttributes(attributes string, log *zap.Logger) {

--- a/cmd/relayproxy/config/config_test.go
+++ b/cmd/relayproxy/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
+	"github.com/thomaspoignant/go-feature-flag/exporter/kafkaexporter"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -902,7 +903,6 @@ func TestMergeConfig_FromOSEnv(t *testing.T) {
 					},
 					{
 						HTTPHeaders: map[string][]string{
-
 							"authorization": {
 								"test1",
 							},
@@ -937,6 +937,55 @@ func TestMergeConfig_FromOSEnv(t *testing.T) {
 				"RETRIEVERS_0_HEADERS_TOKEN":         "token",
 				"RETRIEVERS_2_HEADERS_AUTHORIZATION": "test1",
 				"RETRIEVERS_2_HEADERS_X-GOFF-CUSTOM": "custom",
+			},
+		},
+		{
+			name:         "Change kafka exporters",
+			fileLocation: "../testdata/config/validate-array-env-file.yaml",
+			want: &config.Config{
+				ListenPort:      1031,
+				PollingInterval: 1000,
+				FileFormat:      "yaml",
+				Host:            "localhost",
+				Retrievers: &[]config.RetrieverConf{
+					{
+						Kind: "http",
+						URL:  "https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/examples/retriever_file/flags.goff.yaml",
+						HTTPHeaders: map[string][]string{
+							"authorization": {
+								"test",
+							},
+							"token": {"token"},
+						},
+					},
+					{
+						Kind: "file",
+						Path: "examples/retriever_file/flags.goff.yaml",
+						HTTPHeaders: map[string][]string{
+							"token": {
+								"11213123",
+							},
+							"authorization": {
+								"test1",
+							},
+						},
+					},
+				},
+				Exporter: &config.ExporterConf{
+					Kind: "kafka",
+					Kafka: kafkaexporter.Settings{
+						Addresses: []string{"localhost:19092", "localhost:19093"},
+					},
+				},
+				StartWithRetrieverError: false,
+				Version:                 "1.X.X",
+				EnableSwagger:           true,
+				LogLevel:                "info",
+			},
+			wantErr: assert.NoError,
+			envVars: map[string]string{
+				"EXPORTERS_0_KAFKA_ADDRESSES": "localhost:19092,localhost:19093",
+				"EXPORTERS_0_KIND":            "kafka",
 			},
 		},
 		{

--- a/cmd/relayproxy/config/config_test.go
+++ b/cmd/relayproxy/config/config_test.go
@@ -940,7 +940,7 @@ func TestMergeConfig_FromOSEnv(t *testing.T) {
 			},
 		},
 		{
-			name:         "Change kafka exporters",
+			name:         "Change kafka exporter",
 			fileLocation: "../testdata/config/validate-array-env-file.yaml",
 			want: &config.Config{
 				ListenPort:      1031,
@@ -951,12 +951,6 @@ func TestMergeConfig_FromOSEnv(t *testing.T) {
 					{
 						Kind: "http",
 						URL:  "https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/examples/retriever_file/flags.goff.yaml",
-						HTTPHeaders: map[string][]string{
-							"authorization": {
-								"test",
-							},
-							"token": {"token"},
-						},
 					},
 					{
 						Kind: "file",
@@ -964,9 +958,6 @@ func TestMergeConfig_FromOSEnv(t *testing.T) {
 						HTTPHeaders: map[string][]string{
 							"token": {
 								"11213123",
-							},
-							"authorization": {
-								"test1",
 							},
 						},
 					},
@@ -977,6 +968,67 @@ func TestMergeConfig_FromOSEnv(t *testing.T) {
 						Addresses: []string{"localhost:19092", "localhost:19093"},
 					},
 				},
+				AuthorizedKeys: config.APIKeys{
+					Admin: []string{
+						"apikey3",
+					},
+					Evaluation: []string{
+						"apikey1",
+						"apikey2",
+					},
+				},
+				StartWithRetrieverError: false,
+				Version:                 "1.X.X",
+				EnableSwagger:           true,
+				LogLevel:                "info",
+			},
+			wantErr: assert.NoError,
+			envVars: map[string]string{
+				"EXPORTER_KAFKA_ADDRESSES": "localhost:19092,localhost:19093",
+				"EXPORTER_KIND":            "kafka",
+			},
+		},
+		{
+			name:         "Change kafka exporters",
+			fileLocation: "../testdata/config/valid-env-exporters-kafka.yaml",
+			want: &config.Config{
+				ListenPort:      1031,
+				PollingInterval: 1000,
+				FileFormat:      "yaml",
+				Host:            "localhost",
+				Retrievers: &[]config.RetrieverConf{
+					{
+						Kind: "http",
+						URL:  "https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/examples/retriever_file/flags.goff.yaml",
+					},
+					{
+						Kind: "file",
+						Path: "examples/retriever_file/flags.goff.yaml",
+						HTTPHeaders: map[string][]string{
+							"token": {
+								"11213123",
+							},
+						},
+					},
+				},
+				Exporters: &[]config.ExporterConf{
+					{
+						Kind: "kafka",
+						Kafka: kafkaexporter.Settings{
+							Addresses: []string{"localhost:19092", "localhost:19093"},
+							Topic:     "svc-goff.evaluation",
+						},
+					},
+				},
+				AuthorizedKeys: config.APIKeys{
+					Admin: []string{
+						"apikey3",
+					},
+					Evaluation: []string{
+						"apikey1",
+						"apikey2",
+					},
+				},
 				StartWithRetrieverError: false,
 				Version:                 "1.X.X",
 				EnableSwagger:           true,
@@ -985,7 +1037,6 @@ func TestMergeConfig_FromOSEnv(t *testing.T) {
 			wantErr: assert.NoError,
 			envVars: map[string]string{
 				"EXPORTERS_0_KAFKA_ADDRESSES": "localhost:19092,localhost:19093",
-				"EXPORTERS_0_KIND":            "kafka",
 			},
 		},
 		{

--- a/cmd/relayproxy/testdata/config/valid-env-exporters-kafka.yaml
+++ b/cmd/relayproxy/testdata/config/valid-env-exporters-kafka.yaml
@@ -1,0 +1,23 @@
+listen: 1031
+pollingInterval: 1000
+startWithRetrieverError: false
+retrievers:
+  - kind: http
+    url: https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/examples/retriever_file/flags.goff.yaml
+  - kind: file
+    path: examples/retriever_file/flags.goff.yaml
+    headers:
+      token: 11213123
+exporters:
+  - kind: kafka
+    kafka:
+      topic: svc-goff.evaluation
+      addresses: [ kafka:9092 ]
+enableSwagger: true
+authorizedKeys:
+  evaluation:
+    - apikey1 # owner: userID1
+    - apikey2 # owner: userID2
+  admin:
+    - apikey3
+logLevel: info


### PR DESCRIPTION
## Description
Allow to configure Kafka Addresses through environment variables.

## Closes issue(s)
Resolve #3280

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
