### PR TITLE
docs: add AI tools page and blog post for community skills and MCP server

### DIFF
--- a/website/blog/2026-05-02-ai-tooling-go-feature-flag/index.md
+++ b/website/blog/2026-05-02-ai-tooling-go-feature-flag/index.md
@@ -1,0 +1,123 @@
+---
+title: "AI Tooling for GO Feature Flag and OpenFeature"
+description: Community-built skills and an MCP server that improve the AI-assisted developer experience when working with GO Feature Flag and OpenFeature.
+date: 2026-05-02
+authors: [thomaspoignant]
+tags: [openfeature, ai, developer-experience, community]
+image: https://gofeatureflag.org/assets/images/banner-d245b9f91cecf0c12be153b14acaeb35.png
+---
+![Banner](banner.png)
+
+AI coding assistants have become a regular part of the developer workflow — writing boilerplate,
+suggesting configurations, explaining APIs. But when it comes to feature flags, generic AI often
+gets the details wrong: incorrect flag schema, outdated OpenFeature SDK patterns, or relay proxy
+configuration that doesn't quite match what GO Feature Flag expects.
+
+Community members have built tools that fix this — injecting domain knowledge directly into your
+AI assistant so it generates accurate, idiomatic code from the start.
+
+<!-- truncate -->
+
+## Skills: Teaching your AI assistant about GO Feature Flag and OpenFeature
+
+Skills are bundles of domain knowledge you install into your AI assistant. Once installed, your
+assistant understands the specifics of GO Feature Flag and OpenFeature without you having to
+paste documentation or correct hallucinations.
+
+Both skills are available from the [laurigates/claude-plugins](https://github.com/laurigates/claude-plugins)
+repository and are installed using the `npx playbooks` CLI.
+
+### GO Feature Flag Skill
+
+This skill covers the GO Feature Flag flag format (YAML/JSON/TOML), targeting rules and operators,
+rollout strategies (progressive, scheduled, A/B), relay proxy configuration, and deployment patterns.
+
+```shell
+npx playbooks add skill laurigates/claude-plugins --skill go-feature-flag
+```
+
+After installing, your AI assistant can generate correct flag configurations, suggest appropriate
+rollout strategies, and help you configure the relay proxy without needing to look up the schema.
+
+### OpenFeature Skill
+
+This skill covers the OpenFeature vendor-agnostic SDK API — initialization, client usage,
+evaluation context, hooks, and provider patterns across supported languages.
+
+```shell
+npx playbooks add skill laurigates/claude-plugins --skill openfeature
+```
+
+With this skill installed, your AI assistant understands how to wire up providers, construct
+evaluation context, and follow OpenFeature best practices regardless of which backend you're using.
+
+---
+
+## OpenFeature MCP Server: Live flag evaluation in your editor
+
+The [OpenFeature MCP Server](https://openfeature.dev/docs/reference/other-technologies/mcp/)
+brings GO Feature Flag closer to your editor through the
+[Model Context Protocol](https://modelcontextprotocol.io/) — a standard that lets AI tools
+call external services as part of their reasoning.
+
+It provides two capabilities:
+
+- **SDK installation guidance** — get setup instructions for OpenFeature SDKs across languages
+  and frameworks, directly in your AI conversation
+- **Live flag evaluation** — evaluate feature flags via OFREP against a running GO Feature Flag
+  relay proxy, without leaving your editor
+
+### Install
+
+**Via the Claude Code CLI:**
+```shell
+claude mcp add --transport stdio openfeature npx -y @openfeature/mcp
+```
+
+**Via JSON config** (compatible with Claude Code, Cursor, VS Code, and other MCP-supporting tools):
+```json
+{
+  "mcpServers": {
+    "OpenFeature": {
+      "command": "npx",
+      "args": ["-y", "@openfeature/mcp"]
+    }
+  }
+}
+```
+
+### Configure for live evaluation
+
+To enable flag evaluation against your relay proxy, set the following environment variables
+(or add them to `~/.openfeature-mcp.json`):
+
+| Variable | Description |
+|---|---|
+| `OPENFEATURE_OFREP_BASE_URL` | Your relay proxy endpoint (e.g. `http://localhost:1031`) |
+| `OPENFEATURE_OFREP_BEARER_TOKEN` | Bearer token authentication |
+| `OPENFEATURE_OFREP_API_KEY` | API key authentication |
+
+---
+
+## Putting it all together
+
+The skills and the MCP server address different parts of the workflow. Skills improve code
+generation — your AI assistant produces accurate flag configurations and correct SDK usage
+from the first attempt. The MCP server adds runtime awareness — your assistant can evaluate
+flags against a live relay proxy and suggest SDK setup for the language you're working in.
+
+Together, they close the loop: write a flag configuration, deploy it to the relay proxy,
+and verify its behavior, all without leaving your editor.
+
+---
+
+> **Note:** These tools are community contributions and are not officially maintained by the
+> GO Feature Flag project. For issues, questions, or contributions, refer to the respective
+> project repositories. Full install details are available in the
+> [AI Tools documentation page](/docs/tooling/ai-tools).
+
+If you try these tools, share your feedback on
+[GitHub](https://github.com/thomaspoignant/go-feature-flag) or in the
+[CNCF Slack #openfeature channel](https://cloud-native.slack.com/archives/C0344AANLA1).
+The more people experiment with AI-assisted feature flag workflows, the better these tools
+will get.

--- a/website/docs/tooling/ai-tools.mdx
+++ b/website/docs/tooling/ai-tools.mdx
@@ -1,0 +1,76 @@
+---
+sidebar_position: 80
+description: Community AI tools for working with GO Feature Flag using your favorite AI assistant.
+---
+
+# 🤖 AI Tools
+
+Community-maintained tools that improve the AI-assisted developer experience when working with GO Feature Flag.
+
+:::info Community Tools
+All tools listed on this page are community contributions and are **not officially maintained by the GO Feature Flag project**. For issues or contributions, please refer to the respective project repositories.
+:::
+
+## Skills
+
+Skills add domain knowledge about GO Feature Flag and OpenFeature directly into your favorite AI tool, enabling it to generate accurate flag configurations, deployment patterns, and SDK usage without hallucinating syntax.
+
+Skills are installed using the [playbooks](https://github.com/laurigates/claude-plugins) CLI.
+
+### GO Feature Flag Skill
+
+Teaches your AI assistant about GO Feature Flag flag formats, relay proxy configuration, targeting rules, rollout strategies, and deployment patterns.
+
+- **Source**: [laurigates/claude-plugins — go-feature-flag](https://github.com/laurigates/claude-plugins/tree/main/configure-plugin/skills/go-feature-flag)
+
+```shell
+npx playbooks add skill laurigates/claude-plugins --skill go-feature-flag
+```
+
+### OpenFeature Skill
+
+Teaches your AI assistant about the OpenFeature SDK API, providers, evaluation context, hooks, and best practices.
+
+- **Source**: [laurigates/claude-plugins — openfeature](https://github.com/laurigates/claude-plugins/tree/main/configure-plugin/skills/openfeature)
+
+```shell
+npx playbooks add skill laurigates/claude-plugins --skill openfeature
+```
+
+---
+
+## OpenFeature MCP Server
+
+The [OpenFeature MCP Server](https://openfeature.dev/docs/reference/other-technologies/mcp/) is a [Model Context Protocol](https://modelcontextprotocol.io/) server that gives AI assistants two capabilities:
+
+- **SDK installation guidance** — get setup instructions for OpenFeature SDKs across languages and frameworks
+- **Live flag evaluation** — evaluate feature flags via OFREP against a running GO Feature Flag relay proxy
+
+### Install
+
+**Via Claude Code CLI:**
+```shell
+claude mcp add --transport stdio openfeature npx -y @openfeature/mcp
+```
+
+**Via JSON config** (Claude Code, Cursor, VS Code, and other MCP-compatible AI tools):
+```json
+{
+  "mcpServers": {
+    "OpenFeature": {
+      "command": "npx",
+      "args": ["-y", "@openfeature/mcp"]
+    }
+  }
+}
+```
+
+### Configure for Flag Evaluation
+
+To enable live flag evaluation, point the MCP server at your relay proxy using environment variables or `~/.openfeature-mcp.json`:
+
+| Variable | Description |
+|---|---|
+| `OPENFEATURE_OFREP_BASE_URL` | Your relay proxy endpoint (e.g. `http://localhost:1031`) |
+| `OPENFEATURE_OFREP_BEARER_TOKEN` | Bearer token authentication |
+| `OPENFEATURE_OFREP_API_KEY` | API key authentication |


### PR DESCRIPTION
## Description

- **What was the problem?** No documentation existed for community-built AI tools (skills and MCP server) that improve the developer experience when working with GO Feature Flag and OpenFeature.
- **How it is resolved?** Added a new documentation page under the Tools section listing available community AI tools with install commands and a community disclaimer. Also added a blog post introducing the tools and explaining how they work together.
- **How can we test the change?** Run `make watch-doc` and verify the new page appears under "🛠️ Tools" in the sidebar, and the blog post appears in the blog list.
- **Breaking changes:** None.

## Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)