### PR TITLE
chore(release-please): add relay proxy as separate package with linked versions

### DIFF
--- a/.github/release-please/.release-please-manifest.json
+++ b/.github/release-please/.release-please-manifest.json
@@ -1,5 +1,6 @@
 {
     ".": "1.51.0",
+    "cmd/relayproxy": "1.51.0",
     "cmd/wasm": "0.1.4",
     "openfeature/providers/python-provider": "0.5.0",
     "openfeature/providers/kotlin-provider": "1.0.0",

--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -28,6 +28,17 @@
             "section": "⚙️ CI/CD"
         }
     ],
+    "plugins": [
+        {
+            "type": "linked-versions",
+            "groupName": "go-feature-flag",
+            "components": [
+                ".",
+                "cmd/relayproxy"
+            ],
+            "merge": true
+        }
+    ],
     "packages": {
         ".": {
             "release-type": "go",
@@ -35,6 +46,21 @@
             "changelog-path": ".github/release-please/CHANGELOG.md",
             "path": ".",
             "component": "go-feature-flag",
+            "exclude-paths": [
+                "modules/core",
+                "openfeature/providers/kotlin-provider",
+                "openfeature/providers/python-provider",
+                ".github/release-please",
+                "cmd/wasm",
+                "website"
+            ]
+        },
+        "cmd/relayproxy": {
+            "release-type": "go",
+            "include-component-in-tag": false,
+            "changelog-path": ".github/release-please/CHANGELOG.md",
+            "path": "cmd/relayproxy",
+            "component": "cmd/relayproxy",
             "exclude-paths": [
                 "modules/core",
                 "openfeature/providers/kotlin-provider",


### PR DESCRIPTION
## Description
- **What was the problem?** Relay proxy was not a separate release-please package; we want to support separate (or coordinated) releases for the relay proxy.
- **How it is resolved?** Added `cmd/relayproxy` as a release-please package with the same structure as the root package, and a `linked-versions` plugin so `.` and `cmd/relayproxy` stay in sync under the `go-feature-flag` group.
- **How can we test the change?** Run release-please (e.g. `npx release-please manifest`) and confirm `cmd/relayproxy` appears in the manifest and config; verify changelog/release behavior for the new component.
- **Breaking changes:** None.

## Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)