### PR TITLE
chore: bump go.mod to go 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thomaspoignant/go-feature-flag
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cloud.google.com/go/pubsub v1.50.2


### PR DESCRIPTION
## Description
<!--
Please add a description of what your pull request is doing.
-->
This PR bumps the `go` directive in the main package's `go.mod` from `1.26.3` to `1.26.4`, the latest available Go release.

- **What was the problem?** The main package was pinned to Go `1.26.3`, one patch behind the latest minor/patch release.
- **How it is resolved?** Updated the `go` directive in the root `go.mod` to `1.26.4`.
- **How can we test the change?** Run `go build ./...` — the project builds successfully against Go `1.26.4`.

No source code changes were required; this is a version bump only. Other modules (`modules/core`, `cmd/wasm`) were intentionally left untouched as the request targeted the main package.

## Closes issue(s)
Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)

https://claude.ai/code/session_01AXoWU3sBk6sJy8HwzmGWEk

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXoWU3sBk6sJy8HwzmGWEk)_