### PR TITLE
feat: when using unix socket allow serving monitoring on http

### DIFF
--- a/cmd/relayproxy/api/server.go
+++ b/cmd/relayproxy/api/server.go
@@ -143,6 +143,12 @@ func (s *Server) startUnixSocketServer(ctx context.Context) {
 		}
 	}
 
+	// Start a http server for monitoring if monitoringport is configured
+	if s.monitoringEcho != nil && s.config.GetMonitoringPort(s.zapLog) > 0 {
+		go s.startMonitoringServer()
+		defer func() { _ = s.monitoringEcho.Close() }()
+	}
+
 	lc := net.ListenConfig{}
 	listener, err := lc.Listen(ctx, "unix", socketPath)
 	if err != nil {
@@ -171,16 +177,7 @@ func (s *Server) startUnixSocketServer(ctx context.Context) {
 func (s *Server) startAsHTTPServer() {
 	// starting the monitoring server on a different port if configured
 	if s.monitoringEcho != nil {
-		go func() {
-			addressMonitoring := fmt.Sprintf("%s:%d", s.config.GetServerHost(), s.config.GetMonitoringPort(s.zapLog))
-			s.zapLog.Info(
-				"Starting monitoring",
-				zap.String("address", addressMonitoring))
-			err := s.monitoringEcho.Start(addressMonitoring)
-			if err != nil && !errors.Is(err, http.ErrServerClosed) {
-				s.zapLog.Fatal("Error starting monitoring", zap.Error(err))
-			}
-		}()
+		go s.startMonitoringServer()
 		defer func() { _ = s.monitoringEcho.Close() }()
 	}
 
@@ -193,6 +190,17 @@ func (s *Server) startAsHTTPServer() {
 	err := s.apiEcho.Start(address)
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		s.zapLog.Fatal("Error starting relay proxy", zap.Error(err))
+	}
+}
+
+func (s *Server) startMonitoringServer() {
+	addressMonitoring := fmt.Sprintf("%s:%d", s.config.GetServerHost(), s.config.GetMonitoringPort(s.zapLog))
+	s.zapLog.Info(
+		"Starting monitoring",
+		zap.String("address", addressMonitoring))
+	err := s.monitoringEcho.Start(addressMonitoring)
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		s.zapLog.Fatal("Error starting monitoring", zap.Error(err))
 	}
 }
 

--- a/cmd/relayproxy/api/server_test.go
+++ b/cmd/relayproxy/api/server_test.go
@@ -577,6 +577,86 @@ func Test_Starting_RelayProxy_UnixSocket(t *testing.T) {
 	assert.Equal(t, http.StatusOK, responseI.StatusCode)
 }
 
+func Test_Starting_RelayProxy_UnixSocket_MonitoringPort(t *testing.T) {
+	// Create a temporary directory for the socket
+	tempDir, err := os.MkdirTemp("", "goff-test-socket-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	socketPath := filepath.Join(tempDir, "goff-test.sock")
+
+	proxyConf := &config.Config{
+		CommonFlagSet: config.CommonFlagSet{
+			Retrievers: &[]retrieverconf.RetrieverConf{
+				{
+					Kind: "file",
+					Path: "../../../testdata/flag-config.yaml",
+				},
+			},
+		},
+		Server: config.Server{
+			Mode:           config.ServerModeUnixSocket,
+			UnixSocketPath: socketPath,
+			MonitoringPort: 11026,
+		},
+	}
+	log := log.InitLogger()
+	defer func() { _ = log.ZapLogger.Sync() }()
+
+	metricsV2, err := metric.NewMetrics()
+	if err != nil {
+		log.ZapLogger.Error("impossible to initialize prometheus metrics", zap.Error(err))
+	}
+	wsService := service.NewWebsocketService()
+	defer wsService.Close()
+	prometheusNotifier := metric.NewPrometheusNotifier(metricsV2)
+	proxyNotifier := service.NewNotifierWebsocket(wsService)
+	flagsetManager, err := service.NewFlagsetManager(proxyConf, log.ZapLogger, []notifier.Notifier{
+		prometheusNotifier,
+		proxyNotifier,
+	})
+	require.NoError(t, err)
+
+	services := service.Services{
+		MonitoringService: service.NewMonitoring(flagsetManager),
+		WebsocketService:  wsService,
+		FlagsetManager:    flagsetManager,
+		Metrics:           metricsV2,
+	}
+
+	s := api.New(proxyConf, services, log.ZapLogger)
+	go func() { s.StartWithContext(context.Background()) }()
+	defer s.Stop(context.Background())
+
+	// Wait for the socket to be created
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(socketPath)
+		return err == nil
+	}, 1*time.Second, 10*time.Millisecond, "unix socket file was not created in time")
+
+	// Verify socket file exists
+	_, err = os.Stat(socketPath)
+	assert.NoError(t, err, "Unix socket file should exist")
+
+	// Test health endpoint
+	responseH1, err := http.Get("http://localhost:11026/health")
+	assert.NoError(t, err)
+	defer responseH1.Body.Close()
+	assert.Equal(t, http.StatusOK, responseH1.StatusCode)
+
+	// Test metrics endpoint
+	responseM1, err := http.Get("http://localhost:11026/metrics")
+	assert.NoError(t, err)
+	defer responseM1.Body.Close()
+	assert.Equal(t, http.StatusOK, responseM1.StatusCode)
+
+	// Test info endpoint
+	responseI, err := http.Get("http://localhost:11026/info")
+	assert.NoError(t, err)
+	defer responseI.Body.Close()
+	assert.Equal(t, http.StatusOK, responseI.StatusCode)
+}
+
 func Test_Starting_RelayProxy_UnixSocket_OFREP_API(t *testing.T) {
 	// Create a temporary directory for the socket
 	tempDir, err := os.MkdirTemp("", "goff-test-socket-*")

--- a/cmd/relayproxy/testdata/config/valid-file.yaml
+++ b/cmd/relayproxy/testdata/config/valid-file.yaml
@@ -1,6 +1,7 @@
 server:
   mode: http
   port: 1031
+
 pollingInterval: 1000
 startWithRetrieverError: false
 retriever:

--- a/website/docs/relay-proxy/configure-relay-proxy.mdx
+++ b/website/docs/relay-proxy/configure-relay-proxy.mdx
@@ -492,6 +492,7 @@ The execution mode of the relay proxy, you can choose to start the relay-proxy i
 #### `server.unixSocketPath`
 
 The path where the Unix socket file will be created when the relay proxy is started in `unixsocket` mode.
+If used in combination with `server.monitoringPort` monitoring endpoints will be served via http on the provided port.
 
 - option name: `unixSocketPath`
 - type: **string**


### PR DESCRIPTION
Kubernetes for example only supports health checking via http not using sockets, same goes for most prometheus scrapers.

## Description
<!-- 
Please add a description of what your pull request is doing.
 - What was the problem?
 - How it is resolved?
 - How can we test the change?
 - If there are breaking changes, please describe them in detail and why we cannot avoid them.
-->

## Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
