### PR TITLE
fix(ci): propagate wasm release version

### DIFF
--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -15,6 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Extract version from tag
+        id: extract_version
         run: |
           TAG_NAME="${{ github.ref }}"
           VERSION=$(echo $TAG_NAME | awk -F '/' '{print $NF}' | sed 's/^v//')
@@ -24,7 +25,7 @@ jobs:
 
       - name: Echo Release wasm version
         env:
-          VERSION: ${{ env.VERSION }}
+          VERSION: ${{ steps.extract_version.outputs.VERSION }}
         run: |
           echo "Release wasm version: ${VERSION}"
       - name: Checkout
@@ -41,16 +42,14 @@ jobs:
           tinygo-version: "0.37.0"
       - name: Release WASM
         env:
-          VERSION: ${{ env.VERSION }}
+          VERSION: ${{ steps.extract_version.outputs.VERSION }}
         run: ./.github/ci-scripts/release_wasm.sh "$VERSION"
       - name: Upload assets
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
-        env:
-          VERSION: ${{ env.VERSION }}
         with:
           files: |
-            ./out/release-wasm/gofeatureflag-evaluation_${VERSION}.wasi
-            ./out/release-wasm/gofeatureflag-evaluation_${VERSION}.wasm
+            ./out/release-wasm/gofeatureflag-evaluation_${{ steps.extract_version.outputs.VERSION }}.wasi
+            ./out/release-wasm/gofeatureflag-evaluation_${{ steps.extract_version.outputs.VERSION }}.wasm
 
       - name: Checkout wasm-releases repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -61,7 +60,7 @@ jobs:
 
       - name: Copy WASM files to wasm-releases repository
         env:
-          VERSION: ${{ env.VERSION }}
+          VERSION: ${{ steps.extract_version.outputs.VERSION }}
         run: |
           mkdir -p wasm-releases/evaluation
           cp ./out/release-wasm/gofeatureflag-evaluation_${VERSION}.wasi wasm-releases/evaluation/
@@ -69,18 +68,16 @@ jobs:
 
       - name: Create Pull Request to wasm-releases
         uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8.0.0
-        env:
-          VERSION: ${{ env.VERSION }}
         with:
-          branch: publish-wasm-evaluation-${{ env.VERSION }}
-          title: "feat: Publish WASM files for ${{ env.VERSION }}"
+          branch: publish-wasm-evaluation-${{ steps.extract_version.outputs.VERSION }}
+          title: "feat: Publish WASM files for ${{ steps.extract_version.outputs.VERSION }}"
           body: |
-            Automated pull request to publish evaluation WASM files for release ${{ env.VERSION }}
+            Automated pull request to publish evaluation WASM files for release ${{ steps.extract_version.outputs.VERSION }}
 
             This PR includes:
-            - gofeatureflag-evaluation_${{ env.VERSION }}.wasi
-            - gofeatureflag-evaluation_${{ env.VERSION }}.wasm
-          commit-message: Publish evaluation WASM files for ${{ env.VERSION }}
+            - gofeatureflag-evaluation_${{ steps.extract_version.outputs.VERSION }}.wasi
+            - gofeatureflag-evaluation_${{ steps.extract_version.outputs.VERSION }}.wasm
+          commit-message: Publish evaluation WASM files for ${{ steps.extract_version.outputs.VERSION }}
           assignees: thomaspoignant
           draft: false
           signoff: true


### PR DESCRIPTION
## Description
Fixes the WASM release workflow so the version extracted from the tag is correctly propagated to later steps.

- The workflow was writing `VERSION` to `$GITHUB_OUTPUT` but later steps referenced `${{ env.VERSION }}` (never set).
- The release asset `files:` entries used `${VERSION}`, which does not expand in `with:` inputs.

This PR uses `steps.extract_version.outputs.VERSION` everywhere it’s needed.

## Closes issue(s)
Resolve #

## Checklist
- [x] I have tested this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)