### PR TITLE
chore: Bump Docusaurus to 3.9.2

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,12 +8,12 @@
       "name": "go-feature-flag-website",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "^3.9.1",
-        "@docusaurus/plugin-client-redirects": "^3.9.1",
-        "@docusaurus/plugin-google-gtag": "^3.9.1",
-        "@docusaurus/plugin-google-tag-manager": "^3.9.1",
-        "@docusaurus/preset-classic": "^3.9.1",
-        "@docusaurus/theme-mermaid": "^3.9.1",
+        "@docusaurus/core": "^3.9.2",
+        "@docusaurus/plugin-client-redirects": "^3.9.2",
+        "@docusaurus/plugin-google-gtag": "^3.9.2",
+        "@docusaurus/plugin-google-tag-manager": "^3.9.2",
+        "@docusaurus/preset-classic": "^3.9.2",
+        "@docusaurus/theme-mermaid": "^3.9.2",
         "@easyops-cn/docusaurus-search-local": "^0.52.1",
         "@hookform/error-message": "^2.0.1",
         "@iarna/toml": "^2.2.5",
@@ -49,9 +49,9 @@
         "yaml": "^2.8.1"
       },
       "devDependencies": {
-        "@docusaurus/eslint-plugin": "^3.9.1",
-        "@docusaurus/module-type-aliases": "^3.9.1",
-        "@docusaurus/types": "^3.9.1",
+        "@docusaurus/eslint-plugin": "^3.9.2",
+        "@docusaurus/module-type-aliases": "^3.9.2",
+        "@docusaurus/types": "^3.9.2",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-mdx": "^2.0.5",
         "eslint-plugin-prettier": "^4.2.1",
@@ -64,13 +64,14 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "1.0.30",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-1.0.30.tgz",
-      "integrity": "sha512-QdrSUryr/CLcsCISokLHOImcHj1adGXk1yy4B3qipqLhcNc33Kj/O/3crI790Qp85oDx7sc4vm7R4raf9RA/kg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.0.tgz",
+      "integrity": "sha512-Gj0PuawK7NkZuyYgO/h5kDK/l6hFOjhLdTq3/Lli1FTl47iGmwhH1IZQpAL3Z09BeFYWakcwUmn02ovIm2wy9g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.10"
+        "@ai-sdk/provider-utils": "3.0.12",
+        "@vercel/oidc": "3.0.3"
       },
       "engines": {
         "node": ">=18"
@@ -92,9 +93,9 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.10.tgz",
-      "integrity": "sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.12.tgz",
+      "integrity": "sha512-ZtbdvYxdMoria+2SlNarEk6Hlgyf+zzcznlD55EAl+7VZvJaSg2sqPvwArY7L6TfDEDJsnCq0fdhBSkYo0Xqdg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
@@ -109,13 +110,13 @@
       }
     },
     "node_modules/@ai-sdk/react": {
-      "version": "2.0.56",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.56.tgz",
-      "integrity": "sha512-7glIc65IZYFx+GZIcvMFdp+lkJnpsgRJNGRhStF6naUXtCrhjC5SyyXFMwZk+GMk3ZK9Kb83zdnWqtO7LOXGuA==",
+      "version": "2.0.76",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.76.tgz",
+      "integrity": "sha512-ggAPzyaKJTqUWigpxMzI5DuC0Y3iEpDUPCgz6/6CpnKZY/iok+x5xiZhDemeaP0ILw5IQekV0kdgBR8JPgI8zQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider-utils": "3.0.10",
-        "ai": "5.0.56",
+        "@ai-sdk/provider-utils": "3.0.12",
+        "ai": "5.0.76",
         "swr": "^2.2.5",
         "throttleit": "2.1.0"
       },
@@ -133,15 +134,15 @@
       }
     },
     "node_modules/@algolia/abtesting": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.5.0.tgz",
