### PR TITLE
docs(nodejs provider): Add a mention on how to use server provider with NextJS

### DIFF
--- a/website/docs/sdk/server_providers/openfeature_javascript.mdx
+++ b/website/docs/sdk/server_providers/openfeature_javascript.mdx
@@ -311,7 +311,32 @@ featureFlagClient.track('user_action', context, {
 });
 ```
 
+## NextJS integration
+
+:::warning
+If you're using NextJS with in-process evaluation mode, you might encounter issues loading the WASM binary.
+:::
+
+In the server side, you might have an error like this _(only if you are using the in-process evaluation mode)_:
+
+```
+WasmNotLoadedException: Failed to load WASM binary: WASM file not found
+```
+
+Because of the specificity of **NextJS**, you need to add the following code to your `next.config.ts` file:
+
+```typescript
+const nextConfig: NextConfig = {
+  // ...
+  serverExternalPackages: ["@openfeature/go-feature-flag-provider"],
+  // ...
+};
+```
+
+This will tell NextJS to use the `@openfeature/go-feature-flag-provider` package as an external package and not to bundle it with the application, which is the best way to avoid the WASM binary not found error.
+
 ## Features status
+
 <FeatureTable sdk={sdk.find(it => it.key === 'nodejs')} />
 
 ## Contribute to the provider


### PR DESCRIPTION
## Description
This PR adds documentation about how to use the OpenFeature JavaScript server provider with NextJS.

The documentation explains the limitations and provides guidance on using the server provider in NextJS applications.

## Checklist
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)