### PR TITLE
chore: Bump go to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thomaspoignant/go-feature-flag
 
-go 1.24.4
+go 1.24.6
 
 require (
 	cloud.google.com/go/pubsub v1.49.0


### PR DESCRIPTION
## Description
Bump GO version in order to address the CVE on stdlib.

<img width="1119" height="131" alt="Screenshot 2025-09-19 at 21 08 01" src="https://github.com/user-attachments/assets/97d77157-6af7-48a8-b86d-f0b10820c142" />

## Checklist
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
