### PR TITLE
chore(ci): add base: main to create-pull-request actions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,7 @@ jobs:
         env:
           VERSION: ${{ env.VERSION }}
         with:
+          base: main
           branch: create-new-doc-version-${{ env.VERSION }}
           title: "docs(docusaurus): Create a new documentation version ${{ env.VERSION }}"
           body: Automated pull request to create a new documentation version ${{ env.VERSION }}
@@ -309,6 +310,7 @@ jobs:
         env:
           VERSION: ${{ env.VERSION }}
         with:
+          base: main
           branch: release-jsonschema-${{ env.VERSION }}
           title: "feat(jsonschema): Release a new version of the jsonschema ${{ env.VERSION }}"
           body: Automated pull request to release a new version of the jsonschema ${{ env.VERSION }}
@@ -354,6 +356,7 @@ jobs:
         env:
           VERSION: ${{ env.VERSION }}
         with:
+          base: main
           branch: bump-relay-proxy-helm-chart-${{ env.VERSION }}
           title: "chore(helm): Bump relay-proxy helm chart version ${{ env.VERSION }}"
           body: Automated pull request to bump relay-proxy helm chart version ${{ env.VERSION }}


### PR DESCRIPTION
## Description
<!-- 
Please add a description of what your pull request is doing.
 - What was the problem?
 - How it is resolved?
 - How can we test the change?
 - If there are breaking changes, please describe them in detail and why we cannot avoid them.
-->
- **What was the problem?** The `peter-evans/create-pull-request` actions in the release workflow did not specify a base branch. This can lead to ambiguity or wrong target branch when the workflow runs (e.g. from a different default branch context).
- **How it is resolved?** Added `base: main` to the three create-pull-request steps (docs version, jsonschema release, helm chart bump) so the automated PRs explicitly target `main`.
- **How can we test the change?** Run a release (or trigger the release workflow) and confirm the created PRs target `main`. No code or runtime change; CI-only.
- **Breaking changes?** None.

## Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
