### PR TITLE
feat(relay-proxy): allow to set a prefix for env variables

### DIFF
--- a/cmd/relayproxy/api/routes_monitoring.go
+++ b/cmd/relayproxy/api/routes_monitoring.go
@@ -43,7 +43,7 @@ func (s *Server) initMonitoringEndpoint(echoInstance *echo.Echo) {
 	echoInstance.GET("/health", cHealth.Handler)
 	echoInstance.GET("/info", cInfo.Handler)
 
-	if s.config.Debug || s.config.EnablePprof {
+	if s.config.IsDebugEnabled() || s.config.EnablePprof {
 		pprof.Register(echoInstance)
 	}
 }

--- a/cmd/relayproxy/api/routes_monitoring_test.go
+++ b/cmd/relayproxy/api/routes_monitoring_test.go
@@ -20,31 +20,17 @@ func TestPprofEndpointsStarts(t *testing.T) {
 	type test struct {
 		name               string
 		MonitoringPort     int
-		Debug              bool
 		EnablePprof        bool
 		expectedStatusCode int
 	}
 	tests := []test{
 		{
 			name:               "pprof available in proxy port",
-			Debug:              true,
+			EnablePprof:        true,
 			expectedStatusCode: http.StatusOK,
 		},
 		{
 			name:               "pprof available in monitoring port",
-			Debug:              true,
-			MonitoringPort:     1032,
-			expectedStatusCode: http.StatusOK,
-		},
-		{
-			name:               "pprof not available if debug not enabled",
-			Debug:              false,
-			MonitoringPort:     1032,
-			expectedStatusCode: http.StatusNotFound,
-		},
-		{
-			name:               "pprof available when enablePprof is true",
-			Debug:              false,
 			EnablePprof:        true,
 			MonitoringPort:     1032,
 			expectedStatusCode: http.StatusOK,
@@ -62,7 +48,6 @@ func TestPprofEndpointsStarts(t *testing.T) {
 				},
 				MonitoringPort: tt.MonitoringPort,
 				ListenPort:     1031,
-				Debug:          tt.Debug,
 				EnablePprof:    tt.EnablePprof,
 			}
 

--- a/cmd/relayproxy/config/config.go
+++ b/cmd/relayproxy/config/config.go
@@ -117,13 +117,6 @@ func New(flagSet *pflag.FlagSet, log *zap.Logger, version string) (*Config, erro
 		}
 	}
 
-	if proxyConf.Debug {
-		log.Warn(
-			"Option Debug that you are using in your configuration file is deprecated" +
-				"and will be removed in future versions." +
-				"Please use logLevel: debug to continue to run the relay-proxy with debug logs.")
-	}
-
 	return proxyConf, nil
 }
 
@@ -213,11 +206,6 @@ type Config struct {
 
 	// HideBanner (optional) if true, we don't display the go-feature-flag relay proxy banner
 	HideBanner bool `mapstructure:"hideBanner" koanf:"hidebanner"`
-
-	// Debug (optional) if true, go-feature-flag relay proxy will run on debug mode, with more logs and custom responses.
-	// It will also start the pprof endpoints on the same port as the monitoring.
-	// Default: false
-	Debug bool `mapstructure:"debug" koanf:"debug"`
 
 	// EnablePprof (optional) if true, go-feature-flag relay proxy will start
 	// the pprof endpoints on the same port as the monitoring.
@@ -623,18 +611,13 @@ func (c *Config) IsDebugEnabled() bool {
 	if c == nil {
 		return false
 	}
-	return strings.ToLower(c.LogLevel) == "debug" || c.Debug
+	return strings.ToLower(c.LogLevel) == "debug"
 }
 
 func (c *Config) ZapLogLevel() zapcore.Level {
 	if c == nil {
 		return zapcore.InvalidLevel
 	}
-	// Use debug flag for backward compatibility
-	if c.Debug {
-		return zapcore.DebugLevel
-	}
-
 	level, err := zapcore.ParseLevel(c.LogLevel)
 	if err != nil {
 		return zapcore.InvalidLevel

--- a/cmd/relayproxy/helm-charts/relay-proxy/values.yaml
+++ b/cmd/relayproxy/helm-charts/relay-proxy/values.yaml
@@ -10,18 +10,18 @@ relayproxy:
       url: https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/examples/retriever_file/flags.goff.yaml
     exporter:
       kind: log
+#    envVariablePrefix: "GOFFPROXY_" 
 
 # -- Environment variables to pass to the relay proxy
-env: {}
-  # Examples:
-  # ENV_VARIABLE_EXAMPLE:
-  #   value: my value
-  #
-  # ENV_VARIABLE_FROM_SECRET:
-  #   valueFrom:
-  #     secretKeyRef:
-  #       name: my-secret-name
-  #       key: my-secret-key
+env: { }
+# Examples:
+# LISTEN: 1032
+#
+# ENV_VARIABLE_FROM_SECRET:
+#   valueFrom:
+#     secretKeyRef:
+#       name: my-secret-name
+#       key: my-secret-key
 
 # -- The number of replicas to create for the deployment
 replicaCount: 1
@@ -35,7 +35,7 @@ image:
   tag: ""
 
 # -- Specify imagePullSecrets to be used for the deployment
-imagePullSecrets: []
+imagePullSecrets: [ ]
 # -- replaces the name of the chart in the Chart.yaml file
 nameOverride: ""
 # -- Completely override the deployment name for kubernetes objects
@@ -45,26 +45,26 @@ serviceAccount:
   # -- Specifies whether a service account should be created
   create: true
   # -- Annotations to add to the service account
-  annotations: {}
+  annotations: { }
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
 # -- Pod annotations to add to the deployment
-podAnnotations: {}
+podAnnotations: { }
 
 # -- A security context defines privilege and access control settings for a Pod
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext: { }
+# fsGroup: 2000
 
 # -- A security context defines privilege and access control settings for a Container
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext: { }
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
 
 service:
   # -- The type of service to create
@@ -79,15 +79,15 @@ ingress:
   # -- Ingress class name
   className: ""
   # -- Annotations to add to the ingress
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  annotations: { }
+  # kubernetes.io/ingress.class: nginx
+  # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific
-  tls: []
+  tls: [ ]
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
@@ -113,16 +113,16 @@ autoscaling:
   targetMemoryUtilizationPercentage: 80
 
 # -- Node labels for pod assignment
-nodeSelector: {}
+nodeSelector: { }
 
 # -- Tolerations for pod assignment
-tolerations: []
+tolerations: [ ]
 
 # -- Affinity settings for pod assignment to nodes
-affinity: {}
+affinity: { }
 
 # -- Array of extra objects to deploy with the release (evaluated as a template)
-extraManifests: []
+extraManifests: [ ]
 #  - kind: Role
 #    apiVersion: rbac.authorization.k8s.io/v1
 #    metadata:

--- a/cmd/relayproxy/helm-charts/relay-proxy/values.yaml
+++ b/cmd/relayproxy/helm-charts/relay-proxy/values.yaml
@@ -10,10 +10,10 @@ relayproxy:
       url: https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/examples/retriever_file/flags.goff.yaml
     exporter:
       kind: log
-#    envVariablePrefix: "GOFFPROXY_" 
+#    envVariablePrefix: "GOFFPROXY_"
 
 # -- Environment variables to pass to the relay proxy
-env: { }
+env: {}
 # Examples:
 # LISTEN: 1032
 #
@@ -35,7 +35,7 @@ image:
   tag: ""
 
 # -- Specify imagePullSecrets to be used for the deployment
-imagePullSecrets: [ ]
+imagePullSecrets: []
 # -- replaces the name of the chart in the Chart.yaml file
 nameOverride: ""
 # -- Completely override the deployment name for kubernetes objects
@@ -45,20 +45,20 @@ serviceAccount:
   # -- Specifies whether a service account should be created
   create: true
   # -- Annotations to add to the service account
-  annotations: { }
+  annotations: {}
   # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
 # -- Pod annotations to add to the deployment
-podAnnotations: { }
+podAnnotations: {}
 
 # -- A security context defines privilege and access control settings for a Pod
-podSecurityContext: { }
+podSecurityContext: {}
 # fsGroup: 2000
 
 # -- A security context defines privilege and access control settings for a Container
-securityContext: { }
+securityContext: {}
 # capabilities:
 #   drop:
 #   - ALL
@@ -79,7 +79,7 @@ ingress:
   # -- Ingress class name
   className: ""
   # -- Annotations to add to the ingress
-  annotations: { }
+  annotations: {}
   # kubernetes.io/ingress.class: nginx
   # kubernetes.io/tls-acme: "true"
   hosts:
@@ -87,7 +87,7 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-  tls: [ ]
+  tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
@@ -113,16 +113,16 @@ autoscaling:
   targetMemoryUtilizationPercentage: 80
 
 # -- Node labels for pod assignment
-nodeSelector: { }
+nodeSelector: {}
 
 # -- Tolerations for pod assignment
-tolerations: [ ]
+tolerations: []
 
 # -- Affinity settings for pod assignment to nodes
-affinity: { }
+affinity: {}
 
 # -- Array of extra objects to deploy with the release (evaluated as a template)
-extraManifests: [ ]
+extraManifests: []
 #  - kind: Role
 #    apiVersion: rbac.authorization.k8s.io/v1
 #    metadata:

--- a/cmd/relayproxy/testdata/config/validate-array-env-file-envprefix.yaml
+++ b/cmd/relayproxy/testdata/config/validate-array-env-file-envprefix.yaml
@@ -1,0 +1,21 @@
+listen: 1031
+envVariablePrefix: GOFF_
+pollingInterval: 1000
+startWithRetrieverError: false
+retrievers:
+  - kind: http
+    url: https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/examples/retriever_file/flags.goff.yaml
+  - kind: file
+    path: examples/retriever_file/flags.goff.yaml
+    headers:
+      token: 11213123
+exporter:
+  kind: log
+enableSwagger: true
+authorizedKeys:
+  evaluation:
+    - apikey1 # owner: userID1
+    - apikey2 # owner: userID2
+  admin:
+    - apikey3
+logLevel: info

--- a/website/docs/relay-proxy/configure-relay-proxy.mdx
+++ b/website/docs/relay-proxy/configure-relay-proxy.mdx
@@ -68,6 +68,14 @@ You can override file configurations using environment variables.
   ```shell
   export RETRIEVERS_0_KIND=github
   ```
+
+:::info
+If you want to avoid any collision with existing environment variables that are not specifically related to the relay proxy, you can prefix your environment variables.
+
+You can configure the prefix using the [`envVariablePrefix`](#envvariableprefix) field in your configuration file.
+:::
+
+
 ## Configuration Options
 ### `retrievers`
 This is the configuration on how to retrieve the configuration of the files.
@@ -300,6 +308,20 @@ You will be able to forward those traces to your OpenTelemetry solution directly
 - option name: `openTelemetryOtlpEndpoint`
 - type: **string**
 - default: **none**
+- mandatory: <NotMandatory />
+
+### `envVariablePrefix`
+Prefix for your environment variables.  
+This useful if you want to avoid any collision with existing environment variables that are not specifically related to the relay proxy.
+
+If you use this option you will have to prefix all your environment variables with the value you set here. For example if you want to override the port of the relay-proxy and the prefix is `GOFF_`.
+```shell
+export GOFF_LISTEN=8080
+```
+
+- option name: `envVariablePrefix`
+- type: **string**
+- default: **empty string**
 - mandatory: <NotMandatory />
 
 ## Configuration Types


### PR DESCRIPTION
## Description
Following PR #3336, this solution allow to add a prefix for env variables.
It also remove the `debug` option that was deprecated

## Closes issue(s)
Resolve #3336

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
