### PR TITLE
fix(relayproxy): Error while configuring kafka exporter config

### DIFF
--- a/cmd/relayproxy/service/gofeatureflag.go
+++ b/cmd/relayproxy/service/gofeatureflag.go
@@ -323,29 +323,33 @@ func createExporter(c *config.ExporterConf) (exporter.CommonExporter, error) {
 // setKafkaConfig set the kafka configuration based on the default configuration
 // it will initialize the default configuration and merge it with the changes from the user.
 func setKafkaConfig(k kafkaexporter.Settings) (kafkaexporter.Settings, error) {
-	if k.Config == nil {
-		return k, nil
+	c := kafkaexporter.Settings{
+		Topic:     k.Topic,
+		Addresses: k.Addresses,
 	}
 
-	defaultConfig := sarama.NewConfig()
-	err := mergo.Merge(k.Config, defaultConfig)
-	k.Config = defaultConfig
-	k.Config.Producer.Return.Successes = true
+	if k.Config == nil {
+		return c, nil
+	}
+	saramaConfig := sarama.NewConfig()
+	err := mergo.Merge(saramaConfig, k.Config)
 	if err != nil {
 		return kafkaexporter.Settings{}, err
 	}
+	saramaConfig.Producer.Return.Errors = true
 
-	switch k.Net.SASL.Mechanism {
+	switch saramaConfig.Net.SASL.Mechanism {
 	case sarama.SASLTypeSCRAMSHA256:
-		k.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
+		saramaConfig.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
 			return &kafka.XDGSCRAMClient{HashGeneratorFcn: kafka.SHA256}
 		}
 	case sarama.SASLTypeSCRAMSHA512:
-		k.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
+		saramaConfig.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
 			return &kafka.XDGSCRAMClient{HashGeneratorFcn: kafka.SHA512}
 		}
 	}
-	return k, nil
+	c.Config = saramaConfig
+	return c, nil
 }
 
 func initNotifier(c []config.NotifierConf) ([]notifier.Notifier, error) {

--- a/cmd/relayproxy/service/gofeatureflag.go
+++ b/cmd/relayproxy/service/gofeatureflag.go
@@ -329,6 +329,8 @@ func setKafkaConfig(k kafkaexporter.Settings) (kafkaexporter.Settings, error) {
 
 	defaultConfig := sarama.NewConfig()
 	err := mergo.Merge(k.Config, defaultConfig)
+	k.Config = defaultConfig
+	k.Config.Producer.Return.Successes = true
 	if err != nil {
 		return kafkaexporter.Settings{}, err
 	}


### PR DESCRIPTION
## Description
When in the **relayproxy** you are configuring the `config` field for a kafka exporter, you had the error `error while exporting data: writer: producer: kafka: client has run out of available brokers to talk to`.
See #3307 to have a failing configuration.

This PR fix the issue, by creating a new struct instead of changing the reference.

## Closes issue(s)
Resolve #3307

## Checklist
- [x] I have tested this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