-      "integrity": "sha512-W/ohRkbKQsqDWALJg28X15KF7Tcyg53L1MfdOkLgvkcCcofdzGHSimHHeNG05ojjFw9HK8+VPhe/Vwq4MozIJg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.6.1.tgz",
+      "integrity": "sha512-wV/gNRkzb7sI9vs1OneG129hwe3Q5zPj7zigz3Ps7M5Lpo2hSorrOnXNodHEOV+yXE/ks4Pd+G3CDFIjFTWhMQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.39.0",
-        "@algolia/requester-browser-xhr": "5.39.0",
-        "@algolia/requester-fetch": "5.39.0",
-        "@algolia/requester-node-http": "5.39.0"
+        "@algolia/client-common": "5.40.1",
+        "@algolia/requester-browser-xhr": "5.40.1",
+        "@algolia/requester-fetch": "5.40.1",
+        "@algolia/requester-node-http": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -180,99 +181,99 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.39.0.tgz",
-      "integrity": "sha512-Vf0ZVe+qo3sHDrCinouJqlg8VoxM4Qo/KxNIqMYybkuctutfnp3kIY9OmESplOQ/9NGBthU9EG+4d5fBibWK/A==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.40.1.tgz",
+      "integrity": "sha512-cxKNATPY5t+Mv8XAVTI57altkaPH+DZi4uMrnexPxPHODMljhGYY+GDZyHwv9a+8CbZHcY372OkxXrDMZA4Lnw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.39.0",
-        "@algolia/requester-browser-xhr": "5.39.0",
-        "@algolia/requester-fetch": "5.39.0",
-        "@algolia/requester-node-http": "5.39.0"
+        "@algolia/client-common": "5.40.1",
+        "@algolia/requester-browser-xhr": "5.40.1",
+        "@algolia/requester-fetch": "5.40.1",
+        "@algolia/requester-node-http": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.39.0.tgz",
-      "integrity": "sha512-V16ITZxYIwcv1arNce65JZmn94Ft6vKlBZ//gXw8AvIH32glJz1KcbaVAUr9p7PYlGZ/XVHP6LxDgrpNdtwgcA==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.40.1.tgz",
+      "integrity": "sha512-XP008aMffJCRGAY8/70t+hyEyvqqV7YKm502VPu0+Ji30oefrTn2al7LXkITz7CK6I4eYXWRhN6NaIUi65F1OA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.39.0",
-        "@algolia/requester-browser-xhr": "5.39.0",
-        "@algolia/requester-fetch": "5.39.0",
-        "@algolia/requester-node-http": "5.39.0"
+        "@algolia/client-common": "5.40.1",
+        "@algolia/requester-browser-xhr": "5.40.1",
+        "@algolia/requester-fetch": "5.40.1",
+        "@algolia/requester-node-http": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.39.0.tgz",
-      "integrity": "sha512-UCJTuwySEQeiKPWV3wruhuI/wHbDYenHzgL9pYsvh6r/u5Z+g61ip1iwdAlFp02CnywzI9O7+AQPh2ManYyHmQ==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.40.1.tgz",
+      "integrity": "sha512-gWfQuQUBtzUboJv/apVGZMoxSaB0M4Imwl1c9Ap+HpCW7V0KhjBddqF2QQt5tJZCOFsfNIgBbZDGsEPaeKUosw==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.39.0.tgz",
-      "integrity": "sha512-s0ia8M/ZZR+iO2uLNTBrlQdEb6ZMAMcKMHckp5mcoglxrf8gHifL4LmdhGKdAxAn3UIagtqIP0RCnIymHUbm7A==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.40.1.tgz",
+      "integrity": "sha512-RTLjST/t+lsLMouQ4zeLJq2Ss+UNkLGyNVu+yWHanx6kQ3LT5jv8UvPwyht9s7R6jCPnlSI77WnL80J32ZuyJg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.39.0",
-        "@algolia/requester-browser-xhr": "5.39.0",
-        "@algolia/requester-fetch": "5.39.0",
-        "@algolia/requester-node-http": "5.39.0"
+        "@algolia/client-common": "5.40.1",
+        "@algolia/requester-browser-xhr": "5.40.1",
+        "@algolia/requester-fetch": "5.40.1",
+        "@algolia/requester-node-http": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.39.0.tgz",
-      "integrity": "sha512-vZPIt7Lw+toNsHZUiPhNIc1Z3vUjDp7nzn6AMOaPC73gEuTq2iLPNvM06CSB6aHePo5eMeJIP5YEKBUQUA/PJA==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.40.1.tgz",
+      "integrity": "sha512-2FEK6bUomBzEYkTKzD0iRs7Ljtjb45rKK/VSkyHqeJnG+77qx557IeSO0qVFE3SfzapNcoytTofnZum0BQ6r3Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.39.0",
-        "@algolia/requester-browser-xhr": "5.39.0",
-        "@algolia/requester-fetch": "5.39.0",
-        "@algolia/requester-node-http": "5.39.0"
+        "@algolia/client-common": "5.40.1",
+        "@algolia/requester-browser-xhr": "5.40.1",
+        "@algolia/requester-fetch": "5.40.1",
+        "@algolia/requester-node-http": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.39.0.tgz",
-      "integrity": "sha512-jcPQr3iKTWNVli2NYHPv02aNLwixDjPCpOgMp9CZTvEiPI6Ec4jHX+oFr3LDZagOFY9e1xJhc/JrgMGGW1sHnw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.40.1.tgz",
+      "integrity": "sha512-Nju4NtxAvXjrV2hHZNLKVJLXjOlW6jAXHef/CwNzk1b2qIrCWDO589ELi5ZHH1uiWYoYyBXDQTtHmhaOVVoyXg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.39.0",
-        "@algolia/requester-browser-xhr": "5.39.0",
-        "@algolia/requester-fetch": "5.39.0",
-        "@algolia/requester-node-http": "5.39.0"
+        "@algolia/client-common": "5.40.1",
+        "@algolia/requester-browser-xhr": "5.40.1",
+        "@algolia/requester-fetch": "5.40.1",
+        "@algolia/requester-node-http": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.39.0.tgz",
-      "integrity": "sha512-/IYpF10BpthGZEJQZMhMqV4AqWr5avcWfZm/SIKK1RvUDmzGqLoW/+xeJVX9C8ZnNkIC8hivbIQFaNaRw0BFZQ==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.40.1.tgz",
+      "integrity": "sha512-Mw6pAUF121MfngQtcUb5quZVqMC68pSYYjCRZkSITC085S3zdk+h/g7i6FxnVdbSU6OztxikSDMh1r7Z+4iPlA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.39.0",
-        "@algolia/requester-browser-xhr": "5.39.0",
-        "@algolia/requester-fetch": "5.39.0",
-        "@algolia/requester-node-http": "5.39.0"
+        "@algolia/client-common": "5.40.1",
+        "@algolia/requester-browser-xhr": "5.40.1",
+        "@algolia/requester-fetch": "5.40.1",
+        "@algolia/requester-node-http": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -285,81 +286,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.39.0.tgz",
-      "integrity": "sha512-IgSHKUiuecqLfBlXiuCSdRTdsO3/yvpmXrMFz8fAJ8M4QmDtHkOuD769dmybRYqsbYMHivw+lir4BgbRGMtOIQ==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.40.1.tgz",
+      "integrity": "sha512-z+BPlhs45VURKJIxsR99NNBWpUEEqIgwt10v/fATlNxc4UlXvALdOsWzaFfe89/lbP5Bu4+mbO59nqBC87ZM/g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.39.0",
-        "@algolia/requester-browser-xhr": "5.39.0",
-        "@algolia/requester-fetch": "5.39.0",
-        "@algolia/requester-node-http": "5.39.0"
+        "@algolia/client-common": "5.40.1",
+        "@algolia/requester-browser-xhr": "5.40.1",
+        "@algolia/requester-fetch": "5.40.1",
+        "@algolia/requester-node-http": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.39.0.tgz",
-      "integrity": "sha512-8Xnd4+609SKC/hqVsuFc4evFBmvA2765/4NcH+Dpr756SKPbL1BY0X8kVxlmM3YBLNqnduSQxHxpDJUK58imCA==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.40.1.tgz",
+      "integrity": "sha512-VJMUMbO0wD8Rd2VVV/nlFtLJsOAQvjnVNGkMkspFiFhpBA7s/xJOb+fJvvqwKFUjbKTUA7DjiSi1ljSMYBasXg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.39.0",
-        "@algolia/requester-browser-xhr": "5.39.0",
-        "@algolia/requester-fetch": "5.39.0",
-        "@algolia/requester-node-http": "5.39.0"
+        "@algolia/client-common": "5.40.1",
+        "@algolia/requester-browser-xhr": "5.40.1",
+        "@algolia/requester-fetch": "5.40.1",
+        "@algolia/requester-node-http": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.39.0.tgz",
-      "integrity": "sha512-D7Ye2Ss/5xqUkQUxKm/VqEJLt5kARd9IMmjdzlxaKhGgNlOemTay0lwBmOVFuJRp7UODjp5c9+K+B8g0ORObIw==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.40.1.tgz",
+      "integrity": "sha512-ehvJLadKVwTp9Scg9NfzVSlBKH34KoWOQNTaN8i1Ac64AnO6iH2apJVSP6GOxssaghZ/s8mFQsDH3QIZoluFHA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.39.0",
-        "@algolia/requester-browser-xhr": "5.39.0",
-        "@algolia/requester-fetch": "5.39.0",
-        "@algolia/requester-node-http": "5.39.0"
+        "@algolia/client-common": "5.40.1",
+        "@algolia/requester-browser-xhr": "5.40.1",
+        "@algolia/requester-fetch": "5.40.1",
+        "@algolia/requester-node-http": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.39.0.tgz",
-      "integrity": "sha512-mgPte1ZJqpk9dkVs44J3wKAbHATvHZNlSpzhMdjMLIg/3qTycSZyDiomLiSlxE8CLsxyBAOJWnyKRHfom+Z1rg==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.40.1.tgz",
+      "integrity": "sha512-PbidVsPurUSQIr6X9/7s34mgOMdJnn0i6p+N6Ab+lsNhY5eiu+S33kZEpZwkITYBCIbhzDLOvb7xZD3gDi+USA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.39.0"
+        "@algolia/client-common": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.39.0.tgz",
-      "integrity": "sha512-LIrCkrxu1WnO3ev1+w6NnZ12JZL/o+2H9w6oWnZAjQZIlA/Ym6M9QHkt+OQ/SwkuoiNkW3DAo+Pi4A2V9FPtqg==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.40.1.tgz",
+      "integrity": "sha512-ThZ5j6uOZCF11fMw9IBkhigjOYdXGXQpj6h4k+T9UkZrF2RlKcPynFzDeRgaLdpYk8Yn3/MnFbwUmib7yxj5Lw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.39.0"
+        "@algolia/client-common": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.39.0.tgz",
-      "integrity": "sha512-6beG+egPwXmvhAg+m0STCj+ZssDcjrLzf4L05aKm2nGglMXSSPz0cH/rM+kVD9krNfldiMctURd4wjojW1fV0w==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.40.1.tgz",
+      "integrity": "sha512-H1gYPojO6krWHnUXu/T44DrEun/Wl95PJzMXRcM/szstNQczSbwq6wIFJPI9nyE95tarZfUNU3rgorT+wZ6iCQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.39.0"
+        "@algolia/client-common": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -3381,20 +3382,20 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.1.0.tgz",
-      "integrity": "sha512-nuNKGjHj/FQeWgE9t+i83QD/V67QiaAmGY7xS9TVCRUiCqSljOgIKlsLoQZKKVwEG8f+OWKdznzZkJxGZ7d06A==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.2.0.tgz",
+      "integrity": "sha512-65KU9Fw5fGsPPPlgIghonMcndyx1bszzrDQYLfierN+Ha29yotMHzVS94bPkZS6On9LS8dE4qmW4P/fGjtCf/g==",
       "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.1.0.tgz",
