### PR TITLE
chore(lint): add deprecation warning to lint command

### DIFF
--- a/cmd/lint/main.go
+++ b/cmd/lint/main.go
@@ -12,8 +12,12 @@ func main() {
 	// Deprecation warning
 	const red = "\033[31m"
 	const reset = "\033[0m"
-	fmt.Fprintf(os.Stderr, "%s⚠️ WARNING: The 'lint' command is deprecated and will be removed in a future version.%s\n", red, reset)
-	fmt.Fprintf(os.Stderr, "%s‼️ Please use 'go-feature-flag-lint' instead. See https://gofeatureflag.org/docs/tooling/cli for more information.%s\n\n", red, reset)
+	fmt.Fprintf(os.Stderr, "%s⚠️ WARNING: The 'lint' command is deprecated and will be removed in a future version.%s\n",
+		red, reset)
+	fmt.Fprintf(os.Stderr,
+		"%s‼️ Please use 'go-feature-flag-lint' instead. "+
+			"See https://gofeatureflag.org/docs/tooling/cli for more information.%s\n\n",
+		red, reset)
 
 	var opts struct {
 		InputFile   string `short:"f" long:"input-file" description:"Location of the flag file you want to lint." required:"true"` //nolint: lll


### PR DESCRIPTION
## Description

This PR adds a deprecation warning to the `cmd/lint` command to inform users that it will be removed in a future version.

**What was the problem?**
- The `cmd/lint` command is being deprecated in favor of `go-feature-flag-lint`
- Users need to be informed about this deprecation and directed to the new tool

**How it is resolved?**
- Added a colored deprecation warning message (red text) that displays when the lint command is executed
- The warning includes emojis (⚠️ and ‼️) for better visibility
- Provides a clear message directing users to use `go-feature-flag-lint` instead
- Includes a link to the documentation: https://gofeatureflag.org/docs/tooling/cli

**How can we test the change?**
- Run `go build ./cmd/lint` to build the command
- Execute the lint command with any valid arguments (e.g., `./lint --help` or `./lint --input-file=test.yaml --input-format=yaml`)
- Verify that the red deprecation warning appears before any other output
- Confirm that the linting functionality still works correctly

**Breaking changes:**
None - this is a non-breaking change that only adds a warning message. The command continues to function as before.

## Closes issue(s)
<!-- 
If there's a related issue, please add it here.
-->

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code - N/A: This is a deprecation warning message, existing tests still pass
- [ ] I have updated the documentation (`README.md` and `/website/docs`) - N/A: The deprecation message itself directs users to the documentation
- [x] I have followed the [contributing guide](CONTRIBUTING.md)