### PR TITLE
fix: a potential production situation

### DIFF
--- a/cmd/relayproxy/config/config.go
+++ b/cmd/relayproxy/config/config.go
@@ -162,7 +162,11 @@ func mapEnvVariablesProvider(log *zap.Logger) koanf.Provider {
 			return s, v
 		}
 
-		return strings.ReplaceAll(strings.ToLower(s), "_", "."), v
+		if strings.HasPrefix(s, "OTEL_") {
+			return strings.ReplaceAll(strings.ToLower(s), "_", "."), v
+		}
+
+		return strings.ToLower(s), v
 	})
 }
 


### PR DESCRIPTION
## Description
When we deployed a service called debug_test_service, EKS generated an env var called DEBUG_TEST_SERVICE which
goff understood to mean enable debug, but the value of the service could not be coerced into boolean
so the goff service started crash looping.  This potentially exposed an additional security concern because any env var with this DEBUG prefix would be written to logs. This failure caused us a 2 hour production headache.

## Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)
