### PR TITLE
style: rename local variable for the sake of camelCase

### DIFF
--- a/cmd/cli/evaluate/evaluate.go
+++ b/cmd/cli/evaluate/evaluate.go
@@ -46,17 +46,17 @@ func (e evaluate) Evaluate() (map[string]model.RawVarResult, error) {
 
 	if targetingKey, ok := ctxAsMap["targetingKey"].(string); ok {
 		convertedEvaluationCtx := utils.ConvertEvaluationCtxFromRequest(targetingKey, ctxAsMap)
-		listFLags := make([]string, 0)
+		listFlags := make([]string, 0)
 		if e.flag != "" {
-			listFLags = append(listFLags, e.flag)
+			listFlags = append(listFlags, e.flag)
 		} else {
 			flags, _ := goff.GetFlagsFromCache()
 			for key := range flags {
-				listFLags = append(listFLags, key)
+				listFlags = append(listFlags, key)
 			}
 		}
 
-		for _, flag := range listFLags {
+		for _, flag := range listFlags {
 			res, _ := goff.RawVariation(flag, convertedEvaluationCtx, nil)
 			result[flag] = res
 		}


### PR DESCRIPTION
## Description
Hey :)

I've noticed inconsistency in naming of one local variable and decided to rename it. 

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)
