### PR TITLE
feat(core): merge Disable field in MergeRules for scheduled rollout

### DIFF
--- a/modules/core/flag/rule.go
+++ b/modules/core/flag/rule.go
@@ -269,6 +269,10 @@ func (r *Rule) getPercentageBuckets() map[string]percentageBucket {
 // MergeRules is merging 2 rules.
 // It is used when we have to update a rule in a scheduled rollout.
 func (r *Rule) MergeRules(updatedRule Rule) {
+	if updatedRule.Disable != nil {
+		r.Disable = updatedRule.Disable
+	}
+
 	if updatedRule.Query != nil {
 		r.Query = updatedRule.Query
 	}

--- a/modules/core/flag/rule_test.go
+++ b/modules/core/flag/rule_test.go
@@ -635,6 +635,37 @@ func TestRule_MergeRules(t *testing.T) {
 			},
 		},
 		{
+			name: "merge rule with disable set to true",
+			originalRule: flag.Rule{
+				Name:            testconvert.String("rule1"),
+				VariationResult: testconvert.String("variation_A"),
+			},
+			updatedRule: flag.Rule{
+				Disable: testconvert.Bool(true),
+			},
+			want: flag.Rule{
+				Name:            testconvert.String("rule1"),
+				VariationResult: testconvert.String("variation_A"),
+				Disable:         testconvert.Bool(true),
+			},
+		},
+		{
+			name: "merge rule with disable set to false",
+			originalRule: flag.Rule{
+				Name:            testconvert.String("rule1"),
+				VariationResult: testconvert.String("variation_A"),
+				Disable:         testconvert.Bool(true),
+			},
+			updatedRule: flag.Rule{
+				Disable: testconvert.Bool(false),
+			},
+			want: flag.Rule{
+				Name:            testconvert.String("rule1"),
+				VariationResult: testconvert.String("variation_A"),
+				Disable:         testconvert.Bool(false),
+			},
+		},
+		{
 			name: "merge percentage",
 			originalRule: flag.Rule{
 				Name: testconvert.String("rule1"),


### PR DESCRIPTION
## Description
- **What was the problem?** During scheduled rollout, rule updates could not change the `disable` field; `MergeRules` did not handle `Disable`.
- **How it is resolved?** `Rule.MergeRules` now merges `updatedRule.Disable` when non-nil, so scheduled updates can enable or disable rules.
- **How can we test the change?** `make test` and the new `TestRule_MergeRules` cases: "merge rule with disable set to true" and "merge rule with disable set to false".

## Closes issue(s)
Resolve # (none)

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)