### PR TITLE
ci(security): disable Go module cache in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
+          cache: false
       - name: Set up Maven
         uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
         with:
@@ -61,6 +62,7 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
+          cache: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v3.1.1
@@ -222,6 +224,7 @@ jobs:
         with:
           go-version-file: ./release/${{ env.WEBSITE_DIR }}/.ci/go.mod
           check-latest: true
+          cache: false
 
       - name: Clean up version.json
         working-directory: ./release/${{ env.WEBSITE_DIR }}/.ci
@@ -284,6 +287,7 @@ jobs:
         with:
           go-version-file: ./release/go.mod
           check-latest: true
+          cache: false
 
       - name: Build jsonschema-generator
         working-directory: ./release/


### PR DESCRIPTION
## What

Adds `cache: false` to all `actions/setup-go` steps in `.github/workflows/release.yml` (4 jobs: `integration-tests`, `goreleaser`, `doc-release`, `release-jsonschema`).

## Why

Recommended by [Astral's open-source security article](https://astral.sh/blog/open-source-security-at-astral). A poisoned cache entry could inject malicious build artifacts into a release without changing any source code. The CI cache is a shared, mutable resource — disabling it for release builds ensures every release compiles from a clean state using only vendored or freshly resolved dependencies.

## Details

- Only affects the release workflow; CI cache remains enabled for regular builds where speed matters
- No functional change to build output

## Checklist

- [x] No new dependencies added
- [x] All 4 `setup-go` steps in the file updated