### PR TITLE
(change) Configure GoReleaser to sign the releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,10 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
+      
+      - name: Import GPG key
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
@@ -140,6 +144,11 @@ jobs:
           args: release --clean --timeout 60m
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+
+
 
   is-not-beta-release:
     name: check if release is a beta release

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -775,3 +775,16 @@ scoops:
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
+  
+signs:
+  - artifacts: checksum
+    cmd: gpg
+    args: [
+      "--batch",
+      "--yes",
+      "--pinentry-mode", "loopback",
+      "--passphrase", "{{ .Env.GPG_PASSPHRASE }}",
+      "--local-user", "{{ .Env.GPG_KEY_ID }}",
+      "--output", "${signature}",
+      "--detach-sign", "${artifact}"
+    ]


### PR DESCRIPTION
## Description
This PR configures GoReleaser to sign release artifacts (checksums) using GPG.
- Problem: Releases were not signed, which reduces trust for end users.
- Resolution: 
  - Added `signs` section to `.goreleaser.yaml` to sign checksums with GPG.
  - Updated `.github/workflows/release.yml` to import GPG key from GitHub Secrets and set required env variables (`GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`, `GPG_KEY_ID`).
- How to test:
  - Locally with `goreleaser release --snapshot --clean --skip=publish` using a test GPG key.
  - Verify signature with `gpg --verify dist/checksums.txt.sig dist/checksums.txt`.
- No breaking changes.

## Closes issue(s)
Resolve #3879

## Checklist
- [x] I have tested this code locally
- [ ] I have added unit test to cover this code (not needed for CI/config changes)
- [ ] I have updated the documentation (`README.md` and `/website/docs`) if necessary
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
