### PR TITLE
docs(website): redesign homepage with new hero, comparison, and architecture sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ volume
 
 go.work
 go.work.sum
+.gstack/

--- a/website/data/integrations.js
+++ b/website/data/integrations.js
@@ -150,7 +150,7 @@ export const integrations = {
       logo: azbloblogo,
       docLink: 'azure-blob-storage',
     },
-    
+
     {
       name: 'File System',
       description: 'Export evaluation data to a directory in your file system.',

--- a/website/data/sdk.js
+++ b/website/data/sdk.js
@@ -236,7 +236,7 @@ export const sdk = [
     ),
   },
   {
-    key: 'angular', 
+    key: 'angular',
     language: 'typescript',
     name: 'Angular',
     paradigm: ['Client'],

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -360,19 +360,17 @@ const config = {
             position: 'right',
           },
           {
+            type: 'custom-githubStars',
+            position: 'right',
+            className: 'navbar__right',
+          },
+          {
             type: 'search',
             position: 'right',
           },
           {
             type: 'docsVersionDropdown',
             position: 'right',
-            dropdownItemsAfter: [{to: '/versions', label: 'All versions'}],
-          },
-          {
-            href: 'https://github.com/thomaspoignant/go-feature-flag',
-            position: 'right',
-            className: 'header-github-link navbar__right',
-            'aria-label': 'GitHub repository',
             dropdownItemsAfter: [{to: '/versions', label: 'All versions'}],
           },
           {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -198,6 +198,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz",
       "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.52.1",
         "@algolia/requester-browser-xhr": "5.52.1",
@@ -348,6 +349,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2198,6 +2200,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2220,6 +2223,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2329,6 +2333,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2750,6 +2755,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3809,6 +3815,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
       "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/logger": "3.10.1",
@@ -4314,7 +4321,6 @@
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -4325,7 +4331,6 @@
       "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -4350,7 +4355,6 @@
       "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -4447,7 +4451,6 @@
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
@@ -4463,7 +4466,6 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -4478,8 +4480,7 @@
       "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
@@ -5092,6 +5093,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -6021,6 +6023,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -6675,6 +6678,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7187,6 +7191,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7263,6 +7268,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7327,6 +7333,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
       "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.18.1",
         "@algolia/client-abtesting": "5.52.1",
@@ -7985,6 +7992,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8317,6 +8325,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
       "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "12.0.0",
         "@chevrotain/gast": "12.0.0",
@@ -8893,6 +8902,7 @@
       "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -9106,6 +9116,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9436,6 +9447,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
       "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -9845,6 +9857,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10091,8 +10104,7 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -10309,7 +10321,6 @@
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -10864,6 +10875,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -11108,7 +11120,6 @@
       "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -11126,7 +11137,6 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -11171,7 +11181,6 @@
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -11529,8 +11538,7 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -11642,7 +11650,6 @@
       "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -11755,7 +11762,6 @@
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -11782,7 +11788,6 @@
       "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
@@ -11797,8 +11802,7 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -11939,8 +11943,7 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -12110,7 +12113,6 @@
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -12190,7 +12192,6 @@
       "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -12207,7 +12208,6 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12312,8 +12312,7 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/gray-matter": {
       "version": "4.0.3",
@@ -13207,7 +13206,6 @@
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -14137,8 +14135,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json2toml": {
       "version": "6.1.2",
@@ -14339,7 +14336,6 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -14414,7 +14410,6 @@
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -14472,8 +14467,7 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -17009,6 +17003,7 @@
       "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.15.3.tgz",
       "integrity": "sha512-6+ZSYDs5zgH5CdGfEU2q2Lsa5PztVryL1ys7kAImTU25n2A9LAMj/yneVsQpd03MfwMLDQF+7kakJR9Z+cQxSw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mobx"
@@ -17126,8 +17121,7 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.4",
@@ -17672,7 +17666,6 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -17735,7 +17728,6 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -17790,7 +17782,6 @@
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -17807,7 +17798,6 @@
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -18063,7 +18053,6 @@
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -18089,7 +18078,6 @@
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18379,6 +18367,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -19391,6 +19380,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -19938,7 +19928,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -19949,6 +19938,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -20281,6 +20271,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -20308,6 +20299,7 @@
       "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-16.0.1.tgz",
       "integrity": "sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-dnd/invariant": "^4.0.1",
         "@react-dnd/shallowequal": "^4.0.1",
@@ -20338,6 +20330,7 @@
       "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz",
       "integrity": "sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dnd-core": "^16.0.1"
       }
@@ -20347,6 +20340,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -20393,6 +20387,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.75.0.tgz",
       "integrity": "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -20437,6 +20432,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -20479,6 +20475,7 @@
       "resolved": "https://registry.npmjs.org/react-querybuilder/-/react-querybuilder-8.16.0.tgz",
       "integrity": "sha512-fERnSBAkXpMJTp4QqTKzunalZfHEeftRwLVr52DHkDsO+/nirREvLmWp3w4fNtN4FJrGgspIFbf3Vi5aOR4h4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-querybuilder/core": "^8.16.0",
         "@reduxjs/toolkit": "^2.11.2",
@@ -20563,6 +20560,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -20585,7 +20583,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-querybuilder/node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -20601,6 +20600,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -21521,7 +21521,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -21752,6 +21751,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -22870,6 +22870,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
       "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
         "css-to-react-native": "3.2.0",
@@ -23235,8 +23236,7 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -23340,6 +23340,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23453,7 +23454,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -23502,7 +23504,6 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -24597,6 +24598,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -25087,7 +25089,6 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25194,8 +25195,7 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -25304,6 +25304,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
       "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -25373,7 +25374,6 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },

--- a/website/src/components/home/HomeHeader/index.js
+++ b/website/src/components/home/HomeHeader/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import styles from './styles.module.css';
 import Link from '@docusaurus/Link';
@@ -6,6 +6,37 @@ import clsx from 'clsx';
 
 export function HomeHeader() {
   const {siteConfig} = useDocusaurusContext();
+  const [githubStars, setGithubStars] = useState(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const shieldsUrl = `https://img.shields.io/github/stars/${siteConfig.organizationName}/${siteConfig.projectName}.json`;
+
+    fetch(shieldsUrl, {signal: controller.signal})
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`shields.io responded with ${response.status}`);
+        }
+        return response.json();
+      })
+      .then(data => {
+        if (data?.message) {
+          setGithubStars(data.message);
+        }
+      })
+      .catch(error => {
+        if (error.name !== 'AbortError') {
+          console.error('Failed to fetch GitHub star count:', error);
+        }
+      });
+
+    return () => controller.abort();
+  }, [siteConfig.organizationName, siteConfig.projectName]);
+
+  const githubLinkTitle = githubStars
+    ? `View on GitHub (${githubStars} stars)`
+    : 'View on GitHub';
+
   return (
     <section className={styles.hero}>
       <div className={styles.heroShape}>
@@ -48,8 +79,8 @@ export function HomeHeader() {
         <div className="row">
           <div className="col col--6">
             <div className={styles.heroContent}>
-              <span className="text-gray-800 dark:text-gray-50 text-5xl font-poppins font-bold tracking-[-0.18rem]">
-                GO Feature Flag
+              <span className="text-gray-800 dark:text-gray-50 text-6xl font-poppins font-bold tracking-[-0.18rem]">
+                {`${siteConfig.title}`}
               </span>
               <br />
               <span className="text-titles-500 text-[2.8rem] font-poppins font-bold tracking-[-0.18rem] leading-10">
@@ -57,21 +88,13 @@ export function HomeHeader() {
               </span>
               <p>
                 <span className={styles.descriptionFirstLine}>
-                  Ship Faster, Reduce Risk, and Build Scale
+                  A lightweight, self-hosted feature flag solution built on the
+                  OpenFeature standard.
                 </span>
                 <br />
-                Feature flags lets you modify system behavior without changing
-                code. Deploy every day, release when you are ready. Reduce risk
-                by releasing your features progressively.
+                One container, one config file, <u>no database</u> required - GO
+                Feature Flag works with the softwares you already use.
               </p>
-            </div>
-            <div className={styles.ghStars}>
-              <Link to={siteConfig.customFields.github}>
-                <img
-                  alt="GitHub Repo stars"
-                  src="https://img.shields.io/github/stars/thomaspoignant/go-feature-flag?style=social"
-                />
-              </Link>
             </div>
             <div className={'text-center items-center gap-30'}>
               <div className="relative inline-flex group">
@@ -87,11 +110,18 @@ export function HomeHeader() {
               <div className="relative inline-flex group ml-5 mt-4">
                 <div className="border-gray-700 border-4 absolute transitiona-all duration-1000 opacity-70 -inset-px bg-gradient-to-r from-[#44BCFF] via-[#FF44EC] to-[#FF675E] rounded-xl blur-lg group-hover:opacity-100 group-hover:-inset-1 group-hover:duration-200 animate-tilt hover:no-underline"></div>
                 <Link
-                  to={'/docs/getting-started'}
-                  title="Get Started"
+                  to={siteConfig.customFields.github}
+                  title={githubLinkTitle}
                   className="hover:no-underline hover:text-gray-700 relative inline-flex items-center justify-center px-8 py-4 text-lg font-bold text-white transition-all duration-200 bg-[#9fbeb3] font-pj rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900">
-                  <i className="fa-solid fa-circle-right mr-4"></i>
-                  Get Started
+                  <i
+                    className="fa-brands fa-github mr-4"
+                    aria-hidden="true"></i>
+                  View on GitHub
+                  {githubStars && (
+                    <span className="ml-2 font-semibold opacity-90">
+                      ★ {githubStars}
+                    </span>
+                  )}
                 </Link>
               </div>
             </div>

--- a/website/src/components/home/HomeHeader/index.js
+++ b/website/src/components/home/HomeHeader/index.js
@@ -3,8 +3,27 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import styles from './styles.module.css';
 import Link from '@docusaurus/Link';
 import clsx from 'clsx';
+import {FaStar, FaArrowAltCircleRight} from 'react-icons/fa';
+import {sdk} from '@site/data/sdk';
 
-export function HomeHeader() {
+function GetStartedButton() {
+  return (
+    <div className="relative inline-flex group">
+      <div className="relative inline-flex group">
+        <div className="absolute transitiona-all duration-1000 opacity-70 -inset-px bg-gradient-to-r from-[#44BCFF] via-[#FF44EC] to-[#FF675E] rounded-xl blur-lg group-hover:opacity-100 group-hover:-inset-1 group-hover:duration-200 animate-tilt"></div>
+        <Link
+          to={'/docs/'}
+          title="Get Started with GO Feature Flag"
+          className="hover:no-underline hover:text-white relative inline-flex items-center justify-center px-8 py-4 text-lg font-bold text-white transition-all duration-200 bg-gray-900 font-pj rounded-xl overflow-hidden border-2 border-solid border-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900">
+          <FaArrowAltCircleRight className="mr-2" />
+          Get Started in 60 seconds
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function ViewOnGitHubButton() {
   const {siteConfig} = useDocusaurusContext();
   const [githubStars, setGithubStars] = useState(null);
 
@@ -38,102 +57,129 @@ export function HomeHeader() {
     : 'View on GitHub';
 
   return (
-    <section className={styles.hero}>
-      <div className={styles.heroShape}>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 898.595 671.33">
-          <g data-name="Group 1168">
-            <path
-              data-name="Path 1352"
-              d="M77.225.84S65.754 56.25 72.99 108.615c6.519 47.174 14.071 83.313 45.359 132.19s67.663 74.2 113.344 90.467c10.087 2.544 22.468 4.651 35.375 10.446 17.912 8.956 39.851 18.784 63.185 64.959 29.724 58.823 31.289 129.222 102.94 193.364 30.523 27.324 85.56 48.346 152.718 60.609 90.568 16.538 203.528 16.044 311.709-17.053 0-46.584-.016-642.734-.016-642.734z"
-              fill="#cdf7e7"
-            />
-            <path
-              data-name="Path 1353"
-              d="M4.946.863s-11.953 71.78 4.545 135.746 50.072 127.642 106.223 162.953c30.391 18.524 54.077 22.62 54.077 22.62s35.965 6.587 58.362 28.851 33.95 47.335 40.287 63.6 30.656 87.859 39.048 101.217 22.093 51.037 70.9 84.776 130.668 56.964 257.731 60.438 240.329-44.6 261.458-55.888"
-              fill="none"
-              stroke="#273437"
-              strokeLinecap="round"
-              strokeWidth="1.5"
-            />
-          </g>
-        </svg>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 266.025 234.723">
-          <g data-name="Group 1169">
-            <path
-              data-name="Path 1351"
-              d="M246.353.908s32.245 23.839 14.178 60.475-62.607 44.54-85.191 84.439-37.268 86.821-83.942 85.186c-36.9-1.289-90.335-44.54-90.335-44.54L1.188.657z"
-              fill="#cdf7e7"
-            />
-            <path
-              data-name="Path 1350"
-              d="M178.777.908s4.869 19.639 32.623 49.99 37.492 50.964 33.6 76.932-38.147 51.938-67.684 70.765-58.263 37.33-101.763 35.22c-40.1-1.945-59.9-27.777-71.327-57.935-.862-2.273-1.961-6.034-3.171-6.986"
-              fill="none"
-              stroke="#273437"
-              strokeLinecap="round"
-              strokeWidth="1.5"
-            />
-          </g>
-        </svg>
+    <div className="inline-flex">
+      <Link
+        to={siteConfig.customFields.github}
+        title={githubLinkTitle}
+        className="hover:no-underline inline-flex items-center justify-center px-8 py-3 text-lg font-bold text-gray-800 dark:text-gray-100 hover:text-white bg-transparent hover:bg-[#9fbeb3] border-2 border-solid border-[#9fbeb3] transition-all duration-200 font-pj rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900">
+        <i className="fa-brands fa-github mr-4" aria-hidden="true"></i>
+        View on GitHub
+        {githubStars && (
+          <span className="ml-2 font-semibold">
+            <div className="flex">
+              <FaStar className="w-6 h-6 mr-1" /> <span>{githubStars}</span>
+            </div>
+          </span>
+        )}
+      </Link>
+    </div>
+  );
+}
+
+function HeroBackgroundShapes() {
+  return (
+    <div className={styles.heroShape}>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 898.595 671.33">
+        <g data-name="Group 1168">
+          <path
+            data-name="Path 1352"
+            d="M77.225.84S65.754 56.25 72.99 108.615c6.519 47.174 14.071 83.313 45.359 132.19s67.663 74.2 113.344 90.467c10.087 2.544 22.468 4.651 35.375 10.446 17.912 8.956 39.851 18.784 63.185 64.959 29.724 58.823 31.289 129.222 102.94 193.364 30.523 27.324 85.56 48.346 152.718 60.609 90.568 16.538 203.528 16.044 311.709-17.053 0-46.584-.016-642.734-.016-642.734z"
+            fill="#cdf7e7"
+          />
+          <path
+            data-name="Path 1353"
+            d="M4.946.863s-11.953 71.78 4.545 135.746 50.072 127.642 106.223 162.953c30.391 18.524 54.077 22.62 54.077 22.62s35.965 6.587 58.362 28.851 33.95 47.335 40.287 63.6 30.656 87.859 39.048 101.217 22.093 51.037 70.9 84.776 130.668 56.964 257.731 60.438 240.329-44.6 261.458-55.888"
+            fill="none"
+            stroke="#273437"
+            strokeLinecap="round"
+            strokeWidth="1.5"
+          />
+        </g>
+      </svg>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 266.025 234.723">
+        <g data-name="Group 1169">
+          <path
+            data-name="Path 1351"
+            d="M246.353.908s32.245 23.839 14.178 60.475-62.607 44.54-85.191 84.439-37.268 86.821-83.942 85.186c-36.9-1.289-90.335-44.54-90.335-44.54L1.188.657z"
+            fill="#cdf7e7"
+          />
+          <path
+            data-name="Path 1350"
+            d="M178.777.908s4.869 19.639 32.623 49.99 37.492 50.964 33.6 76.932-38.147 51.938-67.684 70.765-58.263 37.33-101.763 35.22c-40.1-1.945-59.9-27.777-71.327-57.935-.862-2.273-1.961-6.034-3.171-6.986"
+            fill="none"
+            stroke="#273437"
+            strokeLinecap="round"
+            strokeWidth="1.5"
+          />
+        </g>
+      </svg>
+    </div>
+  );
+}
+
+function HeroCopy() {
+  const {siteConfig} = useDocusaurusContext();
+  return (
+    <div className={styles.heroContent}>
+      <span className="block text-base md:text-2xl font-poppins font-semibold tracking-tight text-titles-500 mb-2">
+        {`${siteConfig.title}`}
+      </span>
+      <h1 className="text-[2.25rem] md:text-[3.5rem] leading-[1.1] md:leading-[1.05] font-poppins font-extrabold tracking-[-0.08rem] md:tracking-[-0.18rem] text-gray-800 dark:text-gray-50 m-0 mb-5">
+        Open-source feature flags
+        <span className="text-titles-500"> —&nbsp;built on OpenFeature.</span>
+      </h1>
+      <p className="text-xl md:text-lg leading-relaxed font-normal mb-10 text-[color:var(--goff-main-ff-description)]">
+        The feature flag tool for the AI era: ship fast, roll out safely, roll
+        back instantly. Set up in minutes with no infrastructure to manage — and
+        it works with the stack you already use.
+      </p>
+    </div>
+  );
+}
+
+function HeroCTAs() {
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-4">
+      <GetStartedButton />
+      <ViewOnGitHubButton />
+    </div>
+  );
+}
+
+function HeroProofLine() {
+  return (
+    <p className="mt-6 text-center text-sm md:text-base text-gray-500 dark:text-gray-400">
+      100% OpenSource · MIT Licensed · Support{' '}
+      <span className="font-bold text-gray-900 dark:text-gray-100">
+        {sdk.length} languages & frameworks
+      </span>
+    </p>
+  );
+}
+
+function HeroLogo() {
+  const {siteConfig} = useDocusaurusContext();
+  return (
+    <div className="max-md:hidden">
+      <div className="hero-image">
+        <img src={siteConfig.customFields.logo} alt="go-feature-flag-logo" />
       </div>
+    </div>
+  );
+}
+
+export function HomeHeader() {
+  return (
+    <section className={styles.hero}>
+      <HeroBackgroundShapes />
       <div className={clsx('container', styles.container)}>
         <div className="row">
           <div className="col col--6">
-            <div className={styles.heroContent}>
-              <span className="text-gray-800 dark:text-gray-50 text-6xl font-poppins font-bold tracking-[-0.18rem]">
-                {`${siteConfig.title}`}
-              </span>
-              <br />
-              <span className="text-titles-500 text-[2.8rem] font-poppins font-bold tracking-[-0.18rem] leading-10">
-                {`${siteConfig.tagline}`}
-              </span>
-              <p>
-                <span className={styles.descriptionFirstLine}>
-                  A lightweight, self-hosted feature flag solution built on the
-                  OpenFeature standard.
-                </span>
-                <br />
-                One container, one config file, <u>no database</u> required - GO
-                Feature Flag works with the softwares you already use.
-              </p>
-            </div>
-            <div className={'text-center items-center gap-30'}>
-              <div className="relative inline-flex group">
-                <div className="absolute transitiona-all duration-1000 opacity-70 -inset-px bg-gradient-to-r from-[#44BCFF] via-[#FF44EC] to-[#FF675E] rounded-xl blur-lg group-hover:opacity-100 group-hover:-inset-1 group-hover:duration-200 animate-tilt"></div>
-                <Link
-                  to={siteConfig.customFields.github}
-                  title="Available on GitHub"
-                  className="hover:no-underline hover:text-gray-500 relative inline-flex items-center justify-center px-8 py-4 text-lg font-bold text-white transition-all duration-200 bg-gray-900 font-pj rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900">
-                  <i className="fa-brands fa-github mr-4"></i>
-                  Available on GitHub
-                </Link>
-              </div>
-              <div className="relative inline-flex group ml-5 mt-4">
-                <div className="border-gray-700 border-4 absolute transitiona-all duration-1000 opacity-70 -inset-px bg-gradient-to-r from-[#44BCFF] via-[#FF44EC] to-[#FF675E] rounded-xl blur-lg group-hover:opacity-100 group-hover:-inset-1 group-hover:duration-200 animate-tilt hover:no-underline"></div>
-                <Link
-                  to={siteConfig.customFields.github}
-                  title={githubLinkTitle}
-                  className="hover:no-underline hover:text-gray-700 relative inline-flex items-center justify-center px-8 py-4 text-lg font-bold text-white transition-all duration-200 bg-[#9fbeb3] font-pj rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900">
-                  <i
-                    className="fa-brands fa-github mr-4"
-                    aria-hidden="true"></i>
-                  View on GitHub
-                  {githubStars && (
-                    <span className="ml-2 font-semibold opacity-90">
-                      ★ {githubStars}
-                    </span>
-                  )}
-                </Link>
-              </div>
-            </div>
+            <HeroCopy />
+            <HeroCTAs />
+            <HeroProofLine />
           </div>
-          <div className="max-md:hidden">
-            <div className="hero-image">
-              <img
-                src={siteConfig.customFields.logo}
-                alt="go-feature-flag-logo"
-              />
-            </div>
-          </div>
+          <HeroLogo />
         </div>
       </div>
     </section>

--- a/website/src/components/home/HomeHeader/index.js
+++ b/website/src/components/home/HomeHeader/index.js
@@ -9,16 +9,14 @@ import {sdk} from '@site/data/sdk';
 function GetStartedButton() {
   return (
     <div className="relative inline-flex group">
-      <div className="relative inline-flex group">
-        <div className="absolute transitiona-all duration-1000 opacity-70 -inset-px bg-gradient-to-r from-[#44BCFF] via-[#FF44EC] to-[#FF675E] rounded-xl blur-lg group-hover:opacity-100 group-hover:-inset-1 group-hover:duration-200 animate-tilt"></div>
-        <Link
-          to={'/docs/'}
-          title="Get Started with GO Feature Flag"
-          className="hover:no-underline hover:text-white relative inline-flex items-center justify-center px-8 py-4 text-lg font-bold text-white transition-all duration-200 bg-gray-900 font-pj rounded-xl overflow-hidden border-2 border-solid border-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900">
-          <FaArrowAltCircleRight className="mr-2" />
-          Get Started in 60 seconds
-        </Link>
-      </div>
+      <div className="absolute transitiona-all duration-1000 opacity-70 -inset-px bg-gradient-to-r from-[#44BCFF] via-[#FF44EC] to-[#FF675E] rounded-xl blur-lg group-hover:opacity-100 group-hover:-inset-1 group-hover:duration-200 animate-tilt"></div>
+      <Link
+        to={'/docs/'}
+        title="Get Started with GO Feature Flag"
+        className="hover:no-underline hover:text-white relative inline-flex items-center justify-center px-8 py-4 text-lg font-bold text-white transition-all duration-200 bg-gray-900 font-pj rounded-xl overflow-hidden border-2 border-solid border-transparent focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900">
+        <FaArrowAltCircleRight className="mr-2" />
+        Get Started in 60 seconds
+      </Link>
     </div>
   );
 }

--- a/website/src/components/home/HomeHeader/styles.module.css
+++ b/website/src/components/home/HomeHeader/styles.module.css
@@ -42,14 +42,6 @@ svg:not(:root) {
   margin-left: auto;
 }
 
-.heroContent p {
-  font-size: 1.5rem;
-  line-height: 2rem;
-  font-weight: 400;
-  margin-bottom: 3rem;
-  color: var(--goff-main-ff-description);
-}
-
 .ghStars {
   text-align: center;
 }

--- a/website/src/components/home/HomeHeader/styles.module.css
+++ b/website/src/components/home/HomeHeader/styles.module.css
@@ -42,21 +42,75 @@ svg:not(:root) {
   margin-left: auto;
 }
 
-.heroContent p {
+.brandLine {
+  font-size: 1.25rem;
+  letter-spacing: -0.04rem;
+  line-height: 1.4;
+  margin: 0 0 0.75rem;
+}
+
+.heroHeadline {
+  font-size: clamp(1.75rem, 4.5vw, 2.85rem);
+  letter-spacing: -0.12rem;
+  line-height: 1.15;
+  margin: 0 0 1.25rem;
+}
+
+.heroSubhead {
   font-size: 1.05rem;
-  line-height: 2rem;
+  line-height: 1.75rem;
   font-weight: 400;
-  margin-bottom: 3rem;
+  margin: 0 0 2rem;
   color: var(--goff-main-ff-description);
 }
 
-.ghStars {
-  text-align: center;
+.ctaRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
 }
 
-.ghStars img {
-  margin-bottom: 1rem;
-  height: 1.8rem;
+.ctaPrimary,
+.ctaSecondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1rem 2rem;
+  font-family: Poppins, sans-serif;
+  font-size: 1.125rem;
+  font-weight: 700;
+  border-radius: 0.75rem;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.ctaPrimary {
+  color: #fff;
+  background-color: #111827;
+}
+
+.ctaPrimary:hover {
+  color: #fff;
+  background-color: #1f2937;
+}
+
+.ctaSecondary {
+  color: var(--ifm-font-color-base);
+  background-color: transparent;
+  border: 2px solid var(--ifm-color-emphasis-300);
+}
+
+.ctaSecondary:hover {
+  color: var(--ifm-font-color-base);
+  border-color: var(--ifm-color-emphasis-500);
+}
+
+.starCount {
+  font-size: 0.95rem;
+  font-weight: 600;
+  opacity: 0.85;
 }
 
 .availableGH {
@@ -68,15 +122,8 @@ svg:not(:root) {
   margin: 0.5rem;
 }
 
-.descriptionFirstLine{
-  font-weight: 100;
-  font-size: 1.4rem;
-  text-transform:capitalize;
-  filter: brightness(1.25);
-}
-
-.pushy__btnGoff{
-  background-color: var(--goff-main-subtitle-color)
+.pushy__btnGoff {
+  background-color: var(--goff-main-subtitle-color);
 }
 
 .goffMainSubtitle {
@@ -84,6 +131,6 @@ svg:not(:root) {
   font-family: Poppins, sans-serif;
   font-weight: 700;
   letter-spacing: -0.18rem;
-  font-size: 2.80rem;
+  font-size: 2.8rem;
   line-height: 2.5rem;
 }

--- a/website/src/components/home/HomeHeader/styles.module.css
+++ b/website/src/components/home/HomeHeader/styles.module.css
@@ -42,75 +42,21 @@ svg:not(:root) {
   margin-left: auto;
 }
 
-.brandLine {
-  font-size: 1.25rem;
-  letter-spacing: -0.04rem;
-  line-height: 1.4;
-  margin: 0 0 0.75rem;
-}
-
-.heroHeadline {
-  font-size: clamp(1.75rem, 4.5vw, 2.85rem);
-  letter-spacing: -0.12rem;
-  line-height: 1.15;
-  margin: 0 0 1.25rem;
-}
-
-.heroSubhead {
-  font-size: 1.05rem;
-  line-height: 1.75rem;
+.heroContent p {
+  font-size: 1.5rem;
+  line-height: 2rem;
   font-weight: 400;
-  margin: 0 0 2rem;
+  margin-bottom: 3rem;
   color: var(--goff-main-ff-description);
 }
 
-.ctaRow {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
+.ghStars {
+  text-align: center;
 }
 
-.ctaPrimary,
-.ctaSecondary {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.75rem;
-  padding: 1rem 2rem;
-  font-family: Poppins, sans-serif;
-  font-size: 1.125rem;
-  font-weight: 700;
-  border-radius: 0.75rem;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-}
-
-.ctaPrimary {
-  color: #fff;
-  background-color: #111827;
-}
-
-.ctaPrimary:hover {
-  color: #fff;
-  background-color: #1f2937;
-}
-
-.ctaSecondary {
-  color: var(--ifm-font-color-base);
-  background-color: transparent;
-  border: 2px solid var(--ifm-color-emphasis-300);
-}
-
-.ctaSecondary:hover {
-  color: var(--ifm-font-color-base);
-  border-color: var(--ifm-color-emphasis-500);
-}
-
-.starCount {
-  font-size: 0.95rem;
-  font-weight: 600;
-  opacity: 0.85;
+.ghStars img {
+  margin-bottom: 1rem;
+  height: 1.8rem;
 }
 
 .availableGH {
@@ -122,8 +68,8 @@ svg:not(:root) {
   margin: 0.5rem;
 }
 
-.pushy__btnGoff {
-  background-color: var(--goff-main-subtitle-color);
+.pushy__btnGoff{
+  background-color: var(--goff-main-subtitle-color)
 }
 
 .goffMainSubtitle {
@@ -131,6 +77,6 @@ svg:not(:root) {
   font-family: Poppins, sans-serif;
   font-weight: 700;
   letter-spacing: -0.18rem;
-  font-size: 2.8rem;
+  font-size: 2.80rem;
   line-height: 2.5rem;
 }

--- a/website/src/components/home/how-it-works/index.js
+++ b/website/src/components/home/how-it-works/index.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+
+export function HowItWorks() {
+  return (
+    <section
+      className="py-[3rem] text-center"
+      aria-labelledby="how-it-works-title">
+      <span
+        id="how-it-works-title"
+        className="text-gray-800 dark:text-gray-50 text-5xl font-poppins font-bold tracking-[-0.18rem]">
+        How it works?
+      </span>
+      <p className="mt-3 mb-8 max-w-3xl mx-auto text-gray-500 dark:text-gray-400 text-[1.05rem] leading-relaxed">
+        <p>
+          One <strong>relay-proxy</strong> on your infrastructure, your
+          applications consume flags through OpenFeature SDKs, and your flag
+          configuration lives in a file you already control.
+        </p>{' '}
+        <p>
+          <strong>Retrievers</strong>, <strong>notifiers</strong>, and{' '}
+          <strong>exporters</strong> plug into the stack you are using.
+        </p>
+      </p>
+      <div className="max-w-5xl mx-auto px-4">
+        <div className="rounded-2xl bg-white dark:bg-white/95 p-6 md:p-8 shadow-sm border border-solid border-[#273437]/10">
+          <img
+            src="/docs/openfeature/architecture.svg"
+            alt="GO Feature Flag architecture: OpenFeature SDKs talking to the relay-proxy, which loads flag configuration via retrievers and emits events via notifiers and exporters."
+            className="w-full h-auto"
+            loading="lazy"
+          />
+        </div>
+        <p className="mt-6 text-gray-500 dark:text-gray-400 text-[1.05rem] leading-relaxed">
+          Want the full picture? Read the{' '}
+          <Link to="/docs/concepts/architecture">
+            architecture documentation
+          </Link>{' '}
+          for a deeper dive into every component.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/home/how-it-works/index.js
+++ b/website/src/components/home/how-it-works/index.js
@@ -11,7 +11,7 @@ export function HowItWorks() {
         className="text-gray-800 dark:text-gray-50 text-5xl font-poppins font-bold tracking-[-0.18rem]">
         How it works?
       </span>
-      <p className="mt-3 mb-8 max-w-3xl mx-auto text-gray-500 dark:text-gray-400 text-[1.05rem] leading-relaxed">
+      <div className="mt-3 mb-8 max-w-3xl mx-auto text-gray-500 dark:text-gray-400 text-[1.05rem] leading-relaxed">
         <p>
           One <strong>relay-proxy</strong> on your infrastructure, your
           applications consume flags through OpenFeature SDKs, and your flag
@@ -21,7 +21,7 @@ export function HowItWorks() {
           <strong>Retrievers</strong>, <strong>notifiers</strong>, and{' '}
           <strong>exporters</strong> plug into the stack you are using.
         </p>
-      </p>
+      </div>
       <div className="max-w-5xl mx-auto px-4">
         <div className="rounded-2xl bg-white dark:bg-white/95 p-6 md:p-8 shadow-sm border border-solid border-[#273437]/10">
           <img

--- a/website/src/components/home/using-it/index.js
+++ b/website/src/components/home/using-it/index.js
@@ -20,25 +20,25 @@ export function UsingIt() {
       name: 'Grafana Labs',
       logo: grafana,
       url: 'https://grafana.com',
-      imgClassName: 'max-w-56',
+      imgClassName: 'max-w-48',
     },
     {
       name: 'Miro',
       logo: miro,
       url: 'https://miro.com',
-      imgClassName: 'max-w-36',
+      imgClassName: 'max-w-32',
     },
     {
       name: 'Cast.ai',
       logo: castai,
       url: 'https://cast.ai',
-      imgClassName: 'max-w-32',
+      imgClassName: 'max-w-24',
     },
     {
       name: 'Lyft',
       logo: lyft,
       url: 'https://lyft.com',
-      imgClassName: 'max-w-20',
+      imgClassName: 'max-w-12',
     },
     {
       name: 'Tencent',
@@ -85,7 +85,9 @@ export function UsingIt() {
   return (
     <section className={'pt-5 px-5'}>
       <div className="grid grid-pad text-center">
-        <span className="text-3xl">Trusted by developers from</span>
+        <span className="text-2xl">
+          Trusted in production by engineering teams at
+        </span>
         <UsingItLogos companies={companies} />
       </div>
     </section>
@@ -113,7 +115,7 @@ function UsingItLogos({companies}) {
               src={company.logo}
               alt={company.name}
               className={
-                company.imgClassName ? company.imgClassName : 'max-w-36'
+                company.imgClassName ? company.imgClassName : 'max-w-28'
               }
             />
           </Link>

--- a/website/src/components/home/whatis/index.js
+++ b/website/src/components/home/whatis/index.js
@@ -10,6 +10,11 @@ export function Whatis() {
       <span className="text-gray-800 dark:text-gray-50 text-5xl font-poppins font-bold tracking-[-0.18rem]">
         What is GO Feature Flag?
       </span>
+      <p className="mt-3 mb-1 max-w-4xl mx-auto text-center text-gray-500 dark:text-gray-400 text-[1.05rem] leading-relaxed">
+        GO Feature Flag is an open-source, OpenFeature-native feature flag
+        management system that runs on the infrastructure you already have - no
+        database to operate, no vendor to lock into, and no per-seat bill.
+      </p>
       <div
         className={clsx(
           'flex items-center justify-center m-auto py-[1.5rem] font-poppins text-left text-md max-w-6xl 2xl:max-w-full'
@@ -61,12 +66,12 @@ export function Whatis() {
         </div>
       </div>
       <div className="relative inline-flex group ml-5">
-        <div className="border-gray-700 border-4 absolute transitiona-all duration-1000 opacity-70 -inset-px bg-gradient-to-r from-[#44BCFF] via-[#FF44EC] to-[#FF675E] rounded-xl blur-lg group-hover:opacity-100 group-hover:-inset-1 group-hover:duration-200 animate-tilt hover:no-underline"></div>
+        <div className="absolute transitiona-all duration-1000 opacity-70 -inset-px bg-gradient-to-r from-[#44BCFF] via-[#FF44EC] to-[#FF675E] rounded-xl blur-lg group-hover:opacity-100 group-hover:-inset-1 group-hover:duration-200 animate-tilt"></div>
         <Link
-          to={'/docs/'}
+          to={'/docs/getting-started'}
           title="Dive into GO Feature Flag"
-          className="hover:no-underline hover:text-gray-700 relative inline-flex items-center justify-center px-6 py-3 text-white transition-all duration-200 bg-[#9fbeb3] font-pj rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900">
-          <i className="fa-solid fa-screwdriver-wrench mr-1"></i>
+          className="hover:no-underline hover:text-white relative inline-flex items-center justify-center px-8 py-4 text-lg font-bold text-white transition-all duration-200 bg-gray-900 font-pj rounded-xl overflow-hidden focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900">
+          <i className="fa-solid fa-circle-right mr-4"></i>
           Dive into GO Feature Flag
         </Link>
       </div>

--- a/website/src/components/home/why-goff/index.js
+++ b/website/src/components/home/why-goff/index.js
@@ -168,45 +168,47 @@ export function WhyGoff() {
             )}
             role="table"
             aria-label="Feature flag solution comparison">
-            <div
-              className="min-h-[7.5rem] bg-titles-500/10"
-              role="columnheader"
-              aria-hidden
-            />
-
-            {COLUMNS.map(column => (
+            <div className="contents" role="row">
               <div
-                key={column.key}
-                className={clsx(
-                  'relative flex flex-col justify-center items-center min-h-[8.5rem] px-3 py-4 text-center',
-                  column.featured &&
-                    clsx(
-                      'border-solid border-b',
-                      borderClass,
-                      'bg-titles-500/25 border-t-2 border-l-2 border-r-2 !border-t-titles-500 !border-l-titles-500 !border-r-titles-500 rounded-t-xl'
-                    )
-                )}
-                role="columnheader">
-                {column.badge && (
-                  <span className="absolute top-2.5 right-2.5 px-2 py-0.5 rounded-full bg-titles-500 text-white text-[0.68rem] font-bold tracking-wide uppercase">
-                    {column.badge}
-                  </span>
-                )}
-                <h3 className="m-0 text-[1.22rem] font-bold leading-snug text-gray-800 dark:text-gray-50">
-                  {column.name}
-                </h3>
-                <p className="mt-1.5 mb-0 text-xs leading-snug text-gray-500 dark:text-gray-400">
-                  {column.tagline}
-                </p>
-              </div>
-            ))}
+                className="min-h-[7.5rem] bg-titles-500/10"
+                role="columnheader"
+                aria-hidden
+              />
+
+              {COLUMNS.map(column => (
+                <div
+                  key={column.key}
+                  className={clsx(
+                    'relative flex flex-col justify-center items-center min-h-[8.5rem] px-3 py-4 text-center',
+                    column.featured &&
+                      clsx(
+                        'border-solid border-b',
+                        borderClass,
+                        'bg-titles-500/25 border-t-2 border-l-2 border-r-2 !border-t-titles-500 !border-l-titles-500 !border-r-titles-500 rounded-t-xl'
+                      )
+                  )}
+                  role="columnheader">
+                  {column.badge && (
+                    <span className="absolute top-2.5 right-2.5 px-2 py-0.5 rounded-full bg-titles-500 text-white text-[0.68rem] font-bold tracking-wide uppercase">
+                      {column.badge}
+                    </span>
+                  )}
+                  <h3 className="m-0 text-[1.22rem] font-bold leading-snug text-gray-800 dark:text-gray-50">
+                    {column.name}
+                  </h3>
+                  <p className="mt-1.5 mb-0 text-xs leading-snug text-gray-500 dark:text-gray-400">
+                    {column.tagline}
+                  </p>
+                </div>
+              ))}
+            </div>
 
             {ROWS.map((row, rowIndex) => {
               const isLastRow = rowIndex === lastRowIndex;
               const isAltRow = rowIndex % 2 === 1;
 
               return (
-                <React.Fragment key={row.label}>
+                <div className="contents" role="row" key={row.label}>
                   <div
                     className={clsx(
                       'flex items-center min-h-[3.25rem] px-4 py-3 text-sm font-semibold text-gray-800 dark:text-gray-50',
@@ -237,7 +239,7 @@ export function WhyGoff() {
                       <CellValue data={row.cells[column.key]} />
                     </div>
                   ))}
-                </React.Fragment>
+                </div>
               );
             })}
           </div>

--- a/website/src/components/home/why-goff/index.js
+++ b/website/src/components/home/why-goff/index.js
@@ -1,0 +1,248 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+
+const COLUMNS = [
+  {
+    key: 'goff',
+    name: 'GO Feature Flag',
+    tagline: 'Open source · file-based',
+    featured: true,
+  },
+  {
+    key: 'saas',
+    name: 'SaaS platforms',
+    tagline: 'LaunchDarkly · Split ...',
+  },
+  {
+    key: 'db',
+    name: 'DB-backed OSS',
+    tagline: 'Unleash · Flagsmith ...',
+  },
+  {
+    key: 'diy',
+    name: 'DIY config',
+    tagline: 'Roll your own solution',
+  },
+];
+
+const ROWS = [
+  {
+    label: 'OpenFeature Support',
+    cells: {
+      goff: {
+        icon: 'check',
+        text: 'Support only OpenFeature (no vendor lock-in)',
+      },
+      saas: {text: 'limited support'},
+      db: {text: 'limited support'},
+      diy: {icon: 'cross'},
+    },
+  },
+  {
+    label: 'Pricing',
+    cells: {
+      goff: {text: ' — MIT License', strong: 'Free'},
+      saas: {text: 'Per-seat / per-MAU'},
+      db: {text: 'Free core, paid tiers'},
+      diy: {text: 'Free'},
+    },
+  },
+  {
+    label: 'Database required',
+    cells: {
+      goff: {strong: 'None', text: ' — flags are a file'},
+      saas: {text: 'Vendor-managed'},
+      db: {text: 'PostgreSQL'},
+      diy: {text: 'None'},
+    },
+  },
+  {
+    label: 'Self-hosting',
+    cells: {
+      goff: {icon: 'check', text: 'runs in your infra'},
+      saas: {icon: 'cross', text: 'vendor-hosted only', crossText: true},
+      db: {icon: 'check', text: 'limited self-hosting options'},
+      diy: {icon: 'check'},
+    },
+  },
+  {
+    label: 'Rollouts & targeting',
+    cells: {
+      goff: {icon: 'check'},
+      saas: {icon: 'check'},
+      db: {icon: 'check'},
+      diy: {icon: 'cross', text: 'you build it', crossText: true},
+    },
+  },
+  {
+    label: 'A/B testing',
+    cells: {
+      goff: {icon: 'check'},
+      saas: {icon: 'check'},
+      db: {text: 'Varies'},
+      diy: {icon: 'cross'},
+    },
+  },
+  {
+    label: 'Collect Usage data',
+    cells: {
+      goff: {icon: 'check', text: 'via exporters'},
+      saas: {icon: 'check'},
+      db: {text: 'Partial / paid'},
+      diy: {icon: 'cross', text: 'you build it', crossText: true},
+    },
+  },
+];
+
+const borderClass = 'border-[#273437]/10 dark:border-white/10';
+
+CellValue.propTypes = {
+  data: PropTypes.shape({
+    icon: PropTypes.oneOf(['check', 'cross']),
+    strong: PropTypes.string,
+    text: PropTypes.string,
+    crossText: PropTypes.bool,
+  }),
+};
+
+function CellValue({data}) {
+  if (!data) {
+    return (
+      <span className="inline-flex items-center justify-center flex-wrap gap-1.5 text-[0.82rem] leading-snug text-gray-800 dark:text-gray-50" />
+    );
+  }
+  const {icon, strong, text, crossText} = data;
+  const stack = (icon === 'check' || icon === 'cross') && (strong || text);
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center justify-center text-[0.82rem] leading-snug text-gray-800 dark:text-gray-50',
+        stack ? 'flex-col gap-1' : 'flex-wrap gap-1.5'
+      )}>
+      {icon === 'check' && (
+        <span
+          className="inline-flex items-center justify-center w-5 h-5 rounded-full shrink-0 bg-[#73c6b6] text-white"
+          aria-hidden>
+          <i className="fa-solid fa-check" />
+        </span>
+      )}
+      {icon === 'cross' && (
+        <span
+          className="inline-flex items-center justify-center w-5 h-5 rounded-full shrink-0 bg-red-400/15 text-red-700 dark:text-red-400"
+          aria-hidden>
+          <i className="fa-solid fa-xmark" />
+        </span>
+      )}
+      {strong && <strong>{strong}</strong>}
+      {text && (
+        <span className={crossText ? 'text-gray-500 dark:text-gray-400' : ''}>
+          {text}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export function WhyGoff() {
+  const lastRowIndex = ROWS.length - 1;
+  return (
+    <section
+      className="py-12 px-4 pb-16 bg-gray-100 dark:bg-[#363636] lg:px-6"
+      aria-labelledby="why-goff-title">
+      <div className="max-w-6xl mx-auto">
+        <h2 id="why-goff-title" className="goffMainTitle text-center">
+          Why GO Feature Flag?
+        </h2>
+        <p className="mt-3 mb-10 max-w-2xl mx-auto text-center text-gray-500 dark:text-gray-400 text-[1.05rem] leading-relaxed">
+          Compare file-based open source against SaaS platforms, database-backed
+          tools, and rolling your own.
+        </p>
+
+        <div className="overflow-x-auto pb-2">
+          <div
+            className={clsx(
+              'grid min-w-[52rem] rounded-2xl overflow-hidden bg-white dark:bg-[#2a2a2a] border',
+              borderClass,
+              'grid-cols-[minmax(9rem,1.15fr)_repeat(4,minmax(8.5rem,1fr))]'
+            )}
+            role="table"
+            aria-label="Feature flag solution comparison">
+            <div
+              className="min-h-[7.5rem] bg-titles-500/10"
+              role="columnheader"
+              aria-hidden
+            />
+
+            {COLUMNS.map(column => (
+              <div
+                key={column.key}
+                className={clsx(
+                  'relative flex flex-col justify-center items-center min-h-[8.5rem] px-3 py-4 text-center',
+                  column.featured &&
+                    clsx(
+                      'border-solid border-b',
+                      borderClass,
+                      'bg-titles-500/25 border-t-2 border-l-2 border-r-2 !border-t-titles-500 !border-l-titles-500 !border-r-titles-500 rounded-t-xl'
+                    )
+                )}
+                role="columnheader">
+                {column.badge && (
+                  <span className="absolute top-2.5 right-2.5 px-2 py-0.5 rounded-full bg-titles-500 text-white text-[0.68rem] font-bold tracking-wide uppercase">
+                    {column.badge}
+                  </span>
+                )}
+                <h3 className="m-0 text-[1.22rem] font-bold leading-snug text-gray-800 dark:text-gray-50">
+                  {column.name}
+                </h3>
+                <p className="mt-1.5 mb-0 text-xs leading-snug text-gray-500 dark:text-gray-400">
+                  {column.tagline}
+                </p>
+              </div>
+            ))}
+
+            {ROWS.map((row, rowIndex) => {
+              const isLastRow = rowIndex === lastRowIndex;
+              const isAltRow = rowIndex % 2 === 1;
+
+              return (
+                <React.Fragment key={row.label}>
+                  <div
+                    className={clsx(
+                      'flex items-center min-h-[3.25rem] px-4 py-3 text-sm font-semibold text-gray-800 dark:text-gray-50',
+                      isAltRow && 'bg-titles-500/10'
+                    )}
+                    role="rowheader">
+                    {row.label}
+                  </div>
+
+                  {COLUMNS.map(column => (
+                    <div
+                      key={`${row.label}-${column.key}`}
+                      className={clsx(
+                        'flex items-center justify-center min-h-[3.25rem] px-3 py-2.5 text-center',
+                        isAltRow && 'bg-titles-500/10',
+                        column.featured && isAltRow && 'bg-titles-500/20',
+                        column.featured &&
+                          clsx(
+                            'border-solid',
+                            borderClass,
+                            'border-l-2 border-r-2 !border-l-titles-500 !border-r-titles-500',
+                            isLastRow
+                              ? 'border-b-2 !border-b-titles-500 rounded-b-xl'
+                              : 'border-b'
+                          )
+                      )}
+                      role="cell">
+                      <CellValue data={row.cells[column.key]} />
+                    </div>
+                  ))}
+                </React.Fragment>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -5,6 +5,7 @@ import {Whatis} from '../components/home/whatis';
 import {QuickStart} from '../components/home/HomepageQuickStart';
 import {HomeHeader} from '../components/home/HomeHeader';
 import {Benefit} from '../components/home/benefit';
+import {WhyGoff} from '../components/home/why-goff';
 import {
   Integration,
   OpenFeatureEcosystem,
@@ -13,6 +14,7 @@ import {
 } from '../components/home/features';
 import {UsingIt} from '../components/home/using-it';
 import {Headline} from '../components/home/headline';
+import {HowItWorks} from '../components/home/how-it-works';
 
 export default function Home() {
   const {siteConfig} = useDocusaurusContext();
@@ -21,15 +23,18 @@ export default function Home() {
       title={`${siteConfig.tagline}`}
       description={`${siteConfig.customFields.description}`}>
       <HomeHeader />
-      <Whatis />
-      <QuickStart />
       <UsingIt />
+      <Whatis />
+
+      <QuickStart />
       <div className={'my-10'}></div>
       <OpenFeatureEcosystem />
       <Sdk />
       <Integration />
+      <WhyGoff />
       <Headline />
       <Rollout />
+      <HowItWorks />
       <Benefit />
     </Layout>
   );

--- a/website/src/theme/NavbarItem/ComponentTypes.js
+++ b/website/src/theme/NavbarItem/ComponentTypes.js
@@ -1,0 +1,7 @@
+import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
+import GitHubStarsNavbarItem from '@theme/NavbarItem/GitHubStarsNavbarItem';
+
+export default {
+  ...ComponentTypes,
+  'custom-githubStars': GitHubStarsNavbarItem,
+};

--- a/website/src/theme/NavbarItem/GitHubStarsNavbarItem.js
+++ b/website/src/theme/NavbarItem/GitHubStarsNavbarItem.js
@@ -1,0 +1,56 @@
+import React, {useEffect, useState} from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Link from '@docusaurus/Link';
+
+export default function GitHubStarsNavbarItem() {
+  const {siteConfig} = useDocusaurusContext();
+  const [stars, setStars] = useState(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const shieldsUrl = `https://img.shields.io/github/stars/${siteConfig.organizationName}/${siteConfig.projectName}.json`;
+
+    fetch(shieldsUrl, {signal: controller.signal})
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`shields.io responded with ${response.status}`);
+        }
+        return response.json();
+      })
+      .then(data => {
+        if (data?.message) {
+          setStars(data.message);
+        }
+      })
+      .catch(error => {
+        if (error.name !== 'AbortError') {
+          console.error('Failed to fetch GitHub star count:', error);
+        }
+      });
+
+    return () => controller.abort();
+  }, [siteConfig.organizationName, siteConfig.projectName]);
+
+  const ariaLabel = stars
+    ? `GitHub repository (${stars} stars)`
+    : 'GitHub repository';
+
+  return (
+    <Link
+      to={siteConfig.customFields.github}
+      className="navbar__item inline-flex items-center gap-1.5 font-semibold text-current hover:text-current hover:no-underline hover:opacity-60 transition-opacity"
+      aria-label={ariaLabel}
+      title={ariaLabel}>
+      <i
+        className="fa-brands fa-github text-xl leading-none"
+        aria-hidden="true"
+      />
+      {stars && (
+        <span className="text-sm tabular-nums">
+          <i className="fa-solid fa-star mr-1 text-[#f5b400]" aria-hidden="true" />
+          {stars}
+        </span>
+      )}
+    </Link>
+  );
+}


### PR DESCRIPTION
## Description

Reworks the GO Feature Flag homepage to lead with what makes the project actually different (open-source, self-hosted, OpenFeature-native) and frame it for the AI era — the previous hero gave its largest type to the generic category label \"Cloud Native Feature Flagging\" while the real differentiator was buried in light body copy.

### What changed

- **HomeHeader** — invert the type hierarchy so the differentiator becomes the H1; fold the tagline into the subhead; fix the ungrammatical \"softwares\"; refresh the subhead to position feature flags as an enabler for shipping AI features faster (\"...the AI era: ship fast, roll out safely, roll back instantly...\"). Decompose the section into focused sub-components (`HeroBackgroundShapes`, `HeroCopy`, `HeroCTAs`, `HeroProofLine`, `HeroLogo`). Replace ad-hoc CSS-module rules with inline Tailwind. Fold the live GitHub star count into the \"View on GitHub\" button (fetched from shields.io) and remove the separate floating badge. Give the secondary CTA a ghost treatment (transparent fill, green border) so it stops competing with the primary. Align both buttons in a real flex row with matching `border-box` heights. Add a gradient-fill hover on the primary CTA.
- **WhyGoff** (new section) — a comparison matrix pitting GO Feature Flag against SaaS platforms / DB-backed OSS / DIY config across OpenFeature support, pricing, database requirement, self-hosting, rollouts & targeting, A/B testing, and usage exports.
- **HowItWorks** (new section) — an architecture overview that reuses the existing `/docs/openfeature/architecture.svg` diagram (no new asset) and links to the architecture documentation.
- **Whatis** — lead with a one-sentence summary above the three pillars.
- **UsingIt** — tighten the heading copy (\"Trusted in production by engineering teams at\") and rebalance the logo sizes for a more even row.

### How to test

\`\`\`bash
cd website
npm run build   # passes locally
npm run start   # eyeball the homepage in light + dark mode at desktop / tablet / mobile widths
\`\`\`

In the browser, verify:
- The H1 is the largest element; \"GO Feature Flag\" sits above it small; the green accent on \"— built on OpenFeature.\" reads.
- Both CTAs share the same outer height; primary fills with the cyan→magenta→orange gradient on hover; secondary fills green on hover.
- The proof line under the CTAs lists 4 SDKs/integrations counts.
- The new WhyGoff comparison renders cleanly on mobile (scrolls horizontally).
- HowItWorks renders the architecture SVG inside a white card (legible in dark mode).
- The \"Trusted in production by engineering teams at\" row stays even.

## Closes issue(s)

Resolve #

## Checklist

- [x] I have tested this code
- [ ] I have added unit test to cover this code (n/a — website-only copy/layout changes, no unit-testable logic)
- [ ] I have updated the documentation (\`README.md\` and \`/website/docs\`) (n/a — homepage marketing copy, docs unchanged)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)