### PR TITLE
Ci failure resolution

### DIFF
--- a/retriever/gcstorageretriever/retriever_test.go
+++ b/retriever/gcstorageretriever/retriever_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/thomaspoignant/go-feature-flag/testutils"
-	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
 
@@ -104,7 +103,7 @@ func TestRetriever_Retrieve(t *testing.T) {
 				Bucket: tt.fields.Bucket,
 				Object: tt.fields.Object,
 				Options: []option.ClientOption{
-					option.WithCredentials(&google.Credentials{}),
+					option.WithoutAuthentication(),
 					option.WithHTTPClient(mockedStorage.Server.HTTPClient()),
 				},
 			}


### PR DESCRIPTION
## Description
The CI was failing due to an update in `google.golang.org/api` (v0.258.0) which introduced stricter handling of credential options. The GCS retriever test was failing with `dialing: multiple credential options provided` because it was providing both `option.WithCredentials` and `option.WithHTTPClient`.

This PR resolves the issue by:
- Replacing `option.WithCredentials(&google.Credentials{})` with `option.WithoutAuthentication()` when using a mock HTTP client in the GCS retriever test.
- Removing an unused `golang.org/x/oauth2/google` import.

To test the change, run `go test ./retriever/gcstorageretriever/...`.

## Closes issue(s)
Resolve #

## Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)

---
<a href="https://cursor.com/background-agent?bcId=bc-9b3193f3-23ef-47b0-b839-6c8a90bfca91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b3193f3-23ef-47b0-b839-6c8a90bfca91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

