### PR TITLE
chore(wasm): Build for `wasm-unknown` instead of gojs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ build-jsonschema-generator: create-out-dir ## Build the jsonschema-generator in 
 	CGO_ENABLED=0 GO111MODULE=on $(GOWORK_ENV) $(GOCMD) build $(MODFLAG) -o out/bin/jsonschema-generator ./cmd/jsonschema-generator/
 
 build-wasm: create-out-dir ## Build the wasm evaluation library in out/bin/
-	cd cmd/wasm && $(TINYGOCMD) build -o ../../out/bin/gofeatureflag-evaluation.wasm -target wasm -opt=2 -opt=s --no-debug -scheduler=none
+	cd cmd/wasm && $(TINYGOCMD) build -o ../../out/bin/gofeatureflag-evaluation.wasm -target wasm-unknown -opt=2 -opt=s --no-debug -scheduler=none
 
 build-wasi: create-out-dir ## Build the wasi evaluation library in out/bin/
 	cd cmd/wasm && $(TINYGOCMD) build -o ../../out/bin/gofeatureflag-evaluation.wasi -target wasi -opt=2 -opt=s --no-debug -scheduler=none


### PR DESCRIPTION
## Description
This changes the build to wasm to be targeting wasm-unknown the most "platform agnostic" compilation target.

I attempted to quickly test the result in `open-feature/java-sdk-contrib` but one test seems to be looping, I haven't narrowed down the root cause yet.

## Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #

## Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)