-      "integrity": "sha512-4GHI7TT3sJZ2Vs4Kjadv7vAkMrTsJqHvzvxO3JA7UT8iPRKaDottG5o5uNshPWhVVaBYPC35Ukf8bfCotGpjSg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.2.0.tgz",
+      "integrity": "sha512-zSN/KblmtBcerf7Z87yuKIHZQmxuXvYc6/m0+qnjyNu+Ir67AVOagTa1zBqcxkVUVkmBqUExdcyrdo9hbGbqTw==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/react": "^2.0.30",
         "@algolia/autocomplete-core": "1.19.2",
-        "@docsearch/css": "4.1.0",
+        "@docsearch/css": "4.2.0",
         "ai": "^5.0.30",
         "algoliasearch": "^5.28.0",
         "marked": "^16.3.0",
@@ -3422,9 +3423,9 @@
       }
     },
     "node_modules/@docusaurus/babel": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.9.1.tgz",
-      "integrity": "sha512-/uoi3oG+wvbVWNBRfPrzrEslOSeLxrQEyWMywK51TLDFTANqIRivzkMusudh5bdDty8fXzCYUT+tg5t697jYqg==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.9.2.tgz",
+      "integrity": "sha512-GEANdi/SgER+L7Japs25YiGil/AUDnFFHaCGPBbundxoWtCkA2lmy7/tFmgED4y1htAy6Oi4wkJEQdGssnw9MA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
@@ -3437,8 +3438,8 @@
         "@babel/runtime": "^7.25.9",
         "@babel/runtime-corejs3": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -3448,17 +3449,17 @@
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.9.1.tgz",
-      "integrity": "sha512-E1c9DgNmAz4NqbNtiJVp4UgjLtr8O01IgtXD/NDQ4PZaK8895cMiTOgb3k7mN0qX8A3lb8vqyrPJ842+yMpuUg==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.9.2.tgz",
+      "integrity": "sha512-ZOVi6GYgTcsZcUzjblpzk3wH1Fya2VNpd5jtHoCCFcJlMQ1EYXZetfAnRHLcyiFeBABaI1ltTYbOBtH/gahGVA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.9.1",
-        "@docusaurus/cssnano-preset": "3.9.1",
-        "@docusaurus/logger": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
+        "@docusaurus/babel": "3.9.2",
+        "@docusaurus/cssnano-preset": "3.9.2",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
         "babel-loader": "^9.2.1",
         "clean-css": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
