### PR TITLE
fix(relayproxy): graceful shutdown on Ctrl+C so the port is freed

### DIFF
--- a/cmd/relayproxy/api/server.go
+++ b/cmd/relayproxy/api/server.go
@@ -216,7 +216,7 @@ func (s *Server) startAsHTTPServer(ctx context.Context) {
 
 	go func() {
 		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
 		if err := s.apiEcho.Shutdown(shutdownCtx); err != nil {
 			s.zapLog.Error("error shutting down api server", zap.Error(err))

--- a/cmd/relayproxy/api/server.go
+++ b/cmd/relayproxy/api/server.go
@@ -174,7 +174,7 @@ func (s *Server) startUnixSocketServer(ctx context.Context) {
 	// Start a http server for monitoring if monitoringport is configured
 	if s.isMonitoringPortConfigured() {
 		go s.startMonitoringServer()
-		defer func() { _ = s.monitoringEcho.Close() }()
+		defer func() { _ = s.monitoringEcho.Shutdown(ctx) }()
 	}
 
 	lc := net.ListenConfig{}
@@ -205,7 +205,7 @@ func (s *Server) startUnixSocketServer(ctx context.Context) {
 func (s *Server) startAsHTTPServer(ctx context.Context) {
 	if s.isMonitoringPortConfigured() {
 		go s.startMonitoringServer()
-		defer func() { _ = s.monitoringEcho.Close() }()
+		defer func() { _ = s.monitoringEcho.Shutdown(ctx) }()
 	}
 
 	address := fmt.Sprintf("%s:%d", s.config.ServerHost(), s.config.ServerPort(s.zapLog))

--- a/cmd/relayproxy/api/server.go
+++ b/cmd/relayproxy/api/server.go
@@ -7,7 +7,10 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/labstack/echo-contrib/echoprometheus"
@@ -144,13 +147,16 @@ func (s *Server) StartWithContext(ctx context.Context) {
 		// we can continue because otel is not mandatory to start the server
 	}
 
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
 	switch s.config.ServerMode(s.zapLog) {
 	case config.ServerModeLambda:
 		s.startAwsLambda()
 	case config.ServerModeUnixSocket:
 		s.startUnixSocketServer(ctx)
 	default:
-		s.startAsHTTPServer()
+		s.startAsHTTPServer(ctx)
 	}
 }
 
@@ -196,8 +202,7 @@ func (s *Server) startUnixSocketServer(ctx context.Context) {
 }
 
 // startAsHTTPServer launch the API server
-func (s *Server) startAsHTTPServer() {
-	// starting the monitoring server on a different port if configured
+func (s *Server) startAsHTTPServer(ctx context.Context) {
 	if s.isMonitoringPortConfigured() {
 		go s.startMonitoringServer()
 		defer func() { _ = s.monitoringEcho.Close() }()
@@ -208,6 +213,15 @@ func (s *Server) startAsHTTPServer() {
 		"Starting go-feature-flag relay proxy ...",
 		zap.String("address", address),
 		zap.String("version", s.config.Version))
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := s.apiEcho.Shutdown(shutdownCtx); err != nil {
+			s.zapLog.Error("error shutting down api server", zap.Error(err))
+		}
+	}()
 
 	err := s.apiEcho.Start(address)
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -247,16 +261,14 @@ func (s *Server) Stop(ctx context.Context) {
 	}
 
 	if s.monitoringEcho != nil {
-		err = s.monitoringEcho.Close()
-		if err != nil {
-			s.zapLog.Fatal("impossible to stop monitoring", zap.Error(err))
+		if err = s.monitoringEcho.Shutdown(ctx); err != nil {
+			s.zapLog.Error("error stopping monitoring", zap.Error(err))
 		}
 	}
 
 	if s.apiEcho != nil {
-		err = s.apiEcho.Close()
-		if err != nil {
-			s.zapLog.Fatal("impossible to stop go-feature-flag relay proxy", zap.Error(err))
+		if err = s.apiEcho.Shutdown(ctx); err != nil {
+			s.zapLog.Error("error stopping relay proxy", zap.Error(err))
 		}
 	}
 }

--- a/cmd/relayproxy/api/server.go
+++ b/cmd/relayproxy/api/server.go
@@ -214,21 +214,25 @@ func (s *Server) startAsHTTPServer(ctx context.Context) {
 		zap.String("address", address),
 		zap.String("version", s.config.Version))
 
+	shutdownDone := make(chan struct{})
 	// nolint:gosec
 	go func() {
 		<-ctx.Done()
-		// we use a background context because we want to shutdown the server even if the context is cancelled.
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := s.apiEcho.Shutdown(shutdownCtx); err != nil {
 			s.zapLog.Error("error shutting down api server", zap.Error(err))
 		}
+		close(shutdownDone)
 	}()
 
 	err := s.apiEcho.Start(address)
 	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		s.zapLog.Fatal("Error starting relay proxy", zap.Error(err))
 	}
+
+	// Wait for Shutdown to finish draining connections before returning.
+	<-shutdownDone
 }
 
 func (s *Server) startMonitoringServer() {

--- a/cmd/relayproxy/api/server.go
+++ b/cmd/relayproxy/api/server.go
@@ -214,9 +214,11 @@ func (s *Server) startAsHTTPServer(ctx context.Context) {
 		zap.String("address", address),
 		zap.String("version", s.config.Version))
 
+	// nolint:gosec
 	go func() {
 		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		// we use a background context because we want to shutdown the server even if the context is cancelled.
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := s.apiEcho.Shutdown(shutdownCtx); err != nil {
 			s.zapLog.Error("error shutting down api server", zap.Error(err))

--- a/cmd/relayproxy/api/server_test.go
+++ b/cmd/relayproxy/api/server_test.go
@@ -1120,3 +1120,75 @@ func Test_NativeHistograms_Enabled(t *testing.T) {
 		}
 	}
 }
+
+func Test_PortFreedAfterShutdown(t *testing.T) {
+	// Pick a free port.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	proxyConf := &config.Config{
+		CommonFlagSet: config.CommonFlagSet{
+			Retrievers: &[]retrieverconf.RetrieverConf{
+				{
+					Kind: "file",
+					Path: "../../../testdata/flag-config.yaml",
+				},
+			},
+		},
+		Server: config.Server{
+			Mode: config.ServerModeHTTP,
+			Port: port,
+		},
+	}
+
+	l := log.InitLogger()
+	defer func() { _ = l.ZapLogger.Sync() }()
+
+	wsService := service.NewWebsocketService()
+
+	flagsetManager, err := service.NewFlagsetManager(proxyConf, l.ZapLogger, nil)
+	require.NoError(t, err)
+
+	services := service.Services{
+		MonitoringService: service.NewMonitoring(flagsetManager),
+		WebsocketService:  wsService,
+		FlagsetManager:    flagsetManager,
+	}
+
+	s := api.New(proxyConf, services, l.ZapLogger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.StartWithContext(ctx)
+		close(done)
+	}()
+
+	// Wait for the server to be ready.
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", port))
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Cancel the context to simulate Ctrl+C.
+	cancel()
+	wsService.Close()
+
+	// Wait for StartWithContext to return.
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("server did not stop within 10 seconds")
+	}
+
+	// Verify the port is free by binding to it again.
+	ln2, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	require.NoError(t, err, "port %d should be free after shutdown", port)
+	ln2.Close()
+}

--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -96,7 +96,6 @@ func main() {
 
 	// Init services
 	wsService := service.NewWebsocketService()
-	defer wsService.Close() // close all the open connections
 	prometheusNotifier := metric.NewPrometheusNotifier(metricsV2)
 	proxyNotifier := service.NewNotifierWebsocket(wsService)
 
@@ -120,11 +119,15 @@ func main() {
 	}
 	// Init API server
 	apiServer := api.New(proxyConf, services, logger.ZapLogger)
+
+	// Defers run LIFO: streaming clients disconnect first, then HTTP server stops.
 	defer func() {
 		logger.ZapLogger.Info("Stopping API server")
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		apiServer.Stop(ctx)
 	}()
+	defer wsService.Close()
+
 	apiServer.StartWithContext(context.Background())
 }

--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -125,8 +125,8 @@ func main() {
 		logger.ZapLogger.Info("Stopping API server")
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		apiServer.Stop(ctx)
 		wsService.Close()
+		apiServer.Stop(ctx)
 	}()
 	apiServer.StartWithContext(context.Background())
 }

--- a/cmd/relayproxy/main.go
+++ b/cmd/relayproxy/main.go
@@ -126,8 +126,7 @@ func main() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		apiServer.Stop(ctx)
+		wsService.Close()
 	}()
-	defer wsService.Close()
-
 	apiServer.StartWithContext(context.Background())
 }


### PR DESCRIPTION
## Description

- **Problem**: `startAsHTTPServer` ignored the signal context (`_ context.Context`), so Ctrl+C cancelled the context but nobody told Echo to stop. The server kept blocking, requiring a second Ctrl+C which killed the process abruptly — defers never ran and the port stayed occupied.

- **Resolution**: A goroutine now watches `ctx.Done()` and calls `echo.Shutdown()` with a 5-second timeout. `Stop()` uses `Shutdown` instead of `Close` for graceful connection drain, and `Fatal` is downgraded to `Error` during shutdown so subsequent defers still run. Defer order in `main.go` is corrected so streaming services close before the HTTP server stops.

- **Testing**: New `Test_PortFreedAfterShutdown` starts the server, cancels the context (simulating Ctrl+C), and verifies the port can be re-bound immediately.


## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)