### PR TITLE
chore: bump Helm chart to 1.51.0

### DIFF
--- a/cmd/relayproxy/helm-charts/relay-proxy/Chart.yaml
+++ b/cmd/relayproxy/helm-charts/relay-proxy/Chart.yaml
@@ -5,8 +5,8 @@ sources:
   - "https://github.com/thomaspoignant/go-feature-flag"
 description: A Helm chart to deploy go-feature-flag-relay proxy into Kubernetes
 type: application
-version: 1.50.1
-appVersion: "v1.50.1"
+version: 1.51.0
+appVersion: "v1.51.0"
 
 icon: https://raw.githubusercontent.com/thomaspoignant/go-feature-flag/main/logo.png
 maintainers:


### PR DESCRIPTION
Bumps the relay-proxy Helm chart version and appVersion from 1.50.1 to 1.51.0.