### PR TITLE
chore: Remove dependency on asyncio since it's part of base python

### DIFF
--- a/openfeature/providers/python-provider/pyproject.toml
+++ b/openfeature/providers/python-provider/pyproject.toml
@@ -28,7 +28,6 @@ urllib3 = "^2.1.0"
 pylru = "^1.2.1"
 websocket-client = "^1.6.4"
 rel = "^0.4.9"
-asyncio = "^3.4.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.4,<9.0"


### PR DESCRIPTION
## Description

Depending on the python provider brings in the deprecated `asyncio` package (which has been part of base python for a long time)

## Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #3606

## Checklist
- [X] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)
