### PR TITLE
feat(modules/core): add ConvertInternalFlagToDto converter

### DIFF
--- a/modules/core/dto/converter.go
+++ b/modules/core/dto/converter.go
@@ -28,25 +28,25 @@ func ConvertDtoToInternalFlag(dto DTO) flag.InternalFlag {
 	}
 }
 
-func ConvertInternalFlagToDto(flag flag.InternalFlag) DTO {
+func ConvertInternalFlagToDto(f flag.InternalFlag) DTO {
 	var experimentation *ExperimentationDto
-	if flag.Experimentation != nil {
+	if f.Experimentation != nil {
 		experimentation = &ExperimentationDto{
-			Start: flag.Experimentation.Start,
-			End:   flag.Experimentation.End,
+			Start: f.Experimentation.Start,
+			End:   f.Experimentation.End,
 		}
 	}
 
 	return DTO{
-		TrackEvents:     flag.TrackEvents,
-		Disable:         flag.Disable,
-		Version:         flag.Version,
-		Variations:      flag.Variations,
-		Rules:           flag.Rules,
-		BucketingKey:    flag.BucketingKey,
-		DefaultRule:     flag.DefaultRule,
-		Scheduled:       flag.Scheduled,
+		TrackEvents:     f.TrackEvents,
+		Disable:         f.Disable,
+		Version:         f.Version,
+		Variations:      f.Variations,
+		Rules:           f.Rules,
+		BucketingKey:    f.BucketingKey,
+		DefaultRule:     f.DefaultRule,
+		Scheduled:       f.Scheduled,
 		Experimentation: experimentation,
-		Metadata:        flag.Metadata,
+		Metadata:        f.Metadata,
 	}
 }

--- a/modules/core/dto/converter.go
+++ b/modules/core/dto/converter.go
@@ -29,7 +29,7 @@ func ConvertDtoToInternalFlag(dto DTO) flag.InternalFlag {
 }
 
 func ConvertInternalFlagToDto(flag flag.InternalFlag) DTO {
-	experimentation := &ExperimentationDto{}
+	var experimentation *ExperimentationDto
 	if flag.Experimentation != nil {
 		experimentation = &ExperimentationDto{
 			Start: flag.Experimentation.Start,

--- a/modules/core/dto/converter.go
+++ b/modules/core/dto/converter.go
@@ -27,3 +27,26 @@ func ConvertDtoToInternalFlag(dto DTO) flag.InternalFlag {
 		Metadata:        dto.Metadata,
 	}
 }
+
+func ConvertInternalFlagToDto(flag flag.InternalFlag) DTO {
+	experimentation := &ExperimentationDto{}
+	if flag.Experimentation != nil {
+		experimentation = &ExperimentationDto{
+			Start: flag.Experimentation.Start,
+			End:   flag.Experimentation.End,
+		}
+	}
+
+	return DTO{
+		TrackEvents:     flag.TrackEvents,
+		Disable:         flag.Disable,
+		Version:         flag.Version,
+		Variations:      flag.Variations,
+		Rules:           flag.Rules,
+		BucketingKey:    flag.BucketingKey,
+		DefaultRule:     flag.DefaultRule,
+		Scheduled:       flag.Scheduled,
+		Experimentation: experimentation,
+		Metadata:        flag.Metadata,
+	}
+}

--- a/modules/core/dto/converter_test.go
+++ b/modules/core/dto/converter_test.go
@@ -277,16 +277,13 @@ func TestConvertInternalFlagToDto(t *testing.T) {
 				Version:         testconvert.String("v1"),
 			},
 			expected: dto.DTO{
-				Experimentation: &dto.ExperimentationDto{},
-				Version:         testconvert.String("v1"),
+				Version: testconvert.String("v1"),
 			},
 		},
 		{
-			name:  "empty input",
-			input: flag.InternalFlag{},
-			expected: dto.DTO{
-				Experimentation: &dto.ExperimentationDto{},
-			},
+			name:     "empty input",
+			input:    flag.InternalFlag{},
+			expected: dto.DTO{},
 		},
 	}
 	for _, tt := range tests {

--- a/modules/core/dto/converter_test.go
+++ b/modules/core/dto/converter_test.go
@@ -148,3 +148,151 @@ func TestConvertV1DtoToInternalFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertInternalFlagToDto(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    flag.InternalFlag
+		expected dto.DTO
+	}{
+		{
+			name: "all fields set",
+			input: flag.InternalFlag{
+				BucketingKey: testconvert.String("bucketKey"),
+				Variations: &map[string]*any{
+					"var1": testconvert.Interface("var1"),
+					"var2": testconvert.Interface("var2"),
+				},
+				Rules: &[]flag.Rule{
+					{
+						Name:        testconvert.String("rule1"),
+						Query:       testconvert.String("key eq \"key\""),
+						Percentages: &map[string]float64{"var_true": 100, "var_false": 0},
+					},
+					{
+						Name:  testconvert.String("rule2"),
+						Query: testconvert.String("key eq \"key2\""),
+						ProgressiveRollout: &flag.ProgressiveRollout{
+							Initial: &flag.ProgressiveRolloutStep{
+								Variation:  testconvert.String("var1"),
+								Percentage: testconvert.Float64(30),
+								Date:       testconvert.Time(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)),
+							},
+							End: &flag.ProgressiveRolloutStep{
+								Variation:  testconvert.String("var2"),
+								Percentage: testconvert.Float64(70),
+								Date:       testconvert.Time(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)),
+							},
+						},
+					},
+					{
+						Name:            testconvert.String("rule3"),
+						Query:           testconvert.String("key eq \"key3\""),
+						VariationResult: testconvert.String("var2"),
+					},
+				},
+				DefaultRule: &flag.Rule{
+					VariationResult: testconvert.String("var1"),
+				},
+				Scheduled: &[]flag.ScheduledStep{
+					{
+						Date: testconvert.Time(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)),
+						InternalFlag: flag.InternalFlag{
+							DefaultRule: &flag.Rule{
+								VariationResult: testconvert.String("var2"),
+							},
+						},
+					},
+				},
+				Experimentation: &flag.ExperimentationRollout{
+					Start: testconvert.Time(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)),
+					End:   testconvert.Time(time.Date(2022, 1, 2, 0, 0, 0, 0, time.UTC)),
+				},
+				Metadata:    &map[string]any{"key": "value"},
+				TrackEvents: testconvert.Bool(true),
+				Disable:     testconvert.Bool(false),
+				Version:     testconvert.String("v1"),
+			},
+			expected: dto.DTO{
+				BucketingKey: testconvert.String("bucketKey"),
+				Variations: &map[string]*any{
+					"var1": testconvert.Interface("var1"),
+					"var2": testconvert.Interface("var2"),
+				},
+				Rules: &[]flag.Rule{
+					{
+						Name:        testconvert.String("rule1"),
+						Query:       testconvert.String("key eq \"key\""),
+						Percentages: &map[string]float64{"var_true": 100, "var_false": 0},
+					},
+					{
+						Name:  testconvert.String("rule2"),
+						Query: testconvert.String("key eq \"key2\""),
+						ProgressiveRollout: &flag.ProgressiveRollout{
+							Initial: &flag.ProgressiveRolloutStep{
+								Variation:  testconvert.String("var1"),
+								Percentage: testconvert.Float64(30),
+								Date:       testconvert.Time(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)),
+							},
+							End: &flag.ProgressiveRolloutStep{
+								Variation:  testconvert.String("var2"),
+								Percentage: testconvert.Float64(70),
+								Date:       testconvert.Time(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)),
+							},
+						},
+					},
+					{
+						Name:            testconvert.String("rule3"),
+						Query:           testconvert.String("key eq \"key3\""),
+						VariationResult: testconvert.String("var2"),
+					},
+				},
+				DefaultRule: &flag.Rule{
+					VariationResult: testconvert.String("var1"),
+				},
+				Scheduled: &[]flag.ScheduledStep{
+					{
+						Date: testconvert.Time(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)),
+						InternalFlag: flag.InternalFlag{
+							DefaultRule: &flag.Rule{
+								VariationResult: testconvert.String("var2"),
+							},
+						},
+					},
+				},
+				Experimentation: &dto.ExperimentationDto{
+					Start: testconvert.Time(time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)),
+					End:   testconvert.Time(time.Date(2022, 1, 2, 0, 0, 0, 0, time.UTC)),
+				},
+				Metadata:    &map[string]any{"key": "value"},
+				TrackEvents: testconvert.Bool(true),
+				Disable:     testconvert.Bool(false),
+				Version:     testconvert.String("v1"),
+			},
+		},
+		{
+			name: "nil experimentation",
+			input: flag.InternalFlag{
+				Experimentation: nil,
+				Version:         testconvert.String("v1"),
+			},
+			expected: dto.DTO{
+				Experimentation: &dto.ExperimentationDto{},
+				Version:         testconvert.String("v1"),
+			},
+		},
+		{
+			name:  "empty input",
+			input: flag.InternalFlag{},
+			expected: dto.DTO{
+				Experimentation: &dto.ExperimentationDto{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := dto.ConvertInternalFlagToDto(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add `ConvertInternalFlagToDto` reverse converter to `modules/core/dto/converter.go`.

The existing `ConvertDtoToInternalFlag` converts from DTO → internal representation, but there was no reverse path. This adds `ConvertInternalFlagToDto` (InternalFlag → DTO), needed by the upcoming manifest endpoint feature.

**How to test:**
```bash
cd modules/core && go test ./...
```

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)