### PR TITLE
ci: Disable Govulncheck in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,24 +276,24 @@ jobs:
           cache: false
       - run: make tidy-check
 
-  Govulncheck:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-      - name: Setup go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-          check-latest: true
-          cache: false
-      - name: Run govulncheck
-        run: make vuln-check
+  # Govulncheck:
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  #       with:
+  #         fetch-depth: 1
+  #         persist-credentials: false
+  #     - name: Setup go
+  #       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+  #       with:
+  #         go-version-file: go.mod
+  #         check-latest: true
+  #         cache: false
+  #     - name: Run govulncheck
+  #       run: make vuln-check
 
   WasmBuild:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Comment out the Govulncheck job in the CI workflow because it is to noisy for now.