### PR TITLE
fix(website): reserve space for GitHub star count to avoid layout shift

### DIFF
--- a/website/src/components/home/HomeHeader/index.js
+++ b/website/src/components/home/HomeHeader/index.js
@@ -73,7 +73,12 @@ function ViewOnGitHubButton() {
           <span className="ml-2 font-semibold">
             <div className="flex items-center tabular-nums">
               <FaStar className="w-6 h-6 mr-1" />{' '}
-              <span className={clsx('min-w-[3ch]', !githubStars && 'opacity-0')}>
+              <span
+                className={clsx(
+                  'min-w-[4ch] transition-opacity duration-300',
+                  !githubStars && 'opacity-0'
+                )}>
+
                 {githubStars ?? '0.0k'}
               </span>
             </div>

--- a/website/src/components/home/HomeHeader/index.js
+++ b/website/src/components/home/HomeHeader/index.js
@@ -78,7 +78,6 @@ function ViewOnGitHubButton() {
                   'min-w-[4ch] transition-opacity duration-300',
                   !githubStars && 'opacity-0'
                 )}>
-
                 {githubStars ?? '0.0k'}
               </span>
             </div>

--- a/website/src/components/home/HomeHeader/index.js
+++ b/website/src/components/home/HomeHeader/index.js
@@ -1,10 +1,11 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import styles from './styles.module.css';
 import Link from '@docusaurus/Link';
 import clsx from 'clsx';
 import {FaStar, FaArrowAltCircleRight} from 'react-icons/fa';
 import {sdk} from '@site/data/sdk';
