### PR TITLE
fix(python-provider): use X-API-Key header for relay API keys

### DIFF
--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/data_collector_hook.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/data_collector_hook.py
@@ -112,7 +112,7 @@ class DataCollectorHook(Hook):
                 )
                 headers = {"Content-Type": "application/json"}
                 if self._options.api_key:
-                    headers["Authorization"] = "Bearer {}".format(self._options.api_key)
+                    headers["X-API-Key"] = self._options.api_key
 
                 response = self._http_client.request(
                     method="POST",

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/provider.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/provider.py
@@ -195,7 +195,7 @@ class GoFeatureFlagProvider(BaseModel, AbstractProvider, metaclass=CombinedMetac
             else:
                 headers = {"Content-Type": "application/json"}
                 if self.options.api_key is not None:
-                    headers["Authorization"] = "Bearer {}".format(self.options.api_key)
+                    headers["X-API-Key"] = self.options.api_key
                 url = "{}{}".format(
                     str(self.options.endpoint).rstrip("/"),
                     "/v1/feature/{}/eval".format(flag_key),

--- a/openfeature/providers/python-provider/tests/test_gofeatureflag_python_provider.py
+++ b/openfeature/providers/python-provider/tests/test_gofeatureflag_python_provider.py
@@ -690,6 +690,63 @@ def test_url_parsing(mock_request):
 
 
 @patch("urllib3.poolmanager.PoolManager.request")
+def test_should_send_api_key_in_x_api_key_header_for_evaluation(mock_request):
+    flag_key = "bool_targeting_match"
+    mock_request.return_value = Mock(status="200", data=_read_mock_file(flag_key))
+    goff_provider = GoFeatureFlagProvider(
+        options=GoFeatureFlagOptions(
+            endpoint="https://gofeatureflag.org/",
+            data_flush_interval=100,
+            disable_cache_invalidation=True,
+            api_key="apikey1",
+        ),
+    )
+    api.set_provider(goff_provider)
+    client = api.get_client(domain="test-client")
+    client.get_boolean_details(
+        flag_key=flag_key,
+        default_value=False,
+        evaluation_context=_default_evaluation_ctx,
+    )
+    api.shutdown()
+
+    headers = mock_request.call_args.kwargs["headers"]
+    assert headers["X-API-Key"] == "apikey1"
+    assert "Authorization" not in headers
+
+
+@patch("urllib3.poolmanager.PoolManager.request")
+def test_should_send_api_key_in_x_api_key_header_for_data_collector(mock_request):
+    flag_key = "bool_targeting_match"
+    mock_request.side_effect = [
+        Mock(status="200", data=_read_mock_file(flag_key)),
+        Mock(status="200", data={}),
+        Mock(status="200", data={}),
+    ]
+    goff_provider = GoFeatureFlagProvider(
+        options=GoFeatureFlagOptions(
+            endpoint="https://gofeatureflag.org/",
+            data_flush_interval=100,
+            disable_cache_invalidation=True,
+            api_key="apikey1",
+        )
+    )
+    api.set_provider(goff_provider)
+    client = api.get_client(domain="test-client")
+    client.get_boolean_details(
+        flag_key=flag_key,
+        default_value=False,
+        evaluation_context=_default_evaluation_ctx,
+    )
+    time.sleep(0.2)
+    api.shutdown()
+
+    collector_headers = mock_request.call_args_list[1].kwargs["headers"]
+    assert collector_headers["X-API-Key"] == "apikey1"
+    assert "Authorization" not in collector_headers
+
+
+@patch("urllib3.poolmanager.PoolManager.request")
 def test_should_call_evaluation_api_with_exporter_metadata(
     mock_request: Mock,
 ):


### PR DESCRIPTION
## Description
This updates the Python OpenFeature provider to send configured relay API keys with the OFREP-compliant `X-API-Key` header instead of `Authorization: Bearer ...`.

### What was the problem?
Issue #4319 tracks the migration from legacy `Authorization` API-key usage to `X-API-Key` so `Authorization` can be reserved for future OAuth tokens.

### How is it resolved?
- Switched evaluation requests to set `X-API-Key` when `api_key` is configured.
- Switched data-collector requests to set `X-API-Key` when `api_key` is configured.
- Added unit tests asserting both paths send `X-API-Key` and do not send `Authorization`.

### How can we test the change?
- `python3 -m py_compile openfeature/providers/python-provider/gofeatureflag_python_provider/provider.py openfeature/providers/python-provider/gofeatureflag_python_provider/data_collector_hook.py openfeature/providers/python-provider/tests/test_gofeatureflag_python_provider.py`
- Added tests:
  - `test_should_send_api_key_in_x_api_key_header_for_evaluation`
  - `test_should_send_api_key_in_x_api_key_header_for_data_collector`

> Note: full pytest execution was not runnable in this environment because `pytest`/`poetry` are not installed.

## Closes issue(s)
Resolve #4319

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
