### PR TITLE
docs: add OpenFeature Tracking API documentation

### DIFF
--- a/website/docs/concepts/exporter.mdx
+++ b/website/docs/concepts/exporter.mdx
@@ -51,6 +51,19 @@ Considering the volume of information to process and the potential impact on you
 
 [Check how to configure the exporters](../integrations/export-evaluation-data)
 
+
+## Feature vs Tracking exporters
+
+Exporters can be configured to receive one of two event types:
+
+- **Feature exporters** (default): They receive **feature events**—one event per flag evaluation. Each event describes which flag was evaluated, which variation was returned, and for which user/context. Use this to understand flag usage, power analytics, and feed A/B or experimentation tools. See [flag usage tracking](../tracking/flag-usage-tracking) for details.
+- **Tracking exporters**: They receive **tracking events**—custom actions or outcomes you record via the [OpenFeature Tracking API](https://openfeature.dev/specification/sections/tracking/) (e.g. "user completed checkout", "clicked CTA"). Use this to measure the impact of flags (e.g. conversion per variation) and run experiments. See [Tracking API](../tracking/tracking-api) for details.
+
+You choose the event type per exporter with the `eventType` option (`"feature"` or `"tracking"`).
+The default is `"feature"` when omitted. You can send both kinds of events to the same backend by defining two exporter entries—one for feature events, one for tracking events—if your pipeline accepts both.
+
+For more information, see the [tracking section](../tracking/flag-usage-tracking) (flag usage and [Tracking API](../tracking/tracking-api)).
+
 ## How Exporters Work
 
 When a feature flag is evaluated using any of the SDK, GO Feature Flag notifies the configured exporters with the evaluation result. This result typically includes:

--- a/website/docs/tracking/_category_.json
+++ b/website/docs/tracking/_category_.json
@@ -1,0 +1,6 @@
+{
+  "position": 45,
+  "collapsible": true,
+  "collapsed": true,
+  "label": "📈 Tracking"
+}

--- a/website/docs/tracking/flag-usage-tracking.mdx
+++ b/website/docs/tracking/flag-usage-tracking.mdx
@@ -1,0 +1,82 @@
+---
+sidebar_position: 1
+description: How flag usage (feature events) is recorded and exported when flags are evaluated.
+---
+
+# 📈 Flag usage tracking
+
+## What it is
+
+**Flag usage tracking** records which flag variation each user received whenever a flag is evaluated.  
+For each evaluation, a **feature** event is recorded and sent to the exporters you have configured.
+
+Depending on the way you evaluate your flags, this event is tracked in the relay-proxy or in the OpenFeature provider.
+
+All flag usage events are sent to the [exporters](../integrations/export-evaluation-data) you have configured.
+
+## Why use it
+
+- **Understand how flags are used**: See who saw what variation, power analytics and dashboards, and feed data into A/B or experimentation tools.
+- **Correlate exposures with outcomes**: Essential when you need to link flag evaluations to business metrics or downstream events.
+
+## How it works
+
+### With the relay-proxy
+
+If your app talks to the relay (direct API or via an OpenFeature SDK), evaluations can happen in two places:
+
+1. **In the relay-proxy**: Each evaluation performed by the relay-proxy produces an event that the relay-proxy exports. You can think of the relay-proxy as the component that evaluates and records.
+2. **In the OpenFeature provider**: The OpenFeature provider can evaluate locally the flag without calling the relay-proxy. In that case the OpenFeature provider later sends batched "I evaluated this flag for this user" events to the relay-proxy, and the relay-proxy exports them so you don't miss usage when in-process evaluation is used.
+
+Regardless of where the evaluation happened, the relay-proxu is the place that forwards flag-usage events to your configured exporters.
+
+### Summary
+
+Flag usage tracking means: _every time someone gets a flag value, record that fact and send it to your chosen destinations._
+Whether the evaluation runs in the relay-proxy or from the OpenFeature provider only affects who produces the event and who sends it to the relay-proxy; the concept is the same.
+
+## What you need to do
+
+1. **Turn on tracking for the flags you care about**: Set `trackEvents: true` in the flag configuration of your feature flag(or omit it; the default is `true`). See [configure your flags](../configure_flag/create-flags) for the flag format.
+2. **Configure at least one exporter for evaluation data**: Add a data exporter for feature events (the default event type). See [export evaluation data](../integrations/export-evaluation-data) for available exporters and how to configure them for the relay-proxy or GO module.
+
+No code changes are required beyond configuration for the default "feature" event type.
+
+## Event format
+
+Each flag-usage event (also called a **feature event**) has the following structure when sent to your exporters:
+
+| Field            | Description                                                                                                                                           |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **kind**         | Always `"feature"` for flag usage events.                                                                                                             |
+| **contextKind**  | `"user"` for a known user, or `"anonymousUser"` for an anonymous context.                                                                             |
+| **userKey**      | The targeting key (user or entity identifier) used in the evaluation.                                                                                 |
+| **creationDate** | Unix timestamp (seconds) when the flag was evaluated.                                                                                                 |
+| **key**          | The flag name that was evaluated.                                                                                                               |
+| **variation**    | The variation name returned.                                                                                                                          |
+| **value**        | The resolved value returned to the application.                                                                                                       |
+| **default**      | `true` if the evaluation failed and the default value was returned; otherwise `false`.                                                                |
+| **version**      | Version of the flag configuration (if set).                                                                                                           |
+| **source**       | `"SERVER"` when the evaluation was done in the relay-proxy; `"PROVIDER_CACHE"` when it was served from the SDK cache and later reported to the relay. |
+| **metadata**     | Optional static key-value data added by the provider for context.                                                                                     |
+
+### Example
+
+A minimal feature event in JSON (as sent for example by the [webhook exporter](../integrations/export-evaluation-data/webhook)) looks like:
+
+```json
+{
+  "kind": "feature",
+  "contextKind": "user",
+  "userKey": "94a25909-20d8-40cc-8500-fee99b569345",
+  "creationDate": 1618909178,
+  "key": "my-feature-flag",
+  "variation": "true-variation",
+  "value": true,
+  "default": false,
+  "version": "1.0.0",
+  "source": "SERVER"
+}
+```
+
+To combine flag usage with custom business events (e.g. conversions or revenue), use the [OpenFeature Tracking API](./tracking-api).

--- a/website/docs/tracking/tracking-api.mdx
+++ b/website/docs/tracking/tracking-api.mdx
@@ -1,0 +1,102 @@
+---
+sidebar_position: 2
+description: How to record custom actions and outcomes with the OpenFeature Tracking API for experimentation and analytics.
+---
+
+# 🎯 Tracking API
+
+## What it is
+
+The **OpenFeature Tracking API** lets you record custom actions or outcomes in your app (e.g. "user visited promo page," "user completed checkout with amount 99.99") and associate them with the same user or context you use for flag evaluation.
+This follows the [OpenFeature Tracking specification](https://openfeature.dev/specification/sections/tracking/).
+
+You call something like `client.track("event-name", context, details)` when the action happens in your application.
+
+## Why use it
+
+- **Measure the impact of flags**: For example, did users who saw the new button (flag on) actually click it more? By recording both "which variation they saw" ([flag usage](./flag-usage-tracking)) and "what they did" (tracking events), you can analyze conversion, revenue, or any metric per variation.
+- **Experimentation**: Tracking is the "outcome" side of experimentation—you need both exposures and outcomes to run A/B tests or analyze feature impact.
+
+## Concepts
+
+- **Event name**: A string you choose (e.g. `"clicked-checkout"`, `"visited-promo-page"`).
+- **Context**: The same evaluation context (user key, attributes) you use for flag evaluation, so tracking events can be joined with flag exposures in your analytics.
+- **Details**: Optional extra data—for example a numeric **value** (e.g. order total) and/or custom fields (e.g. currency, item IDs). Useful for revenue, scores, or any structured payload your analytics expect.
+
+## How it works
+
+### With the relay-proxy and SDKs
+
+Your app uses an OpenFeature client (e.g. Kotlin, JavaScript).
+
+When you call `client.track(...)`, the provider records the event and later sends it in a batch to the relay's data collector.
+The relay-proxy then forwards those events to the **tracking** exporters you configured.
+
+Flow:
+
+```mermaid
+sequenceDiagram
+    participant app as App
+    participant sdk as OpenFeature SDK
+    participant p as Go Feature Flag Provider
+    participant rp as RelayProxy
+    participant exp as Exporter
+    app ->> sdk: Track()
+    sdk ->> p:
+    p ->> p: Buffer track events
+    p ->> rp: Send events to the relay-proxy
+    rp -->> p:
+    rp ->> exp: Store events to the Tracking Exporter
+    exp -->> rp:
+```
+
+The relay-proxy never calls `track` itself; it only receives and forwards tracking events from SDKs.
+
+### Summary
+
+The Tracking API means: _record a named action or outcome for this user/context and optional details._ Events flow from your app (via the SDK) to the relay-proxy, then to the exporters you set up for tracking.
+
+## What you need to do
+
+1. **Call the OpenFeature track API** where the action or outcome occurs in your application (using the client provided by your OpenFeature SDK).
+2. **Configure at least one exporter for tracking events**: Use a new exporter with the option `eventType: "tracking"` set, so the relay-proxy sends these events to that exporter. See [export evaluation data](../integrations/export-evaluation-data) and the relay-proxy configuration for how to add an exporter with `eventType: "tracking"`.
+
+You can send tracking and flag-usage events to the same backend by defining two exporter entries (one for feature events, one for tracking events) if your pipeline accepts both.
+
+## Event format
+
+Each tracking event has the following structure when sent to your exporters:
+
+| Field                    | Description                                                                                                                                                                                                                                                 |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **kind**                 | Always `"tracking"` for custom tracking events.                                                                                                                                                                                                             |
+| **contextKind**          | `"user"` for a known user, or `"anonymousUser"` for an anonymous context.                                                                                                                                                                                   |
+| **userKey**              | The targeting key (user or entity identifier) from the evaluation context.                                                                                                                                                                                  |
+| **creationDate**         | Unix timestamp (seconds) when the event was recorded.                                                                                                                                                                                                       |
+| **key**                  | The tracking event name you passed (e.g. `"clicked-checkout"`).                                                                                                                                                                                             |
+| **evaluationContext**    | The evaluation context (attributes, key) used when tracking, so you can join with flag exposures.                                                                                                                                                           |
+| **trackingEventDetails** | Optional data: a numeric **value** and/or custom key–value fields. Keys are strings; values can be boolean, string, number, or nested structure, as per the [OpenFeature Tracking specification](https://openfeature.dev/specification/sections/tracking/). |
+
+### Example
+
+A minimal tracking event in JSON:
+
+```json
+{
+  "kind": "tracking",
+  "contextKind": "user",
+  "userKey": "94a25909-20d8-40cc-8500-fee99b569345",
+  "creationDate": 1618909178,
+  "key": "clicked-checkout",
+  "evaluationContext": {
+    "targetingKey": "94a25909-20d8-40cc-8500-fee99b569345",
+    "email": "user@example.com"
+  },
+  "trackingEventDetails": {
+    "value": 99.77,
+    "currencyCode": "USD"
+  }
+}
+```
+
+For the exact types and semantics of tracking event details (e.g. `value` and custom fields), see the [OpenFeature Tracking specification](https://openfeature.dev/specification/sections/tracking/).


### PR DESCRIPTION
## Description

This PR adds a new documentation section about tracking in GO Feature Flag.

### What was the problem?
The documentation was missing information about the OpenFeature Tracking API and how flag usage tracking works in GO Feature Flag.

### How it is resolved?
Added a new "Tracking" documentation section with two comprehensive pages:

1. **Flag usage tracking** (`flag-usage-tracking.mdx`):
   - Explains what flag usage tracking is
   - Describes how it works with the relay proxy and OpenFeature providers
   - Documents the feature event format with field descriptions and JSON example

2. **Tracking API** (`tracking-api.mdx`):
   - Explains the OpenFeature Tracking API for custom events
   - Describes how to record actions/outcomes for experimentation
   - Includes a mermaid sequence diagram showing the event flow
   - Documents the tracking event format with JSON example

### How can we test the change?
Run `make watch-doc` and navigate to the new Tracking section in the documentation.

## Closes issue(s)

Resolve #4544

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)