### PR TITLE
fix: migrate from deprecated s3/manager to s3/transfermanager

### DIFF
--- a/exporter/s3exporterv2/exporter.go
+++ b/exporter/s3exporterv2/exporter.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/exporter/fileexporter"
@@ -78,7 +78,7 @@ func (f *Exporter) initializeUploader(ctx context.Context) error {
 		}
 
 		client := s3.NewFromConfig(*f.AwsConfig, f.S3ClientOptions...)
-		f.s3Uploader = manager.NewUploader(client)
+		f.s3Uploader = transfermanager.New(client)
 	})
 	return initErr
 }
@@ -136,7 +136,7 @@ func (f *Exporter) Export(
 			continue
 		}
 
-		result, err := f.s3Uploader.Upload(ctx, &s3.PutObjectInput{
+		result, err := f.s3Uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
 			Bucket: aws.String(f.Bucket),
 			Key:    aws.String(f.S3Path + "/" + file.Name()),
 			Body:   of,
@@ -146,7 +146,11 @@ func (f *Exporter) Export(
 			return err
 		}
 
-		f.ffLogger.Info("[S3Exporter] file uploaded.", slog.String("location", result.Location))
+		location := ""
+		if result.Location != nil {
+			location = *result.Location
+		}
+		f.ffLogger.Info("[S3Exporter] file uploaded.", slog.String("location", location))
 	}
 	return nil
 }

--- a/exporter/s3exporterv2/uploader_api.go
+++ b/exporter/s3exporterv2/uploader_api.go
@@ -3,19 +3,17 @@ package s3exporterv2
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 )
 
-var _ UploaderAPI = (*manager.Uploader)(nil)
+var _ UploaderAPI = (*transfermanager.Client)(nil)
 
 // UploaderAPI provides methods to manage uploads to an S3 bucket.
 type UploaderAPI interface {
-	// Upload provides a method to upload objects to S3.
-	Upload(
+	// UploadObject uploads an object to S3.
+	UploadObject(
 		ctx context.Context,
-		input *s3.PutObjectInput,
-		opts ...func(uploader *manager.Uploader),
-	) (
-		*manager.UploadOutput, error)
+		input *transfermanager.UploadObjectInput,
+		opts ...func(*transfermanager.Options),
+	) (*transfermanager.UploadObjectOutput, error)
 }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7
-	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.0
+	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.2
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.43.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.21

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.3/go.mod h1:uk1vhHHERfSVCUnq
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 h1:I0GyV8wiYrP8XpA70g1HBcQO1JlQxCMTW9npl5UbDHY=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17/go.mod h1:tyw7BOl5bBe/oqvoIeECFJjMdzXoa/dfVz3QQ5lgHGA=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.3/go.mod h1:0dHuD2HZZSiwfJSy1FO5bX1hQ1TxVV1QXXjpn3XUE44=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.0 h1:MpkX8EjkwuvyuX9B7+Zgk5M4URb2WQ84Y6jM81n5imw=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.0/go.mod h1:4V9Pv5sFfMPWQF0Q0zYN6BlV/504dFGaTeogallRqQw=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.2 h1:1q8/WwEqZnM/vO4q1gx2g7lHYmyN+o4P7G6EW4zKbRQ=
+github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.1.2/go.mod h1:owKRexW+Ir5ACD2UTesmjkQ+w7mcmknLNfwOiKfVLTg=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.9/go.mod h1:AnVH5pvai0pAF4lXRq0bmhbes1u9R8wTE+g+183bZNM=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 h1:xOLELNKGp2vsiteLsvLPwxC+mYmO6OZ8PYgiuPJzF8U=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17/go.mod h1:5M5CI3D12dNOtH3/mk6minaRwI2/37ifCURZISxA/IQ=

--- a/retriever/s3retrieverv2/downloader_api.go
+++ b/retriever/s3retrieverv2/downloader_api.go
@@ -2,21 +2,18 @@ package s3retrieverv2
 
 import (
 	"context"
-	"io"
 
-	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 )
 
-var _ DownloaderAPI = (*manager.Downloader)(nil)
+var _ DownloaderAPI = (*transfermanager.Client)(nil)
 
-// DownloaderAPI provides methods to manage downloads to an S3 bucket.
+// DownloaderAPI provides methods to manage downloads from an S3 bucket.
 type DownloaderAPI interface {
-	Download(
+	// DownloadObject downloads an object from S3.
+	DownloadObject(
 		ctx context.Context,
-		w io.WriterAt,
-		input *s3.GetObjectInput,
-		options ...func(*manager.Downloader),
-	) (
-		n int64, err error)
+		input *transfermanager.DownloadObjectInput,
+		opts ...func(*transfermanager.Options),
+	) (*transfermanager.DownloadObjectOutput, error)
 }


### PR DESCRIPTION
## Description
- **What was the problem?** The linter reported 6 staticcheck warnings about deprecated AWS SDK v2 functions (`manager.NewUploader`, `manager.Uploader`, `manager.NewDownloader`, `manager.Downloader`) from the `github.com/aws/aws-sdk-go-v2/feature/s3/manager` package. These are superseded by the new `transfermanager` package.
- **How it is resolved?** Migrated all S3 upload/download operations to use the new `github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager` package, which provides the modern `transfermanager.New()`, `UploadObject()`, and `DownloadObject()` APIs.
- **How can we test the change?** Run `make lint` to verify no staticcheck warnings remain. Run `make test` to ensure all existing tests pass with the new API.
- **If there are breaking changes, please describe them in detail and why we cannot avoid them.** This is an internal implementation change. The public APIs of `s3exporterv2.Exporter` and `s3retrieverv2.Retriever` remain unchanged.

## Closes issue(s)
Resolve #

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)