@@ -3491,18 +3492,18 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.1.tgz",
-      "integrity": "sha512-FWDk1LIGD5UR5Zmm9rCrXRoxZUgbwuP6FBA7rc50DVfzqDOMkeMe3NyJhOsA2dF0zBE3VbHEIMmTjKwTZJwbaA==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
+      "integrity": "sha512-HbjwKeC+pHUFBfLMNzuSjqFE/58+rLVKmOU3lxQrpsxLBOGosYco/Q0GduBb0/jEMRiyEqjNT/01rRdOMWq5pw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.9.1",
-        "@docusaurus/bundler": "3.9.1",
-        "@docusaurus/logger": "3.9.1",
-        "@docusaurus/mdx-loader": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
-        "@docusaurus/utils-common": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/babel": "3.9.2",
+        "@docusaurus/bundler": "3.9.2",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/mdx-loader": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -3552,9 +3553,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.1.tgz",
-      "integrity": "sha512-2y7+s7RWQMqBg+9ejeKwvZs7Bdw/hHIVJIodwMXbs2kr+S48AhcmAfdOh6Cwm0unJb0hJUshN0ROwRoQMwl3xg==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.2.tgz",
+      "integrity": "sha512-8gBKup94aGttRduABsj7bpPFTX7kbwu+xh3K9NMCF5K4bWBqTFYW+REKHF6iBVDHRJ4grZdIPbvkiHd/XNKRMQ==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -3567,9 +3568,9 @@
       }
     },
     "node_modules/@docusaurus/eslint-plugin": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/eslint-plugin/-/eslint-plugin-3.9.1.tgz",
-      "integrity": "sha512-GHOjHgX/x04IO/fw4s0Ea3Y/0hagpiO60uBByPg/A1HxnOdJmczxtA7ykexvyNwHs0UDNtrfok1gc89b4Y61CA==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/eslint-plugin/-/eslint-plugin-3.9.2.tgz",
+      "integrity": "sha512-LnCrmrR4EtzpSiq6aoSfiY0Lf8P0WslGbBFZJ0olKXJIMxey8dpKevT1K/+tN87Lbn2H/VrdGGSPGlfVKmihAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3584,9 +3585,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.9.1.tgz",
-      "integrity": "sha512-C9iFzXwHzwvGlisE4bZx+XQE0JIqlGAYAd5LzpR7fEDgjctu7yL8bE5U4nTNywXKHURDzMt4RJK8V6+stFHVkA==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.9.2.tgz",
+      "integrity": "sha512-/SVCc57ByARzGSU60c50rMyQlBuMIJCjcsJlkphxY6B0GV4UH3tcA1994N8fFfbJ9kX3jIBe/xg3XP5qBtGDbA==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -3597,14 +3598,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.1.tgz",
-      "integrity": "sha512-/1PY8lqry8jCt0qZddJSpc0U2sH6XC27kVJZfpA7o2TiQ3mdBQyH5AVbj/B2m682B1ounE+XjI0LdpOkAQLPoA==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.2.tgz",
+      "integrity": "sha512-wiYoGwF9gdd6rev62xDU8AAM8JuLI/hlwOtCzMmYcspEkzecKrP8J8X+KpYnTlACBUUtXNJpSoCwFWJhLRevzQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -3636,12 +3637,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.1.tgz",
-      "integrity": "sha512-YBce3GbJGGcMbJTyHcnEOMvdXqg41pa5HsrMCGA5Rm4z0h0tHS6YtEldj0mlfQRhCG7Y0VD66t2tb87Aom+11g==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
+      "integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.9.1",
+        "@docusaurus/types": "3.9.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3655,16 +3656,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-client-redirects": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.9.1.tgz",
-      "integrity": "sha512-+1InCGvAnw46H+TnVqxaYlJC0qy9AY5gTMgTx2ZFryjAsImJNs3i1pEYW/iUTVbOdtWRj3E/87E4ehbBIaA1TA==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.9.2.tgz",
+      "integrity": "sha512-lUgMArI9vyOYMzLRBUILcg9vcPTCyyI2aiuXq/4npcMVqOr6GfmwtmBYWSbNMlIUM0147smm4WhpXD0KFboffw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/logger": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
-        "@docusaurus/utils-common": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -3679,19 +3680,19 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.9.1.tgz",
-      "integrity": "sha512-vT6kIimpJLWvW9iuWzH4u7VpTdsGlmn4yfyhq0/Kb1h4kf9uVouGsTmrD7WgtYBUG1P+TSmQzUUQa+ALBSRTig==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.9.2.tgz",
+      "integrity": "sha512-3I2HXy3L1QcjLJLGAoTvoBnpOwa6DPUa3Q0dMK19UTY9mhPkKQg/DYhAGTiBUKcTR0f08iw7kLPqOhIgdV3eVQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/logger": "3.9.1",
-        "@docusaurus/mdx-loader": "3.9.1",
-        "@docusaurus/theme-common": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
-        "@docusaurus/utils-common": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/mdx-loader": "3.9.2",
+        "@docusaurus/theme-common": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -3713,20 +3714,20 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.1.tgz",
-      "integrity": "sha512-DyLk9BIA6I9gPIuia8XIL+XIEbNnExam6AHzRsfrEq4zJr7k/DsWW7oi4aJMepDnL7jMRhpVcdsCxdjb0/A9xg==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
+      "integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/logger": "3.9.1",
-        "@docusaurus/mdx-loader": "3.9.1",
-        "@docusaurus/module-type-aliases": "3.9.1",
-        "@docusaurus/theme-common": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
-        "@docusaurus/utils-common": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/mdx-loader": "3.9.2",
+        "@docusaurus/module-type-aliases": "3.9.2",
+        "@docusaurus/theme-common": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -3746,16 +3747,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.9.1.tgz",
-      "integrity": "sha512-/1wFzRnXYASI+Nv9ck9IVPIMw0O5BGQ8ZVhDzEwhkL+tl44ycvSnY6PIe6rW2HLxsw61Z3WFwAiU8+xMMtMZpg==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.9.2.tgz",
+      "integrity": "sha512-s4849w/p4noXUrGpPUF0BPqIAfdAe76BLaRGAGKZ1gTDNiGxGcpsLcwJ9OTi1/V8A+AzvsmI9pkjie2zjIQZKA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/mdx-loader": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/mdx-loader": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -3769,15 +3770,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-css-cascade-layers": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.9.1.tgz",
-      "integrity": "sha512-/QyW2gRCk/XE3ttCK/ERIgle8KJ024dBNKMu6U5SmpJvuT2il1n5jR/48Pp/9wEwut8WVml4imNm6X8JsL5A0Q==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.9.2.tgz",
+      "integrity": "sha512-w1s3+Ss+eOQbscGM4cfIFBlVg/QKxyYgj26k5AnakuHkKxH6004ZtuLe5awMBotIYF2bbGDoDhpgQ4r/kcj4rQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3785,14 +3786,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.9.1.tgz",
-      "integrity": "sha512-qPeAuk0LccC251d7jg2MRhNI+o7niyqa924oEM/AxnZJvIpMa596aAxkRImiAqNN6+gtLE1Hkrz/RHUH2HDGsA==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.9.2.tgz",
+      "integrity": "sha512-j7a5hWuAFxyQAkilZwhsQ/b3T7FfHZ+0dub6j/GxKNFJp2h9qk/P1Bp7vrGASnvA9KNQBBL1ZXTe7jlh4VdPdA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^2.3.0",
         "tslib": "^2.6.0"
