### PR TITLE
fix: Admin key only should not enable authentication

### DIFF
--- a/cmd/relayproxy/api/server_test.go
+++ b/cmd/relayproxy/api/server_test.go
@@ -305,7 +305,6 @@ func Test_VersionHeader_Disabled(t *testing.T) {
 
 func Test_AuthenticationMiddleware(t *testing.T) {
 	t.Run("Non Admin Endpoint", func(t *testing.T) {
-
 		tests := []struct {
 			name          string
 			configAPIKeys *config.APIKeys
@@ -447,6 +446,7 @@ func Test_AuthenticationMiddleware(t *testing.T) {
 				time.Sleep(10 * time.Millisecond)
 
 				request, err := http.NewRequest("POST", "http://localhost:11024/admin/v1/retriever/refresh", nil)
+				assert.NoError(t, err)
 				request.Header.Add("Content-Type", "application/json")
 				if tt.configAPIKeys != nil && len(tt.configAPIKeys.Admin) > 0 {
 					request.Header.Add("Authorization", "Bearer "+tt.configAPIKeys.Admin[0])

--- a/cmd/relayproxy/config/api_keys.go
+++ b/cmd/relayproxy/config/api_keys.go
@@ -73,6 +73,5 @@ func (c *Config) preloadAPIKeys() {
 		addAPIKeys(c.AuthorizedKeys.Admin, AdminKeyType)
 
 		c.apiKeysSet = apiKeySet
-
 	})
 }


### PR DESCRIPTION
## Description
This PR put back the old way to manage keys inside GO Feature Flag.
When you have set only admin keys we don't force authentication on all the endpoints.

## Closes issue(s)
Resolve #3955

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
