### PR TITLE
chore: add comment explaining parquet-go replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -303,4 +303,6 @@ require (
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
+// This change is needed to keep compatibility with AWS Athena v3 (Trino engine).
+// Check https://github.com/thomaspoignant/go-feature-flag/issues/4569 for more details.
 replace github.com/xitongsys/parquet-go => github.com/rudderlabs/parquet-go v0.0.3


### PR DESCRIPTION
## Description

This PR adds a documentation comment to `go.mod` explaining why the `parquet-go` replace directive is needed. The comment clarifies that this change is required for compatibility with AWS Athena v3 (Trino engine).

## Closes issue(s)

Related to issue #4569

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [x] I have updated the documentation (comment in go.mod)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)