### PR TITLE
fix: return flat error in logs

### DIFF
--- a/exporter/data_exporter.go
+++ b/exporter/data_exporter.go
@@ -146,7 +146,7 @@ func (d *dataExporterImpl[T]) sendEvents(ctx context.Context, events []T) error 
 			err := exp.Export(ctx, legacyLogger, events)
 			slog.WarnContext(ctx, "You are using an exporter with the old logger."+
 				"Please update your custom exporter to comply to the new Exporter interface.",
-				slog.Any("err", err))
+				slog.Any("error", err.Error()))
 			if err != nil {
 				return fmt.Errorf("error while exporting data (deprecated): %w", err)
 			}

--- a/internal/cache/cache_manager.go
+++ b/internal/cache/cache_manager.go
@@ -147,13 +147,13 @@ func (c *cacheManagerImpl) PersistCache(
 		}
 		data, err := yaml.Marshal(newCache)
 		if err != nil {
-			c.logger.Error("Error while marshalling flags to persist", slog.Any("error", err))
+			c.logger.Error("Error while marshalling flags to persist", slog.Any("error", err.Error()))
 			return
 		}
 
 		err = os.WriteFile(c.persistentFlagConfigurationFile, data, 0600)
 		if err != nil {
-			c.logger.Error("Error while writing flags to file", slog.Any("error", err))
+			c.logger.Error("Error while writing flags to file", slog.Any("error", err.Error()))
 			return
 		}
 		c.logger.Info(

--- a/internal/cache/in_memory_cache.go
+++ b/internal/cache/in_memory_cache.go
@@ -26,7 +26,7 @@ func (fc *InMemoryCache) addFlag(key string, value flag.InternalFlag) {
 		fc.Flags[key] = value
 	} else {
 		fc.Logger.Error("[cache] invalid configuration for flag",
-			slog.String("key", key), slog.Any("error", err))
+			slog.String("key", key), slog.Any("error", err.Error()))
 	}
 }
 
@@ -71,7 +71,7 @@ func (fc *InMemoryCache) Init(flags map[string]dto.DTO) {
 			cache[key] = flagToAdd
 		} else {
 			fc.Logger.Error("[cache] invalid configuration for flag",
-				slog.String("key", key), slog.Any("error", err))
+				slog.String("key", key), slog.Any("error", err.Error()))
 		}
 	}
 	fc.Flags = cache

--- a/internal/flag/rule.go
+++ b/internal/flag/rule.go
@@ -90,13 +90,13 @@ func evaluateRule(query string, queryFormat QueryFormat, ctx ffcontext.Context) 
 		strCtx, err := json.Marshal(mapCtx)
 		if err != nil {
 			slog.ErrorContext(context.Background(), "error while marhsalling the context for the jsonlogic query",
-				slog.Any("mapCtx", mapCtx), slog.Any("error", err))
+				slog.Any("mapCtx", mapCtx), slog.Any("error", err.Error()))
 			return false
 		}
 		result, err := jsonlogic.Apply(query, string(strCtx))
 		if err != nil {
 			slog.ErrorContext(context.Background(), "error while evaluating the jsonlogic query",
-				slog.String("query", query), slog.Any("error", err))
+				slog.String("query", query), slog.Any("error", err.Error()))
 			return false
 		}
 		switch v := result.(type) {

--- a/internal/notification/notification_service.go
+++ b/internal/notification/notification_service.go
@@ -40,7 +40,7 @@ func (c *notificationService) Notify(
 				defer c.waitGroup.Done()
 				err := notif.Notify(diff)
 				if err != nil {
-					log.Error("error while calling the notifier", slog.Any("err", err))
+					log.Error("error while calling the notifier", slog.Any("error", err.Error()))
 				}
 			}()
 		}

--- a/retriever/manager.go
+++ b/retriever/manager.go
@@ -76,7 +76,7 @@ func (m *Manager) StartPolling() {
 			if err != nil {
 				m.logger.Error(
 					"Error while updating the cache.",
-					slog.Any("error", err),
+					slog.Any("error", err.Error()),
 				)
 			}
 		case <-m.bgUpdater.updaterChan:
@@ -178,7 +178,7 @@ func (m *Manager) handleFirstRetrieverError(err error) error {
 	default:
 		// We accept to start with a retriever error, we will serve only default value
 		m.logger.Error("Impossible to retrieve the flags, starting with the "+
-			"retriever error", slog.Any("error", err))
+			"retriever error", slog.Any("error", err.Error()))
 	}
 	return nil
 }
@@ -233,7 +233,7 @@ func (m *Manager) ForceRefresh() bool {
 	if err != nil {
 		m.logger.Error(
 			"Error while force updating the cache.",
-			slog.Any("error", err),
+			slog.Any("error", err.Error()),
 		)
 		return false
 	}


### PR DESCRIPTION
## Description
This PR corrects how we log error inside the go module, to avoid having an object in the error field when using slog.

## Closes issue(s)
Resolve #3849

## Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
