### PR TITLE
docs: fix dockerhub linting command for cli

### DIFF
--- a/cmd/cli/DOCKERHUB.md
+++ b/cmd/cli/DOCKERHUB.md
@@ -52,8 +52,7 @@ docker run -v <location_of_your_local_file>:/config.yaml \
 ## How to lint a configuration file
 ```shell
 docker run -v <location_of_your_local_file>:/config.yaml \
-  gofeatureflag/go-feature-flag-cli lint \
-  --config=/config.yaml \
+  gofeatureflag/go-feature-flag-cli lint "/config.yaml" \
   --format="yaml"
 ```
 


### PR DESCRIPTION
## Description

- **Problem:** CLI lint command in DOCKERHUB.md used two separate args (`--config=/config.yaml`) which didn't match actual CLI usage.
- **Resolved:** Combined into single positional arg `lint "/config.yaml"` matching the correct CLI interface.
- **Testing:** Verify command runs correctly with Docker image.
- **Breaking changes:** None.

# Closes
Closes #5144

## Checklist
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)