### PR TITLE
ci(security): add zizmor workflow to audit GitHub Actions

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,32 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    branches: ["**"]
+    paths:
+      - '.github/workflows/**'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Adds a new workflow (`.github/workflows/zizmor.yml`) that runs [zizmor](https://github.com/zizmorcore/zizmor), a static analyser for GitHub Actions workflows.

## Why

Recommended by [Astral's open-source security article](https://astral.sh/blog/open-source-security-at-astral). Zizmor catches dangerous patterns that are easy to miss during review:
- Dangerous triggers (`pull_request_target`, `workflow_run`)
- Missing or overly broad permissions
- Script injection risks
- Unpinned actions

Results are uploaded as SARIF to GitHub's Code Scanning dashboard.

## Details

- Runs on push to `main` and on PRs, **scoped to changes under `.github/workflows/`** — no-op on regular code changes
- Action pinned to full SHA (`zizmorcore/zizmor-action@71321a20` = v0.5.2)
- `permissions: {}` at workflow level, minimal per-job grants

## Checklist

- [x] No new dependencies added
- [x] Action pinned to SHA
- [x] Scoped trigger (path filter)