@@ -3806,14 +3807,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.9.1.tgz",
-      "integrity": "sha512-k4Qq2HphqOrIU/CevGPdEO1yJnWUI8m0zOJsYt5NfMJwNsIn/gDD6gv/DKD+hxHndQT5pacsfBd4BWHZVNVroQ==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.9.2.tgz",
+      "integrity": "sha512-mAwwQJ1Us9jL/lVjXtErXto4p4/iaLlweC54yDUK1a97WfkC6Z2k5/769JsFgwOwOP+n5mUQGACXOEQ0XDuVUw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3825,14 +3826,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.9.1.tgz",
-      "integrity": "sha512-n9BURBiQyJKI/Ecz35IUjXYwXcgNCSq7/eA07+ZYcDiSyH2p/EjPf8q/QcZG3CyEJPZ/SzGkDHePfcVPahY4Gg==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.9.2.tgz",
+      "integrity": "sha512-YJ4lDCphabBtw19ooSlc1MnxtYGpjFV9rEdzjLsUnBCeis2djUyCozZaFhCg6NGEwOn7HDDyMh0yzcdRpnuIvA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -3845,14 +3846,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.9.1.tgz",
-      "integrity": "sha512-rZAQZ25ZuXaThBajxzLjXieTDUCMmBzfAA6ThElQ3o7Q+LEpOjCIrwGFau0KLY9HeG6x91+FwwsAM8zeApYDrg==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.9.2.tgz",
+      "integrity": "sha512-LJtIrkZN/tuHD8NqDAW1Tnw0ekOwRTfobWPsdO15YxcicBo2ykKF0/D6n0vVBfd3srwr9Z6rzrIWYrMzBGrvNw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3864,17 +3865,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.9.1.tgz",
-      "integrity": "sha512-k/bf5cXDxAJUYTzqatgFJwmZsLUbIgl6S8AdZMKGG2Mv2wcOHt+EQNN9qPyWZ5/9cFj+Q8f8DN+KQheBMYLong==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.9.2.tgz",
+      "integrity": "sha512-WLh7ymgDXjG8oPoM/T4/zUP7KcSuFYRZAUTl8vR6VzYkfc18GBM4xLhcT+AKOwun6kBivYKUJf+vlqYJkm+RHw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/logger": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
-        "@docusaurus/utils-common": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -3888,15 +3889,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-svgr": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.9.1.tgz",
-      "integrity": "sha512-TeZOXT2PSdTNR1OpDJMkYqFyX7MMhbd4t16hQByXksgZQCXNyw3Dio+KaDJ2Nj+LA4WkOvsk45bWgYG5MAaXSQ==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.9.2.tgz",
+      "integrity": "sha512-n+1DE+5b3Lnf27TgVU5jM1d4x5tUh2oW5LTsBxJX4PsAPV0JGcmI6p3yLYtEY0LRVEIJh+8RsdQmRE66wSV8mw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "@svgr/core": "8.1.0",
         "@svgr/webpack": "^8.1.0",
         "tslib": "^2.6.0",
