### PR TITLE
chore: update Prometheus API version to v2 in test configuration

### DIFF
--- a/cmd/relayproxy/testdata/prometheus-grafana/prometheus/prometheus.yml
+++ b/cmd/relayproxy/testdata/prometheus-grafana/prometheus/prometheus.yml
@@ -8,7 +8,7 @@ alerting:
         - targets: []
       scheme: http
       timeout: 10s
-      api_version: v1
+      api_version: v2
 scrape_configs:
   - job_name: go-feature-flag
     scrape_interval: 15s


### PR DESCRIPTION
## Description
This PR updates the Prometheus API version from v1 to v2 in the test configuration file for the Prometheus-Grafana testdata.

- **What was the problem?** The Prometheus configuration was using the deprecated v1 API version
- **How it is resolved?** Updated the `api_version` field from `v1` to `v2` in the Prometheus configuration
- **How can we test the change?** The change is in test configuration, so existing tests should validate this

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code (N/A - configuration change)
- [ ] I have updated the documentation (N/A - internal test configuration)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)