### PR TITLE
chore: Bump go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thomaspoignant/go-feature-flag
 
-go 1.24.3
+go 1.24.4
 
 require (
 	cloud.google.com/go/pubsub v1.49.0


### PR DESCRIPTION
## Description
Version `1.24.3` has a CVE on stdlib, bumping to latest version.