+import useGitHubStars from '@site/src/hooks/useGitHubStars';
 
 function GetStartedButton() {
   return (
@@ -23,39 +24,7 @@ function GetStartedButton() {
 
 function ViewOnGitHubButton() {
   const {siteConfig} = useDocusaurusContext();
-  const [githubStars, setGithubStars] = useState(null);
-  const [failed, setFailed] = useState(false);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    const shieldsUrl = `https://img.shields.io/github/stars/${siteConfig.organizationName}/${siteConfig.projectName}.json`;
-
-    fetch(shieldsUrl, {signal: controller.signal})
-      .then(response => {
-        if (!response.ok) {
-          throw new Error(`shields.io responded with ${response.status}`);
-        }
-        return response.json();
-      })
-      .then(data => {
-        const isStarCount =
-          typeof data?.message === 'string' &&
-          /^[\d.,]+[kmb]?$/i.test(data.message.trim());
-        if (isStarCount) {
-          setGithubStars(data.message);
-        } else {
-          setFailed(true);
-        }
-      })
-      .catch(error => {
-        if (error.name !== 'AbortError') {
-          console.error('Failed to fetch GitHub star count:', error);
-          setFailed(true);
-        }
-      });
-
-    return () => controller.abort();
-  }, [siteConfig.organizationName, siteConfig.projectName]);
+  const {stars: githubStars, failed} = useGitHubStars();
 
   const githubLinkTitle = githubStars
     ? `View on GitHub (${githubStars} stars)`

--- a/website/src/components/home/HomeHeader/index.js
+++ b/website/src/components/home/HomeHeader/index.js
@@ -24,6 +24,7 @@ function GetStartedButton() {
 function ViewOnGitHubButton() {
   const {siteConfig} = useDocusaurusContext();
   const [githubStars, setGithubStars] = useState(null);
+  const [failed, setFailed] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -42,11 +43,14 @@ function ViewOnGitHubButton() {
           /^[\d.,]+[kmb]?$/i.test(data.message.trim());
         if (isStarCount) {
           setGithubStars(data.message);
+        } else {
+          setFailed(true);
         }
       })
       .catch(error => {
         if (error.name !== 'AbortError') {
           console.error('Failed to fetch GitHub star count:', error);
+          setFailed(true);
         }
       });
 
@@ -65,10 +69,13 @@ function ViewOnGitHubButton() {
         className="hover:no-underline inline-flex items-center justify-center px-8 py-3 text-lg font-bold text-gray-800 dark:text-gray-100 hover:text-white bg-transparent hover:bg-[#9fbeb3] border-2 border-solid border-[#9fbeb3] transition-all duration-200 font-pj rounded-xl focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-900">
         <i className="fa-brands fa-github mr-4" aria-hidden="true"></i>
         View on GitHub
-        {githubStars && (
+        {(githubStars !== null || !failed) && (
           <span className="ml-2 font-semibold">
-            <div className="flex">
-              <FaStar className="w-6 h-6 mr-1" /> <span>{githubStars}</span>
+            <div className="flex items-center tabular-nums">
+              <FaStar className="w-6 h-6 mr-1" />{' '}
+              <span className={clsx('min-w-[3ch]', !githubStars && 'opacity-0')}>
+                {githubStars ?? '0.0k'}
+              </span>
             </div>
           </span>
         )}

--- a/website/src/hooks/useGitHubStars.js
+++ b/website/src/hooks/useGitHubStars.js
@@ -1,0 +1,49 @@
+import {useEffect, useState} from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+/**
+ * Fetches the GitHub star count from shields.io.
+ *
+ * Returns `{stars, failed}` where `stars` is the formatted count once available
+ * (e.g. `"5.8k"`) and `failed` becomes `true` when the count can't be retrieved.
+ * While loading, both are falsy/`null`, letting callers reserve space and only
+ * hide the star block on failure.
+ */
+export default function useGitHubStars() {
+  const {siteConfig} = useDocusaurusContext();
+  const [stars, setStars] = useState(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const shieldsUrl = `https://img.shields.io/github/stars/${siteConfig.organizationName}/${siteConfig.projectName}.json`;
+
+    fetch(shieldsUrl, {signal: controller.signal})
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`shields.io responded with ${response.status}`);
+        }
+        return response.json();
+      })
+      .then(data => {
+        const isStarCount =
+          typeof data?.message === 'string' &&
+          /^[\d.,]+[kmb]?$/i.test(data.message.trim());
+        if (isStarCount) {
+          setStars(data.message);
+        } else {
+          setFailed(true);
+        }
+      })
+      .catch(error => {
+        if (error.name !== 'AbortError') {
+          console.error('Failed to fetch GitHub star count:', error);
+          setFailed(true);
+        }
+      });
+
+    return () => controller.abort();
+  }, [siteConfig.organizationName, siteConfig.projectName]);
+
+  return {stars, failed};
+}

--- a/website/src/theme/NavbarItem/GitHubStarsNavbarItem.js
+++ b/website/src/theme/NavbarItem/GitHubStarsNavbarItem.js
@@ -1,43 +1,12 @@
-import React, {useEffect, useState} from 'react';
+import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Link from '@docusaurus/Link';
 import clsx from 'clsx';
+import useGitHubStars from '@site/src/hooks/useGitHubStars';
 
 export default function GitHubStarsNavbarItem() {
   const {siteConfig} = useDocusaurusContext();
-  const [stars, setStars] = useState(null);
-  const [failed, setFailed] = useState(false);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    const shieldsUrl = `https://img.shields.io/github/stars/${siteConfig.organizationName}/${siteConfig.projectName}.json`;
-
-    fetch(shieldsUrl, {signal: controller.signal})
-      .then(response => {
-        if (!response.ok) {
-          throw new Error(`shields.io responded with ${response.status}`);
-        }
-        return response.json();
-      })
-      .then(data => {
-        const isStarCount =
-          typeof data?.message === 'string' &&
-          /^[\d.,]+[kmb]?$/i.test(data.message.trim());
-        if (isStarCount) {
-          setStars(data.message);
-        } else {
-          setFailed(true);
-        }
-      })
-      .catch(error => {
-        if (error.name !== 'AbortError') {
-          console.error('Failed to fetch GitHub star count:', error);
-          setFailed(true);
-        }
-      });
-
-    return () => controller.abort();
-  }, [siteConfig.organizationName, siteConfig.projectName]);
+  const {stars, failed} = useGitHubStars();
 
   const ariaLabel = stars
     ? `GitHub repository (${stars} stars)`
