### PR TITLE
ci: bump codecov-action to v7.0.0 to fix GPG signature verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           cache: false
       - run: make coverage
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description

**What was the problem?**

The `Coverage` job in `ci.yml` was failing on every run at the "Upload coverage reports to Codecov" step, blocking all CI:

```
gpg: no valid OpenPGP data found.
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
    Exiting...
##[error]Process completed with exit code 1.
```

The workflow pinned `codecov/codecov-action` at **v6.0.1**, which imports the Codecov GPG public key from the `codecovsecurity` keybase account. Codecov **deleted** that account during a keybase migration (see the [v7.0.0 release notes](https://github.com/codecov/codecov-action/releases/tag/v7.0.0)). With no key to import, the downloaded CLI binary's signature can't be verified and the step exits 1. Since `fail_ci_if_error: true`, this blocked every CI run.

**How it is resolved?**

Bump `codecov/codecov-action` from v6.0.1 to **v7.0.0** (pinned to commit `fb8b3582c8e4def4969c97caa2f19720cb33a72f`), which imports the key from the new `codecovsecops` account and restores signature verification. No input changes — `fail_ci_if_error` and `token` are unchanged.

Note: v7.0.0 and Codecov's v6.0.2 backport point to the same commit; v7.0.0 was chosen to track the current major line.

**How can we test the change?**

The Coverage job in this PR's CI run now downloads the key, verifies the signature, and uploads the report (step goes green).

## Closes issue(s)

Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)