@@ -3911,26 +3912,26 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.9.1.tgz",
-      "integrity": "sha512-ZHga2xsxxsyd0dN1BpLj8S889Eu9eMBuj2suqxdw/vaaXu/FjJ8KEGbcaeo6nHPo8VQcBBnPEdkBtSDm2TfMNw==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.9.2.tgz",
+      "integrity": "sha512-IgyYO2Gvaigi21LuDIe+nvmN/dfGXAiMcV/murFqcpjnZc7jxFAxW+9LEjdPt61uZLxG4ByW/oUmX/DDK9t/8w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/plugin-content-blog": "3.9.1",
-        "@docusaurus/plugin-content-docs": "3.9.1",
-        "@docusaurus/plugin-content-pages": "3.9.1",
-        "@docusaurus/plugin-css-cascade-layers": "3.9.1",
-        "@docusaurus/plugin-debug": "3.9.1",
-        "@docusaurus/plugin-google-analytics": "3.9.1",
-        "@docusaurus/plugin-google-gtag": "3.9.1",
-        "@docusaurus/plugin-google-tag-manager": "3.9.1",
-        "@docusaurus/plugin-sitemap": "3.9.1",
-        "@docusaurus/plugin-svgr": "3.9.1",
-        "@docusaurus/theme-classic": "3.9.1",
-        "@docusaurus/theme-common": "3.9.1",
-        "@docusaurus/theme-search-algolia": "3.9.1",
-        "@docusaurus/types": "3.9.1"
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/plugin-content-blog": "3.9.2",
+        "@docusaurus/plugin-content-docs": "3.9.2",
+        "@docusaurus/plugin-content-pages": "3.9.2",
+        "@docusaurus/plugin-css-cascade-layers": "3.9.2",
+        "@docusaurus/plugin-debug": "3.9.2",
+        "@docusaurus/plugin-google-analytics": "3.9.2",
+        "@docusaurus/plugin-google-gtag": "3.9.2",
+        "@docusaurus/plugin-google-tag-manager": "3.9.2",
+        "@docusaurus/plugin-sitemap": "3.9.2",
+        "@docusaurus/plugin-svgr": "3.9.2",
+        "@docusaurus/theme-classic": "3.9.2",
+        "@docusaurus/theme-common": "3.9.2",
+        "@docusaurus/theme-search-algolia": "3.9.2",
+        "@docusaurus/types": "3.9.2"
       },
       "engines": {
         "node": ">=20.0"
@@ -3941,24 +3942,24 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.9.1.tgz",
-      "integrity": "sha512-LrAIu/mQ04nG6s1cssC0TMmICD8twFIIn/hJ5Pd9uIPQvtKnyAKEn12RefopAul5KfMo9kixPaqogV5jIJr26w==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.9.2.tgz",
+      "integrity": "sha512-IGUsArG5hhekXd7RDb11v94ycpJpFdJPkLnt10fFQWOVxAtq5/D7hT6lzc2fhyQKaaCE62qVajOMKL7OiAFAIA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/logger": "3.9.1",
-        "@docusaurus/mdx-loader": "3.9.1",
-        "@docusaurus/module-type-aliases": "3.9.1",
-        "@docusaurus/plugin-content-blog": "3.9.1",
-        "@docusaurus/plugin-content-docs": "3.9.1",
-        "@docusaurus/plugin-content-pages": "3.9.1",
-        "@docusaurus/theme-common": "3.9.1",
-        "@docusaurus/theme-translations": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
-        "@docusaurus/utils-common": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/mdx-loader": "3.9.2",
+        "@docusaurus/module-type-aliases": "3.9.2",
+        "@docusaurus/plugin-content-blog": "3.9.2",
+        "@docusaurus/plugin-content-docs": "3.9.2",
+        "@docusaurus/plugin-content-pages": "3.9.2",
+        "@docusaurus/theme-common": "3.9.2",
+        "@docusaurus/theme-translations": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-common": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "infima": "0.2.0-alpha.45",
@@ -3981,15 +3982,15 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.1.tgz",
-      "integrity": "sha512-j9adi961F+6Ps9d0jcb5BokMcbjXAAJqKkV43eo8nh4YgmDj7KUNDX4EnOh/MjTQeO06oPY5cxp3yUXdW/8Ggw==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
+      "integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.9.1",
-        "@docusaurus/module-type-aliases": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
-        "@docusaurus/utils-common": "3.9.1",
+        "@docusaurus/mdx-loader": "3.9.2",
+        "@docusaurus/module-type-aliases": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-common": "3.9.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -4009,16 +4010,16 @@
       }
     },
     "node_modules/@docusaurus/theme-mermaid": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.9.1.tgz",
-      "integrity": "sha512-aKMFlQfxueVBPdCdrNSshG12fOkJXSn1sb6EhI/sGn3UpiTEiazJm4QLP6NoF78mqq8O5Ar2Yll+iHWLvCsuZQ==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.9.2.tgz",
+      "integrity": "sha512-5vhShRDq/ntLzdInsQkTdoKWSzw8d1jB17sNPYhA/KvYYFXfuVEGHLM6nrf8MFbV8TruAHDG21Fn3W4lO8GaDw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/module-type-aliases": "3.9.1",
-        "@docusaurus/theme-common": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/module-type-aliases": "3.9.2",
+        "@docusaurus/theme-common": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "mermaid": ">=11.6.0",
         "tslib": "^2.6.0"
       },