@@ -55,7 +24,10 @@ export default function GitHubStarsNavbarItem() {
       />
       {(stars !== null || !failed) && (
         <span className="text-sm tabular-nums inline-flex items-center">
-          <i className="fa-solid fa-star mr-1 text-[#f5b400]" aria-hidden="true" />
+          <i
+            className="fa-solid fa-star mr-1 text-[#f5b400]"
+            aria-hidden="true"
+          />
           <span
             className={clsx(
               'min-w-[4ch] transition-opacity duration-300',

--- a/website/src/theme/NavbarItem/GitHubStarsNavbarItem.js
+++ b/website/src/theme/NavbarItem/GitHubStarsNavbarItem.js
@@ -1,10 +1,12 @@
 import React, {useEffect, useState} from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Link from '@docusaurus/Link';
+import clsx from 'clsx';
 
 export default function GitHubStarsNavbarItem() {
   const {siteConfig} = useDocusaurusContext();
   const [stars, setStars] = useState(null);
+  const [failed, setFailed] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -23,11 +25,14 @@ export default function GitHubStarsNavbarItem() {
           /^[\d.,]+[kmb]?$/i.test(data.message.trim());
         if (isStarCount) {
           setStars(data.message);
+        } else {
+          setFailed(true);
         }
       })
       .catch(error => {
         if (error.name !== 'AbortError') {
           console.error('Failed to fetch GitHub star count:', error);
+          setFailed(true);
         }
       });
 
@@ -48,10 +53,12 @@ export default function GitHubStarsNavbarItem() {
         className="fa-brands fa-github text-xl leading-none"
         aria-hidden="true"
       />
-      {stars && (
-        <span className="text-sm tabular-nums">
+      {(stars !== null || !failed) && (
+        <span className="text-sm tabular-nums inline-flex items-center">
           <i className="fa-solid fa-star mr-1 text-[#f5b400]" aria-hidden="true" />
-          {stars}
+          <span className={clsx('min-w-[3ch]', !stars && 'opacity-0')}>
+            {stars ?? '0.0k'}
+          </span>
         </span>
       )}
     </Link>

--- a/website/src/theme/NavbarItem/GitHubStarsNavbarItem.js
+++ b/website/src/theme/NavbarItem/GitHubStarsNavbarItem.js
@@ -56,7 +56,11 @@ export default function GitHubStarsNavbarItem() {
       {(stars !== null || !failed) && (
         <span className="text-sm tabular-nums inline-flex items-center">
           <i className="fa-solid fa-star mr-1 text-[#f5b400]" aria-hidden="true" />
-          <span className={clsx('min-w-[3ch]', !stars && 'opacity-0')}>
+          <span
+            className={clsx(
+              'min-w-[4ch] transition-opacity duration-300',
+              !stars && 'opacity-0'
+            )}>
             {stars ?? '0.0k'}
           </span>
         </span>


### PR DESCRIPTION
## Description

The homepage fetches the GitHub star count asynchronously (in the navbar and the hero "View on GitHub" button), and previously rendered nothing until the count resolved — inserting the star icon + number then shifted the surrounding layout. This PR reserves a stable, `tabular-nums` slot (`min-w-[3ch]`) for the count while loading and fades the number into place, so the common success path produces no layout shift. A new `failed` state distinguishes "loading" from "could not load", so when the count genuinely can't be retrieved the block stays fully hidden (preserving the behavior from #5450). To test, throttle the network and reload the homepage: the navbar items and hero CTA row should no longer jump when the star count appears.

## Closes issue(s)
<!--
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)