### PR TITLE
docs: add Buzzvil to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -17,3 +17,4 @@ Thank you for trusting the `go-feature-flag` and using it in your organization.
 | LandsEnd             | https://www.landsend.com                              | FF for backend and frontend apps               |
 | Grafana Labs         | https://grafana.com                                   | GOFF relay with OpenFeature clients            |
 | Miro                 | https://www.miro.com                                  | Feature flags in general with OpenFeature      | 
+| Buzzvil              | https://www.buzzvil.com/en                            | FF for backend/frontend                        |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -17,4 +17,4 @@ Thank you for trusting the `go-feature-flag` and using it in your organization.
 | LandsEnd             | https://www.landsend.com                              | FF for backend and frontend apps               |
 | Grafana Labs         | https://grafana.com                                   | GOFF relay with OpenFeature clients            |
 | Miro                 | https://www.miro.com                                  | Feature flags in general with OpenFeature      | 
-| Buzzvil              | https://www.buzzvil.com/en                            | FF for backend/frontend                        |
+| Buzzvil              | https://www.buzzvil.com/en                            | Feature flags for backend and frontend         |


### PR DESCRIPTION
## Description

Adding **Buzzvil** to the list of `go-feature-flag` adopters.

- **Organization:** Buzzvil
- **Website:** https://www.buzzvil.com/en
- **Description of use:** FF for backend/frontend

## Checklist
- [x] I have updated the documentation (`README.md` and `/website/docs`) (N/A — only `ADOPTERS.md` is impacted)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)