@@ -4037,19 +4038,19 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.9.1.tgz",
-      "integrity": "sha512-WjM28bzlgfT6nHlEJemkwyGVpvGsZWPireV/w+wZ1Uo64xCZ8lNOb4xwQRukDaLSed3oPBN0gSnu06l5VuCXHg==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.9.2.tgz",
+      "integrity": "sha512-GBDSFNwjnh5/LdkxCKQHkgO2pIMX1447BxYUBG2wBiajS21uj64a+gH/qlbQjDLxmGrbrllBrtJkUHxIsiwRnw==",
       "license": "MIT",
       "dependencies": {
         "@docsearch/react": "^3.9.0 || ^4.1.0",
-        "@docusaurus/core": "3.9.1",
-        "@docusaurus/logger": "3.9.1",
-        "@docusaurus/plugin-content-docs": "3.9.1",
-        "@docusaurus/theme-common": "3.9.1",
-        "@docusaurus/theme-translations": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
-        "@docusaurus/utils-validation": "3.9.1",
+        "@docusaurus/core": "3.9.2",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/plugin-content-docs": "3.9.2",
+        "@docusaurus/theme-common": "3.9.2",
+        "@docusaurus/theme-translations": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-validation": "3.9.2",
         "algoliasearch": "^5.37.0",
         "algoliasearch-helper": "^3.26.0",
         "clsx": "^2.0.0",
@@ -4068,9 +4069,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.9.1.tgz",
-      "integrity": "sha512-mUQd49BSGKTiM6vP9+JFgRJL28lMIN3PUvXjF3rzuOHMByUZUBNwCt26Z23GkKiSIOrRkjKoaBNTipR/MHdYSQ==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.9.2.tgz",
+      "integrity": "sha512-vIryvpP18ON9T9rjgMRFLr2xJVDpw1rtagEGf8Ccce4CkTrvM/fRB8N2nyWYOW5u3DdjkwKw5fBa+3tbn9P4PA==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -4081,9 +4082,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.1.tgz",
-      "integrity": "sha512-ElekJ29sk39s5LTEZMByY1c2oH9FMtw7KbWFU3BtuQ1TytfIK39HhUivDEJvm5KCLyEnnfUZlvSNDXeyk0vzAA==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+      "integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -4126,14 +4127,14 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.1.tgz",
-      "integrity": "sha512-YAL4yhhWLl9DXuf5MVig260a6INz4MehrBGFU/CZu8yXmRiYEuQvRFWh9ZsjfAOyaG7za1MNmBVZ4VVAi/CiJA==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.2.tgz",
+      "integrity": "sha512-lBSBiRruFurFKXr5Hbsl2thmGweAPmddhF3jb99U4EMDA5L+e5Y1rAkOS07Nvrup7HUMBDrCV45meaxZnt28nQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.1",
-        "@docusaurus/types": "3.9.1",
-        "@docusaurus/utils-common": "3.9.1",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/types": "3.9.2",
+        "@docusaurus/utils-common": "3.9.2",
         "escape-string-regexp": "^4.0.0",
         "execa": "5.1.1",
         "file-loader": "^6.2.0",
@@ -4158,12 +4159,12 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.9.1.tgz",
-      "integrity": "sha512-4M1u5Q8Zn2CYL2TJ864M51FV4YlxyGyfC3x+7CLuR6xsyTVNBNU4QMcPgsTHRS9J2+X6Lq7MyH6hiWXyi/sXUQ==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.9.2.tgz",
+      "integrity": "sha512-I53UC1QctruA6SWLvbjbhCpAw7+X7PePoe5pYcwTOEXD/PxeP8LnECAhTHHwWCblyUX5bMi4QLRkxvyZ+IT8Aw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.9.1",
+        "@docusaurus/types": "3.9.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -4171,14 +4172,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.1.tgz",
-      "integrity": "sha512-5bzab5si3E1udrlZuVGR17857Lfwe8iFPoy5AvMP9PXqDfoyIKT7gDQgAmxdRDMurgHaJlyhXEHHdzDKkOxxZQ==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.2.tgz",
+      "integrity": "sha512-l7yk3X5VnNmATbwijJkexdhulNsQaNDwoagiwujXoxFbWLcxHQqNQ+c/IAlzrfMMOfa/8xSBZ7KEKDesE/2J7A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.9.1",
-        "@docusaurus/utils": "3.9.1",
-        "@docusaurus/utils-common": "3.9.1",
+        "@docusaurus/logger": "3.9.2",
+        "@docusaurus/utils": "3.9.2",
+        "@docusaurus/utils-common": "3.9.2",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -6672,6 +6673,15 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.3.tgz",
+      "integrity": "sha512-yNEQvPcVrK9sIe637+I0jD6leluPxzwJKx/Haw6F4H77CdDsszUn5V3o96LPziXkSNE2B83+Z3mjqGKBK/R6Gg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -6960,14 +6970,14 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.56",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.56.tgz",
-      "integrity": "sha512-Rl++Ogg6DxzFkVHAOJZzhqcqvqtBLGOP9mMxJOGr2EJWj5HH5zjqDcnRh6x5vBoca5kj/Gd0rvUZFMnyI+sRiw==",
+      "version": "5.0.76",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.76.tgz",
+      "integrity": "sha512-ZCxi1vrpyCUnDbtYrO/W8GLvyacV9689f00yshTIQ3mFFphbD7eIv40a2AOZBv3GGRA7SSRYIDnr56wcS/gyQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "1.0.30",
+        "@ai-sdk/gateway": "2.0.0",
         "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.10",
+        "@ai-sdk/provider-utils": "3.0.12",
         "@opentelemetry/api": "1.9.0"
       },
       "engines": {
@@ -7042,25 +7052,25 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.39.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.39.0.tgz",
-      "integrity": "sha512-DzTfhUxzg9QBNGzU/0kZkxEV72TeA4MmPJ7RVfLnQwHNhhliPo7ynglEWJS791rNlLFoTyrKvkapwr/P3EXV9A==",
+      "version": "5.40.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.40.1.tgz",
+      "integrity": "sha512-iUNxcXUNg9085TJx0HJLjqtDE0r1RZ0GOGrt8KNQqQT5ugu8lZsHuMUYW/e0lHhq6xBvmktU9Bw4CXP9VQeKrg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.5.0",
-        "@algolia/client-abtesting": "5.39.0",
-        "@algolia/client-analytics": "5.39.0",
-        "@algolia/client-common": "5.39.0",
-        "@algolia/client-insights": "5.39.0",
-        "@algolia/client-personalization": "5.39.0",
-        "@algolia/client-query-suggestions": "5.39.0",
-        "@algolia/client-search": "5.39.0",
-        "@algolia/ingestion": "1.39.0",
-        "@algolia/monitoring": "1.39.0",
-        "@algolia/recommend": "5.39.0",
-        "@algolia/requester-browser-xhr": "5.39.0",
-        "@algolia/requester-fetch": "5.39.0",
-        "@algolia/requester-node-http": "5.39.0"
+        "@algolia/abtesting": "1.6.1",
+        "@algolia/client-abtesting": "5.40.1",
+        "@algolia/client-analytics": "5.40.1",
+        "@algolia/client-common": "5.40.1",
+        "@algolia/client-insights": "5.40.1",
+        "@algolia/client-personalization": "5.40.1",
+        "@algolia/client-query-suggestions": "5.40.1",
+        "@algolia/client-search": "5.40.1",
+        "@algolia/ingestion": "1.40.1",
+        "@algolia/monitoring": "1.40.1",
+        "@algolia/recommend": "5.40.1",
+        "@algolia/requester-browser-xhr": "5.40.1",
+        "@algolia/requester-fetch": "5.40.1",
+        "@algolia/requester-node-http": "5.40.1"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -7517,9 +7527,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.5.tgz",
-      "integrity": "sha512-TiU4qUT9jdCuh4aVOG7H1QozyeI2sZRqoRPdqBIaslfNt4WUSanRBueAwl2x5jt4rXBMim3lIN2x6yT8PDi24Q==",
+      "version": "2.8.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.18.tgz",
+      "integrity": "sha512-UYmTpOBwgPScZpS4A+YbapwWuBwasxvO/2IOHArSsAhL/+ZdmATBXTex3t+l2hXwLVYK382ibr/nKoY9GKe86w==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -7673,9 +7683,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.26.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
-      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+      "version": "4.26.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
+      "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
       "funding": [
         {
           "type": "opencollective",
@@ -7692,9 +7702,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.3",
-        "caniuse-lite": "^1.0.30001741",
-        "electron-to-chromium": "^1.5.218",
+        "baseline-browser-mapping": "^2.8.9",
+        "caniuse-lite": "^1.0.30001746",
+        "electron-to-chromium": "^1.5.227",
         "node-releases": "^2.0.21",
         "update-browserslist-db": "^1.1.3"
       },
@@ -7877,9 +7887,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001743",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
-      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
+      "version": "1.0.30001751",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
       "funding": [
         {
           "type": "opencollective",
@@ -8596,12 +8606,12 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.45.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.1.tgz",
-      "integrity": "sha512-tqTt5T4PzsMIZ430XGviK4vzYSoeNJ6CXODi6c/voxOT6IZqBht5/EKaSNnYiEjjRYxjVz7DQIsOsY0XNi8PIA==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.46.0.tgz",
+      "integrity": "sha512-p9hObIIEENxSV8xIu+V68JjSeARg6UVMG5mR+JEUguG3sI6MsiS1njz2jHmyJDvA+8jX/sytkBHup6kxhM9law==",
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.25.3"
+        "browserslist": "^4.26.3"
       },
       "funding": {
         "type": "opencollective",
@@ -8609,9 +8619,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.45.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.1.tgz",
-      "integrity": "sha512-OHnWFKgTUshEU8MK+lOs1H8kC8GkTi9Z1tvNkxrCcw9wl3MJIO7q2ld77wjWn4/xuGrVu2X+nME1iIIPBSdyEQ==",
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.46.0.tgz",
+      "integrity": "sha512-NMCW30bHNofuhwLhYPt66OLOKTMbOhgTTatKVbaQC3KRHpTCiRIBYvtshr+NBYSnBxwAFhjW/RfJ0XbIjS16rw==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -10175,9 +10185,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.221",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.221.tgz",
-      "integrity": "sha512-/1hFJ39wkW01ogqSyYoA4goOXOtMRy6B+yvA1u42nnsEGtHzIzmk93aPISumVQeblj47JUHLC9coCjUxb1EvtQ==",
+      "version": "1.5.237",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.237.tgz",
+      "integrity": "sha512-icUt1NvfhGLar5lSWH3tHNzablaA5js3HVHacQimfP8ViEBOQv+L7DKEuHdbTZ0SKCO1ogTJTIL1Gwk9S6Qvcg==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -26881,9 +26891,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "license": "MIT"
     },
     "node_modules/stickyfill": {
@@ -30113,9 +30123,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
-      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/website/package.json
+++ b/website/package.json
@@ -16,12 +16,12 @@
     "eslint:fix": "eslint \"**/*.js\" --fix"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.9.1",
-    "@docusaurus/plugin-client-redirects": "^3.9.1",
-    "@docusaurus/plugin-google-gtag": "^3.9.1",
-    "@docusaurus/plugin-google-tag-manager": "^3.9.1",
-    "@docusaurus/preset-classic": "^3.9.1",
-    "@docusaurus/theme-mermaid": "^3.9.1",
+    "@docusaurus/core": "^3.9.2",
+    "@docusaurus/plugin-client-redirects": "^3.9.2",
+    "@docusaurus/plugin-google-gtag": "^3.9.2",
+    "@docusaurus/plugin-google-tag-manager": "^3.9.2",
+    "@docusaurus/preset-classic": "^3.9.2",
+    "@docusaurus/theme-mermaid": "^3.9.2",
     "@easyops-cn/docusaurus-search-local": "^0.52.1",
     "@hookform/error-message": "^2.0.1",
     "@iarna/toml": "^2.2.5",
@@ -57,9 +57,9 @@
     "yaml": "^2.8.1"
   },
   "devDependencies": {
-    "@docusaurus/eslint-plugin": "^3.9.1",
-    "@docusaurus/module-type-aliases": "^3.9.1",
-    "@docusaurus/types": "^3.9.1",
+    "@docusaurus/eslint-plugin": "^3.9.2",
+    "@docusaurus/module-type-aliases": "^3.9.2",
+    "@docusaurus/types": "^3.9.2",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-mdx": "^2.0.5",
     "eslint-plugin-prettier": "^4.2.1",


### PR DESCRIPTION
## Description
This pull request updates Docusaurus from version 3.9.1 to 3.9.2 for the website.

**What was the problem?**
The website was using an outdated version of Docusaurus (3.9.1) and needed to be updated to the latest patch version (3.9.2) for bug fixes and improvements.

**How it is resolved?**
Updated all Docusaurus-related packages in package.json and package-lock.json from version 3.9.1 to 3.9.2:
- @docusaurus/core
- @docusaurus/plugin-client-redirects
- @docusaurus/plugin-google-gtag
- @docusaurus/plugin-google-tag-manager
- @docusaurus/preset-classic
- @docusaurus/theme-mermaid
- @docusaurus/eslint-plugin
- @docusaurus/module-type-aliases
- @docusaurus/types

**How can we test the change?**
- Run `npm install` in the website directory
- Run `npm run build` to ensure the website builds successfully
- Run `npm start` to test the development server
- Verify all website functionality works as expected

**If there are breaking changes, please describe them in detail and why we cannot avoid them.**
This is a patch version update (3.9.1 → 3.9.2) which should not contain any breaking changes. Docusaurus follows semantic versioning, so patch updates only include bug fixes and minor improvements.

## Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)