### PR TITLE
feat: Ignore top-level keys started with `x-`

### DIFF
--- a/cmd/cli/helper/read_config_file.go
+++ b/cmd/cli/helper/read_config_file.go
@@ -66,19 +66,22 @@ func readConfigFile(configFile, configFormat string) (map[string]dto.DTO, error)
 		if err != nil {
 			return nil, fmt.Errorf("%s: could not parse file (toml): %w", configFile, err)
 		}
-		return flags, nil
 	case "json":
 		err := json.Unmarshal(dat, &flags)
 		if err != nil {
 			return nil, fmt.Errorf("%s: could not parse file (json): %w", configFile, err)
 		}
-		return flags, nil
 	default:
 		// default is YAML
 		err := yaml.Unmarshal(dat, &flags)
 		if err != nil {
 			return nil, fmt.Errorf("%s: could not parse file (yaml): %w", configFile, err)
 		}
-		return flags, nil
 	}
+	for key := range flags {
+		if strings.HasPrefix(key, "x-") {
+			delete(flags, key)
+		}
+	}
+	return flags, nil
 }

--- a/testdata/flag-config.yaml
+++ b/testdata/flag-config.yaml
@@ -16,17 +16,20 @@ test-flag:
     description: this is a simple feature flag
     issue-link: https://jira.xxx/GOFF-01
 
+x-reusable-targeting: &x-reusable-targeting
+  name: rule1
+  query: key eq "not-a-key"
+  percentage:
+    False: 0
+    True: 100
+
 test-flag2:
   variations:
     Default: false
     False: false
     True: true
   targeting:
-    - name: rule1
-      query: key eq "not-a-key"
-      percentage:
-        False: 0
-        True: 100
+    - *x-reusable-targeting
   defaultRule:
     name: defaultRule
     variation: Default


### PR DESCRIPTION
Currently, go-feature-flag doesn't support reusable targeting conditions out of the box. So we cannot define set of rules

```yaml
my-custom-group:
  - query: role eq "admin"
  - query: group eq "QA"
  - query: email eq "custom@example.com"

...
my-flag:
  targeting:
    - query: my-custom-group eq true
      variation: enabled
```

But something similar can be achieved using YAML anchors. The issue with this approach is go-feature-flag treats every top-level key as a flag. So this is invalid configuration because my-custom-group is invalid flag:

```yaml
x-custom-group: &x-custom-group
  - query: role eq "admin"
    variation: enabled
  - query: group eq "QA"
    variation: enabled
  - query: email eq "custom@example.com"
    variation: enabled

...
my-flag:
  variations:
    enabled: true
    disabled: false
  targeting:
    - *x-custom-group
  defaultRule:
    variation: disabled
```

It is possible to define anchors as part of the flag and then reuse it, but it lowers readability of the config file.

Usually, YAML consumers ignores keys started with `x-`. E.g. docker compose does this since 2017, openapi allows `x-` keys for extending schema since it was swagger, etc.

So this commit brings this approach into `go-feature-flag`. Now we can define top-level anchors started with `x-` and reuse these snippets to define multiple flags.

I've decided to ignore `x-` keys for JSON and TOML too. E.g. for JSON it might be used as a comment, so there is still value provided. And it is nice to be able to transparently convert flags definition between formats so they remain valid.

## Description
<!-- 
Please add a description of what your pull request is doing.
 - What was the problem?
 - How it is resolved?
 - How can we test the change?
 - If there are breaking changes, please describe them in detail and why we cannot avoid them.
-->

## Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #

## Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)
