### PR TITLE
chore: bump helm chart version to 1.50.0 and fix Makefile usage instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,8 @@ generate-helm-docs: ## Generates helm documentation for the project
 bump-helm-chart-version: ## Bump Helm chart version (usage: make bump-helm-chart-version VERSION=v1.2.3)
 	@if [ -z "$(VERSION)" ]; then \
 		echo "$(RED)Error: VERSION is required$(RESET)"; \
-		echo "Usage: make bump-helm-chart-version VERSION=v1.2.3"; \
-		echo "       make bump-helm-chart-version VERSION=1.2.3"; \
+		echo "Usage: VERSION=v1.2.3 make bump-helm-chart-version"; \
+		echo "       VERSION=v1.2.3 make bump-helm-chart-version"; \
 		exit 1; \
 	fi
 	.github/ci-scripts/bump-helm-chart.sh $(VERSION)

--- a/cmd/relayproxy/helm-charts/relay-proxy/Chart.yaml
+++ b/cmd/relayproxy/helm-charts/relay-proxy/Chart.yaml
@@ -5,8 +5,8 @@ sources:
   - "https://github.com/thomaspoignant/go-feature-flag"
 description: A Helm chart to deploy go-feature-flag-relay proxy into Kubernetes
 type: application
-version: 1.49.0
-appVersion: "v1.49.0"
+version: 1.50.0
+appVersion: "v1.50.0"
 
 icon: https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/logo.png
 maintainers:


### PR DESCRIPTION
## Description

This PR:
- Bumps the Helm chart version from 1.49.0 to 1.50.0 in `Chart.yaml`
- Fixes the usage instructions in the Makefile for the `bump-helm-chart-version` target to show the correct syntax (VERSION=... before make command)

## Closes issue(s)
N/A - Minor maintenance update

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code (N/A - no code changes)
- [ ] I have updated the documentation (N/A - only internal Makefile usage)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)