### PR TITLE
feat: support PostgreSQL connection pool configuration

### DIFF
--- a/cmdhelpers/retrieverconf/init/retriever_init.go
+++ b/cmdhelpers/retrieverconf/init/retriever_init.go
@@ -3,6 +3,7 @@ package init
 import (
 	"context"
 	"fmt"
+	"math"
 	"time"
 
 	awsConf "github.com/aws/aws-sdk-go-v2/config"
@@ -177,6 +178,12 @@ func createAzBlobStorageRetriever(
 
 func createPostgreSQLRetriever(
 	c *retrieverconf.RetrieverConf, _ time.Duration) (retriever.Retriever, error) {
+	if c.MaxOpenConns < 0 || c.MaxOpenConns > math.MaxInt32 {
+		return nil, fmt.Errorf("maxOpenConns out of range for postgresql retriever: %d", c.MaxOpenConns)
+	}
+	if c.MaxIdleConns < 0 || c.MaxIdleConns > math.MaxInt32 {
+		return nil, fmt.Errorf("maxIdleConns out of range for postgresql retriever: %d", c.MaxIdleConns)
+	}
 	poolCfg := postgresqlretriever.PoolConfig{
 		MaxOpenConns: int32(c.MaxOpenConns),
 		MaxIdleConns: int32(c.MaxIdleConns),

--- a/cmdhelpers/retrieverconf/init/retriever_init.go
+++ b/cmdhelpers/retrieverconf/init/retriever_init.go
@@ -177,5 +177,28 @@ func createAzBlobStorageRetriever(
 
 func createPostgreSQLRetriever(
 	c *retrieverconf.RetrieverConf, _ time.Duration) (retriever.Retriever, error) {
-	return &postgresqlretriever.Retriever{URI: c.URI, Table: c.Table, Columns: c.Columns}, nil
+	poolCfg := postgresqlretriever.PoolConfig{
+		MaxOpenConns: int32(c.MaxOpenConns),
+		MaxIdleConns: int32(c.MaxIdleConns),
+	}
+	if c.ConnMaxLifetime != "" {
+		d, err := time.ParseDuration(c.ConnMaxLifetime)
+		if err != nil {
+			return nil, fmt.Errorf("invalid connMaxLifetime for postgresql retriever: %w", err)
+		}
+		poolCfg.ConnMaxLifetime = d
+	}
+	if c.ConnMaxIdleTime != "" {
+		d, err := time.ParseDuration(c.ConnMaxIdleTime)
+		if err != nil {
+			return nil, fmt.Errorf("invalid connMaxIdleTime for postgresql retriever: %w", err)
+		}
+		poolCfg.ConnMaxIdleTime = d
+	}
+	return &postgresqlretriever.Retriever{
+		URI:     c.URI,
+		Table:   c.Table,
+		Columns: c.Columns,
+		Pool:    poolCfg,
+	}, nil
 }

--- a/cmdhelpers/retrieverconf/init/retriever_init.go
+++ b/cmdhelpers/retrieverconf/init/retriever_init.go
@@ -178,29 +178,29 @@ func createAzBlobStorageRetriever(
 
 func createPostgreSQLRetriever(
 	c *retrieverconf.RetrieverConf, _ time.Duration) (retriever.Retriever, error) {
-	if c.MaxOpenConns < 0 || c.MaxOpenConns > math.MaxInt32 {
-		return nil, fmt.Errorf("maxOpenConns out of range for postgresql retriever: %d", c.MaxOpenConns)
+	if c.MaxConns < 0 || c.MaxConns > math.MaxInt32 {
+		return nil, fmt.Errorf("maxConns out of range for postgresql retriever: %d", c.MaxConns)
 	}
-	if c.MaxIdleConns < 0 || c.MaxIdleConns > math.MaxInt32 {
-		return nil, fmt.Errorf("maxIdleConns out of range for postgresql retriever: %d", c.MaxIdleConns)
+	if c.MinConns < 0 || c.MinConns > math.MaxInt32 {
+		return nil, fmt.Errorf("minConns out of range for postgresql retriever: %d", c.MinConns)
 	}
 	poolCfg := postgresqlretriever.PoolConfig{
-		MaxOpenConns: int32(c.MaxOpenConns),
-		MaxIdleConns: int32(c.MaxIdleConns),
+		MaxConns: int32(c.MaxConns),
+		MinConns: int32(c.MinConns),
 	}
-	if c.ConnMaxLifetime != "" {
-		d, err := time.ParseDuration(c.ConnMaxLifetime)
+	if c.MaxConnLifetime != "" {
+		d, err := time.ParseDuration(c.MaxConnLifetime)
 		if err != nil {
-			return nil, fmt.Errorf("invalid connMaxLifetime for postgresql retriever: %w", err)
+			return nil, fmt.Errorf("invalid maxConnLifetime for postgresql retriever: %w", err)
 		}
-		poolCfg.ConnMaxLifetime = d
+		poolCfg.MaxConnLifetime = d
 	}
-	if c.ConnMaxIdleTime != "" {
-		d, err := time.ParseDuration(c.ConnMaxIdleTime)
+	if c.MaxConnIdleTime != "" {
+		d, err := time.ParseDuration(c.MaxConnIdleTime)
 		if err != nil {
-			return nil, fmt.Errorf("invalid connMaxIdleTime for postgresql retriever: %w", err)
+			return nil, fmt.Errorf("invalid maxConnIdleTime for postgresql retriever: %w", err)
 		}
-		poolCfg.ConnMaxIdleTime = d
+		poolCfg.MaxConnIdleTime = d
 	}
 	return &postgresqlretriever.Retriever{
 		URI:     c.URI,

--- a/cmdhelpers/retrieverconf/init/retriever_init_test.go
+++ b/cmdhelpers/retrieverconf/init/retriever_init_test.go
@@ -1,6 +1,7 @@
 package init
 
 import (
+	"math"
 	"net/http"
 	"testing"
 	"time"
@@ -273,20 +274,42 @@ func Test_InitRetriever(t *testing.T) {
 				Kind:            "postgresql",
 				URI:             "postgresql://user:password@localhost:5432/database",
 				Table:           "flags",
-				MaxOpenConns:    25,
-				MaxIdleConns:    5,
-				ConnMaxLifetime: "1h",
-				ConnMaxIdleTime: "30m",
+				MaxConns:        25,
+				MinConns:        5,
+				MaxConnLifetime: "1h",
+				MaxConnIdleTime: "30m",
 			},
 			want: &postgresqlretriever.Retriever{
 				URI:   "postgresql://user:password@localhost:5432/database",
 				Table: "flags",
 				Pool: postgresqlretriever.PoolConfig{
-					MaxOpenConns:    25,
-					MaxIdleConns:    5,
-					ConnMaxLifetime: time.Hour,
-					ConnMaxIdleTime: 30 * time.Minute,
+					MaxConns:        25,
+					MinConns:        5,
+					MaxConnLifetime: time.Hour,
+					MaxConnIdleTime: 30 * time.Minute,
 				},
+			},
+			wantType: &postgresqlretriever.Retriever{},
+		},
+		{
+			name:    "Convert Postgres Retriever with maxConns out of range",
+			wantErr: assert.Error,
+			conf: &retrieverconf.RetrieverConf{
+				Kind:     "postgresql",
+				URI:      "postgresql://user:password@localhost:5432/database",
+				Table:    "flags",
+				MaxConns: math.MaxInt32 + 1,
+			},
+			wantType: &postgresqlretriever.Retriever{},
+		},
+		{
+			name:    "Convert Postgres Retriever with minConns out of range",
+			wantErr: assert.Error,
+			conf: &retrieverconf.RetrieverConf{
+				Kind:     "postgresql",
+				URI:      "postgresql://user:password@localhost:5432/database",
+				Table:    "flags",
+				MinConns: math.MaxInt32 + 1,
 			},
 			wantType: &postgresqlretriever.Retriever{},
 		},
@@ -297,7 +320,7 @@ func Test_InitRetriever(t *testing.T) {
 				Kind:            "postgresql",
 				URI:             "postgresql://user:password@localhost:5432/database",
 				Table:           "flags",
-				ConnMaxLifetime: "not-a-duration",
+				MaxConnLifetime: "not-a-duration",
 			},
 			wantType: &postgresqlretriever.Retriever{},
 		},

--- a/cmdhelpers/retrieverconf/init/retriever_init_test.go
+++ b/cmdhelpers/retrieverconf/init/retriever_init_test.go
@@ -266,6 +266,41 @@ func Test_InitRetriever(t *testing.T) {
 			},
 			wantType: &postgresqlretriever.Retriever{},
 		},
+		{
+			name:    "Convert Postgres Retriever with pool config",
+			wantErr: assert.NoError,
+			conf: &retrieverconf.RetrieverConf{
+				Kind:            "postgresql",
+				URI:             "postgresql://user:password@localhost:5432/database",
+				Table:           "flags",
+				MaxOpenConns:    25,
+				MaxIdleConns:    5,
+				ConnMaxLifetime: "1h",
+				ConnMaxIdleTime: "30m",
+			},
+			want: &postgresqlretriever.Retriever{
+				URI:   "postgresql://user:password@localhost:5432/database",
+				Table: "flags",
+				Pool: postgresqlretriever.PoolConfig{
+					MaxOpenConns:    25,
+					MaxIdleConns:    5,
+					ConnMaxLifetime: time.Hour,
+					ConnMaxIdleTime: 30 * time.Minute,
+				},
+			},
+			wantType: &postgresqlretriever.Retriever{},
+		},
+		{
+			name:    "Convert Postgres Retriever with invalid duration",
+			wantErr: assert.Error,
+			conf: &retrieverconf.RetrieverConf{
+				Kind:            "postgresql",
+				URI:             "postgresql://user:password@localhost:5432/database",
+				Table:           "flags",
+				ConnMaxLifetime: "not-a-duration",
+			},
+			wantType: &postgresqlretriever.Retriever{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmdhelpers/retrieverconf/retriever_conf.go
+++ b/cmdhelpers/retrieverconf/retriever_conf.go
@@ -55,6 +55,14 @@ type RetrieverConf struct {
 	Database   string            `mapstructure:"database"       koanf:"database"`
 	Collection string            `mapstructure:"collection"     koanf:"collection"`
 
+	// MaxOpenConns, MaxIdleConns, ConnMaxLifetime and ConnMaxIdleTime are
+	// optional connection pool settings used by the postgresql retriever.
+	// When left unset, the driver defaults are used and behavior is unchanged.
+	MaxOpenConns    int    `mapstructure:"maxOpenConns"    koanf:"maxopenconns"`
+	MaxIdleConns    int    `mapstructure:"maxIdleConns"    koanf:"maxidleconns"`
+	ConnMaxLifetime string `mapstructure:"connMaxLifetime" koanf:"connmaxlifetime"`
+	ConnMaxIdleTime string `mapstructure:"connMaxIdleTime" koanf:"connmaxidletime"`
+
 	// RedisOptions is the serializable redis configuration that can be used in JSON/YAML files
 	RedisOptions *SerializableRedisOptions `mapstructure:"redisOptions"   koanf:"redisOptions"`
 
@@ -113,6 +121,30 @@ func (c *RetrieverConf) validatePostgreSQLRetriever() error {
 	}
 	if c.Table == "" {
 		return err.NewRetrieverConfError("table", string(c.Kind))
+	}
+	if c.MaxOpenConns < 0 {
+		return fmt.Errorf("invalid retriever configuration, "+
+			"\"maxOpenConns\" must not be negative for kind \"%s\"", c.Kind)
+	}
+	if c.MaxIdleConns < 0 {
+		return fmt.Errorf("invalid retriever configuration, "+
+			"\"maxIdleConns\" must not be negative for kind \"%s\"", c.Kind)
+	}
+	if c.MaxOpenConns > 0 && c.MaxIdleConns > c.MaxOpenConns {
+		return fmt.Errorf("invalid retriever configuration, "+
+			"\"maxIdleConns\" must not be greater than \"maxOpenConns\" for kind \"%s\"", c.Kind)
+	}
+	if c.ConnMaxLifetime != "" {
+		if _, errParse := time.ParseDuration(c.ConnMaxLifetime); errParse != nil {
+			return fmt.Errorf("invalid retriever configuration, "+
+				"\"connMaxLifetime\" is not a valid duration for kind \"%s\": %w", c.Kind, errParse)
+		}
+	}
+	if c.ConnMaxIdleTime != "" {
+		if _, errParse := time.ParseDuration(c.ConnMaxIdleTime); errParse != nil {
+			return fmt.Errorf("invalid retriever configuration, "+
+				"\"connMaxIdleTime\" is not a valid duration for kind \"%s\": %w", c.Kind, errParse)
+		}
 	}
 	return nil
 }

--- a/cmdhelpers/retrieverconf/retriever_conf.go
+++ b/cmdhelpers/retrieverconf/retriever_conf.go
@@ -55,13 +55,13 @@ type RetrieverConf struct {
 	Database   string            `mapstructure:"database"       koanf:"database"`
 	Collection string            `mapstructure:"collection"     koanf:"collection"`
 
-	// MaxOpenConns, MaxIdleConns, ConnMaxLifetime and ConnMaxIdleTime are
+	// MaxConns, MinConns, MaxConnLifetime and MaxConnIdleTime are
 	// optional connection pool settings used by the postgresql retriever.
 	// When left unset, the driver defaults are used and behavior is unchanged.
-	MaxOpenConns    int    `mapstructure:"maxOpenConns"    koanf:"maxopenconns"    json:",omitempty"`
-	MaxIdleConns    int    `mapstructure:"maxIdleConns"    koanf:"maxidleconns"    json:",omitempty"`
-	ConnMaxLifetime string `mapstructure:"connMaxLifetime" koanf:"connmaxlifetime" json:",omitempty"`
-	ConnMaxIdleTime string `mapstructure:"connMaxIdleTime" koanf:"connmaxidletime" json:",omitempty"`
+	MaxConns        int    `mapstructure:"maxConns"        koanf:"maxconns"        json:"maxConns,omitempty"`
+	MinConns        int    `mapstructure:"minConns"        koanf:"minconns"        json:"minConns,omitempty"`
+	MaxConnLifetime string `mapstructure:"maxConnLifetime" koanf:"maxconnlifetime" json:"maxConnLifetime,omitempty"`
+	MaxConnIdleTime string `mapstructure:"maxConnIdleTime" koanf:"maxconnidletime" json:"maxConnIdleTime,omitempty"`
 
 	// RedisOptions is the serializable redis configuration that can be used in JSON/YAML files
 	RedisOptions *SerializableRedisOptions `mapstructure:"redisOptions"   koanf:"redisOptions"`
@@ -122,28 +122,28 @@ func (c *RetrieverConf) validatePostgreSQLRetriever() error {
 	if c.Table == "" {
 		return err.NewRetrieverConfError("table", string(c.Kind))
 	}
-	if c.MaxOpenConns < 0 {
+	if c.MaxConns < 0 {
 		return fmt.Errorf("invalid retriever configuration, "+
-			"\"maxOpenConns\" must not be negative for kind \"%s\"", c.Kind)
+			"\"maxConns\" must not be negative for kind \"%s\"", c.Kind)
 	}
-	if c.MaxIdleConns < 0 {
+	if c.MinConns < 0 {
 		return fmt.Errorf("invalid retriever configuration, "+
-			"\"maxIdleConns\" must not be negative for kind \"%s\"", c.Kind)
+			"\"minConns\" must not be negative for kind \"%s\"", c.Kind)
 	}
-	if c.MaxOpenConns > 0 && c.MaxIdleConns > c.MaxOpenConns {
+	if c.MaxConns > 0 && c.MinConns > c.MaxConns {
 		return fmt.Errorf("invalid retriever configuration, "+
-			"\"maxIdleConns\" must not be greater than \"maxOpenConns\" for kind \"%s\"", c.Kind)
+			"\"minConns\" must not be greater than \"maxConns\" for kind \"%s\"", c.Kind)
 	}
-	if c.ConnMaxLifetime != "" {
-		if _, errParse := time.ParseDuration(c.ConnMaxLifetime); errParse != nil {
+	if c.MaxConnLifetime != "" {
+		if _, errParse := time.ParseDuration(c.MaxConnLifetime); errParse != nil {
 			return fmt.Errorf("invalid retriever configuration, "+
-				"\"connMaxLifetime\" is not a valid duration for kind \"%s\": %w", c.Kind, errParse)
+				"\"maxConnLifetime\" is not a valid duration for kind \"%s\": %w", c.Kind, errParse)
 		}
 	}
-	if c.ConnMaxIdleTime != "" {
-		if _, errParse := time.ParseDuration(c.ConnMaxIdleTime); errParse != nil {
+	if c.MaxConnIdleTime != "" {
+		if _, errParse := time.ParseDuration(c.MaxConnIdleTime); errParse != nil {
 			return fmt.Errorf("invalid retriever configuration, "+
-				"\"connMaxIdleTime\" is not a valid duration for kind \"%s\": %w", c.Kind, errParse)
+				"\"maxConnIdleTime\" is not a valid duration for kind \"%s\": %w", c.Kind, errParse)
 		}
 	}
 	return nil

--- a/cmdhelpers/retrieverconf/retriever_conf.go
+++ b/cmdhelpers/retrieverconf/retriever_conf.go
@@ -58,10 +58,10 @@ type RetrieverConf struct {
 	// MaxOpenConns, MaxIdleConns, ConnMaxLifetime and ConnMaxIdleTime are
 	// optional connection pool settings used by the postgresql retriever.
 	// When left unset, the driver defaults are used and behavior is unchanged.
-	MaxOpenConns    int    `mapstructure:"maxOpenConns"    koanf:"maxopenconns"`
-	MaxIdleConns    int    `mapstructure:"maxIdleConns"    koanf:"maxidleconns"`
-	ConnMaxLifetime string `mapstructure:"connMaxLifetime" koanf:"connmaxlifetime"`
-	ConnMaxIdleTime string `mapstructure:"connMaxIdleTime" koanf:"connmaxidletime"`
+	MaxOpenConns    int    `mapstructure:"maxOpenConns"    koanf:"maxopenconns"    json:",omitempty"`
+	MaxIdleConns    int    `mapstructure:"maxIdleConns"    koanf:"maxidleconns"    json:",omitempty"`
+	ConnMaxLifetime string `mapstructure:"connMaxLifetime" koanf:"connmaxlifetime" json:",omitempty"`
+	ConnMaxIdleTime string `mapstructure:"connMaxIdleTime" koanf:"connmaxidletime" json:",omitempty"`
 
 	// RedisOptions is the serializable redis configuration that can be used in JSON/YAML files
 	RedisOptions *SerializableRedisOptions `mapstructure:"redisOptions"   koanf:"redisOptions"`

--- a/cmdhelpers/retrieverconf/retriever_conf_test.go
+++ b/cmdhelpers/retrieverconf/retriever_conf_test.go
@@ -382,73 +382,73 @@ func TestRetrieverConf_IsValid(t *testing.T) {
 				Kind:            "postgresql",
 				URI:             "xxx",
 				Table:           "xxx",
-				MaxOpenConns:    20,
-				MaxIdleConns:    5,
-				ConnMaxLifetime: "1h",
-				ConnMaxIdleTime: "30m",
+				MaxConns:        20,
+				MinConns:        5,
+				MaxConnLifetime: "1h",
+				MaxConnIdleTime: "30m",
 			},
 		},
 		{
-			name: "kind postgresql invalid negative maxOpenConns",
+			name: "kind postgresql invalid negative maxConns",
 			fields: retrieverconf.RetrieverConf{
-				Kind:         "postgresql",
-				URI:          "xxx",
-				Table:        "xxx",
-				MaxOpenConns: -1,
+				Kind:     "postgresql",
+				URI:      "xxx",
+				Table:    "xxx",
+				MaxConns: -1,
 			},
 			wantErr: true,
 			errValue: "invalid retriever configuration, " +
-				"\"maxOpenConns\" must not be negative for kind \"postgresql\"",
+				"\"maxConns\" must not be negative for kind \"postgresql\"",
 		},
 		{
-			name: "kind postgresql invalid negative maxIdleConns",
+			name: "kind postgresql invalid negative minConns",
 			fields: retrieverconf.RetrieverConf{
-				Kind:         "postgresql",
-				URI:          "xxx",
-				Table:        "xxx",
-				MaxIdleConns: -2,
+				Kind:     "postgresql",
+				URI:      "xxx",
+				Table:    "xxx",
+				MinConns: -2,
 			},
 			wantErr: true,
 			errValue: "invalid retriever configuration, " +
-				"\"maxIdleConns\" must not be negative for kind \"postgresql\"",
+				"\"minConns\" must not be negative for kind \"postgresql\"",
 		},
 		{
-			name: "kind postgresql invalid maxIdleConns greater than maxOpenConns",
+			name: "kind postgresql invalid minConns greater than maxConns",
 			fields: retrieverconf.RetrieverConf{
-				Kind:         "postgresql",
-				URI:          "xxx",
-				Table:        "xxx",
-				MaxOpenConns: 5,
-				MaxIdleConns: 10,
+				Kind:     "postgresql",
+				URI:      "xxx",
+				Table:    "xxx",
+				MaxConns: 5,
+				MinConns: 10,
 			},
 			wantErr: true,
 			errValue: "invalid retriever configuration, " +
-				"\"maxIdleConns\" must not be greater than \"maxOpenConns\" for kind \"postgresql\"",
+				"\"minConns\" must not be greater than \"maxConns\" for kind \"postgresql\"",
 		},
 		{
-			name: "kind postgresql invalid connMaxLifetime duration",
+			name: "kind postgresql invalid maxConnLifetime duration",
 			fields: retrieverconf.RetrieverConf{
 				Kind:            "postgresql",
 				URI:             "xxx",
 				Table:           "xxx",
-				ConnMaxLifetime: "not-a-duration",
+				MaxConnLifetime: "not-a-duration",
 			},
 			wantErr: true,
 			errValue: "invalid retriever configuration, " +
-				"\"connMaxLifetime\" is not a valid duration for kind \"postgresql\": " +
+				"\"maxConnLifetime\" is not a valid duration for kind \"postgresql\": " +
 				"time: invalid duration \"not-a-duration\"",
 		},
 		{
-			name: "kind postgresql invalid connMaxIdleTime duration",
+			name: "kind postgresql invalid maxConnIdleTime duration",
 			fields: retrieverconf.RetrieverConf{
 				Kind:            "postgresql",
 				URI:             "xxx",
 				Table:           "xxx",
-				ConnMaxIdleTime: "xyz",
+				MaxConnIdleTime: "xyz",
 			},
 			wantErr: true,
 			errValue: "invalid retriever configuration, " +
-				"\"connMaxIdleTime\" is not a valid duration for kind \"postgresql\": " +
+				"\"maxConnIdleTime\" is not a valid duration for kind \"postgresql\": " +
 				"time: invalid duration \"xyz\"",
 		},
 	}

--- a/cmdhelpers/retrieverconf/retriever_conf_test.go
+++ b/cmdhelpers/retrieverconf/retriever_conf_test.go
@@ -376,6 +376,81 @@ func TestRetrieverConf_IsValid(t *testing.T) {
 			wantErr:  true,
 			errValue: "invalid retriever: no \"table\" property found for kind \"postgresql\"",
 		},
+		{
+			name: "kind postgresql valid with pool block",
+			fields: retrieverconf.RetrieverConf{
+				Kind:            "postgresql",
+				URI:             "xxx",
+				Table:           "xxx",
+				MaxOpenConns:    20,
+				MaxIdleConns:    5,
+				ConnMaxLifetime: "1h",
+				ConnMaxIdleTime: "30m",
+			},
+		},
+		{
+			name: "kind postgresql invalid negative maxOpenConns",
+			fields: retrieverconf.RetrieverConf{
+				Kind:         "postgresql",
+				URI:          "xxx",
+				Table:        "xxx",
+				MaxOpenConns: -1,
+			},
+			wantErr: true,
+			errValue: "invalid retriever configuration, " +
+				"\"maxOpenConns\" must not be negative for kind \"postgresql\"",
+		},
+		{
+			name: "kind postgresql invalid negative maxIdleConns",
+			fields: retrieverconf.RetrieverConf{
+				Kind:         "postgresql",
+				URI:          "xxx",
+				Table:        "xxx",
+				MaxIdleConns: -2,
+			},
+			wantErr: true,
+			errValue: "invalid retriever configuration, " +
+				"\"maxIdleConns\" must not be negative for kind \"postgresql\"",
+		},
+		{
+			name: "kind postgresql invalid maxIdleConns greater than maxOpenConns",
+			fields: retrieverconf.RetrieverConf{
+				Kind:         "postgresql",
+				URI:          "xxx",
+				Table:        "xxx",
+				MaxOpenConns: 5,
+				MaxIdleConns: 10,
+			},
+			wantErr: true,
+			errValue: "invalid retriever configuration, " +
+				"\"maxIdleConns\" must not be greater than \"maxOpenConns\" for kind \"postgresql\"",
+		},
+		{
+			name: "kind postgresql invalid connMaxLifetime duration",
+			fields: retrieverconf.RetrieverConf{
+				Kind:            "postgresql",
+				URI:             "xxx",
+				Table:           "xxx",
+				ConnMaxLifetime: "not-a-duration",
+			},
+			wantErr: true,
+			errValue: "invalid retriever configuration, " +
+				"\"connMaxLifetime\" is not a valid duration for kind \"postgresql\": " +
+				"time: invalid duration \"not-a-duration\"",
+		},
+		{
+			name: "kind postgresql invalid connMaxIdleTime duration",
+			fields: retrieverconf.RetrieverConf{
+				Kind:            "postgresql",
+				URI:             "xxx",
+				Table:           "xxx",
+				ConnMaxIdleTime: "xyz",
+			},
+			wantErr: true,
+			errValue: "invalid retriever configuration, " +
+				"\"connMaxIdleTime\" is not a valid duration for kind \"postgresql\": " +
+				"time: invalid duration \"xyz\"",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thomaspoignant/go-feature-flag
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/bigquery v1.77.0

--- a/retriever/postgresqlretriever/postgres.go
+++ b/retriever/postgresqlretriever/postgres.go
@@ -14,30 +14,26 @@ import (
 // the corresponding pgxpool default (or the value already encoded in the
 // connection URI) is used, so existing configurations are unaffected.
 type PoolConfig struct {
-	// MaxOpenConns maps to pgxpool's MaxConns: the maximum number of
-	// connections in the pool.
-	MaxOpenConns int32
-	// MaxIdleConns maps to pgxpool's MinConns: the minimum number of
-	// connections the pool keeps open. pgxpool has no direct cap on idle
-	// connections (idle connections are bounded by MaxConns), so this controls
-	// the pool floor rather than an idle ceiling. It must not exceed
-	// MaxOpenConns.
-	MaxIdleConns int32
-	// ConnMaxLifetime maps to pgxpool's MaxConnLifetime: the duration since
-	// creation after which a connection is automatically closed.
-	ConnMaxLifetime time.Duration
-	// ConnMaxIdleTime maps to pgxpool's MaxConnIdleTime: the duration after
-	// which an idle connection is automatically closed by the health check.
-	ConnMaxIdleTime time.Duration
+	// MaxConns is the maximum number of connections in the pool.
+	MaxConns int32
+	// MinConns is the minimum number of connections the pool keeps open. It
+	// must not exceed MaxConns when both are configured.
+	MinConns int32
+	// MaxConnLifetime is the duration since creation after which a connection
+	// is automatically closed.
+	MaxConnLifetime time.Duration
+	// MaxConnIdleTime is the duration after which an idle connection is
+	// automatically closed by the health check.
+	MaxConnIdleTime time.Duration
 }
 
 // IsZero reports whether no pool setting has been configured. When true,
 // GetPool builds the pool exactly as it did before pool settings existed.
 func (p PoolConfig) IsZero() bool {
-	return p.MaxOpenConns == 0 &&
-		p.MaxIdleConns == 0 &&
-		p.ConnMaxLifetime == 0 &&
-		p.ConnMaxIdleTime == 0
+	return p.MaxConns == 0 &&
+		p.MinConns == 0 &&
+		p.MaxConnLifetime == 0 &&
+		p.MaxConnIdleTime == 0
 }
 
 // cacheKey returns a stable cache key for a URI + pool config combination.
@@ -47,8 +43,8 @@ func cacheKey(uri string, p PoolConfig) string {
 	if p.IsZero() {
 		return uri
 	}
-	return fmt.Sprintf("%s|%d|%d|%d|%d",
-		uri, p.MaxOpenConns, p.MaxIdleConns, p.ConnMaxLifetime, p.ConnMaxIdleTime)
+	return fmt.Sprintf("%s|maxConns=%d|minConns=%d|maxConnLifetime=%d|maxConnIdleTime=%d",
+		uri, p.MaxConns, p.MinConns, p.MaxConnLifetime, p.MaxConnIdleTime)
 }
 
 type poolEntry struct {
@@ -109,17 +105,21 @@ func newPool(ctx context.Context, uri string, poolCfg PoolConfig) (*pgxpool.Pool
 	if err != nil {
 		return nil, err
 	}
-	if poolCfg.MaxOpenConns > 0 {
-		config.MaxConns = poolCfg.MaxOpenConns
+	if poolCfg.MaxConns > 0 {
+		config.MaxConns = poolCfg.MaxConns
 	}
-	if poolCfg.MaxIdleConns > 0 {
-		config.MinConns = poolCfg.MaxIdleConns
+	if poolCfg.MinConns > 0 {
+		config.MinConns = poolCfg.MinConns
 	}
-	if poolCfg.ConnMaxLifetime > 0 {
-		config.MaxConnLifetime = poolCfg.ConnMaxLifetime
+	if poolCfg.MaxConnLifetime > 0 {
+		config.MaxConnLifetime = poolCfg.MaxConnLifetime
 	}
-	if poolCfg.ConnMaxIdleTime > 0 {
-		config.MaxConnIdleTime = poolCfg.ConnMaxIdleTime
+	if poolCfg.MaxConnIdleTime > 0 {
+		config.MaxConnIdleTime = poolCfg.MaxConnIdleTime
+	}
+	if config.MinConns > 0 && config.MaxConns > 0 && config.MinConns > config.MaxConns {
+		return nil, fmt.Errorf("invalid pool configuration: minConns (%d) must not exceed maxConns (%d)",
+			config.MinConns, config.MaxConns)
 	}
 
 	return pgxpool.NewWithConfig(ctx, config)

--- a/retriever/postgresqlretriever/postgres.go
+++ b/retriever/postgresqlretriever/postgres.go
@@ -2,10 +2,54 @@ package postgresqlretriever
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// PoolConfig holds the optional connection pool settings for the PostgreSQL
+// retriever. Every field is optional: when a field is left at its zero value,
+// the corresponding pgxpool default (or the value already encoded in the
+// connection URI) is used, so existing configurations are unaffected.
+type PoolConfig struct {
+	// MaxOpenConns maps to pgxpool's MaxConns: the maximum number of
+	// connections in the pool.
+	MaxOpenConns int32
+	// MaxIdleConns maps to pgxpool's MinConns: the minimum number of
+	// connections the pool keeps open. pgxpool has no direct cap on idle
+	// connections (idle connections are bounded by MaxConns), so this controls
+	// the pool floor rather than an idle ceiling. It must not exceed
+	// MaxOpenConns.
+	MaxIdleConns int32
+	// ConnMaxLifetime maps to pgxpool's MaxConnLifetime: the duration since
+	// creation after which a connection is automatically closed.
+	ConnMaxLifetime time.Duration
+	// ConnMaxIdleTime maps to pgxpool's MaxConnIdleTime: the duration after
+	// which an idle connection is automatically closed by the health check.
+	ConnMaxIdleTime time.Duration
+}
+
+// IsZero reports whether no pool setting has been configured. When true,
+// GetPool builds the pool exactly as it did before pool settings existed.
+func (p PoolConfig) IsZero() bool {
+	return p.MaxOpenConns == 0 &&
+		p.MaxIdleConns == 0 &&
+		p.ConnMaxLifetime == 0 &&
+		p.ConnMaxIdleTime == 0
+}
+
+// cacheKey returns a stable cache key for a URI + pool config combination.
+// Two retrievers that share a URI but request different pool settings get
+// distinct cached pools instead of silently reusing the first one created.
+func cacheKey(uri string, p PoolConfig) string {
+	if p.IsZero() {
+		return uri
+	}
+	return fmt.Sprintf("%s|%d|%d|%d|%d",
+		uri, p.MaxOpenConns, p.MaxIdleConns, p.ConnMaxLifetime, p.ConnMaxIdleTime)
+}
 
 type poolEntry struct {
 	pool     *pgxpool.Pool
@@ -18,18 +62,24 @@ var (
 )
 
 // GetPool returns a pool for a given URI, creating it if needed.
-func GetPool(ctx context.Context, uri string) (*pgxpool.Pool, error) {
+//
+// The optional poolCfg controls the connection pool sizing and lifetimes. When
+// it is the zero value, the pool is built exactly as before so existing
+// behavior is unchanged.
+func GetPool(ctx context.Context, uri string, poolCfg PoolConfig) (*pgxpool.Pool, error) {
 	mu.Lock()
 	defer mu.Unlock()
 
+	key := cacheKey(uri, poolCfg)
+
 	// If already exists, bump refCount
-	if entry, ok := poolMap[uri]; ok {
+	if entry, ok := poolMap[key]; ok {
 		entry.refCount++
 		return entry.pool, nil
 	}
 
 	// Create a new pool
-	pool, err := pgxpool.New(ctx, uri)
+	pool, err := newPool(ctx, uri, poolCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +88,7 @@ func GetPool(ctx context.Context, uri string) (*pgxpool.Pool, error) {
 		return nil, err
 	}
 
-	poolMap[uri] = &poolEntry{
+	poolMap[key] = &poolEntry{
 		pool:     pool,
 		refCount: 1,
 	}
@@ -46,12 +96,46 @@ func GetPool(ctx context.Context, uri string) (*pgxpool.Pool, error) {
 	return pool, nil
 }
 
+// newPool builds a pgxpool.Pool for the given URI. When poolCfg is the zero
+// value it falls back to pgxpool.New so the resulting pool is identical to the
+// previous behavior. Otherwise it parses the URI and overrides only the fields
+// that were explicitly configured.
+func newPool(ctx context.Context, uri string, poolCfg PoolConfig) (*pgxpool.Pool, error) {
+	if poolCfg.IsZero() {
+		return pgxpool.New(ctx, uri)
+	}
+
+	config, err := pgxpool.ParseConfig(uri)
+	if err != nil {
+		return nil, err
+	}
+	if poolCfg.MaxOpenConns > 0 {
+		config.MaxConns = poolCfg.MaxOpenConns
+	}
+	if poolCfg.MaxIdleConns > 0 {
+		config.MinConns = poolCfg.MaxIdleConns
+	}
+	if poolCfg.ConnMaxLifetime > 0 {
+		config.MaxConnLifetime = poolCfg.ConnMaxLifetime
+	}
+	if poolCfg.ConnMaxIdleTime > 0 {
+		config.MaxConnIdleTime = poolCfg.ConnMaxIdleTime
+	}
+
+	return pgxpool.NewWithConfig(ctx, config)
+}
+
 // ReleasePool decreases refCount and closes/removes when it hits zero.
-func ReleasePool(_ context.Context, uri string) {
+//
+// poolCfg must match the value passed to GetPool so the correct cached pool is
+// released; the zero value targets the default (URI-only) pool.
+func ReleasePool(_ context.Context, uri string, poolCfg PoolConfig) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	entry, ok := poolMap[uri]
+	key := cacheKey(uri, poolCfg)
+
+	entry, ok := poolMap[key]
 	if !ok {
 		return // nothing to do
 	}
@@ -59,6 +143,6 @@ func ReleasePool(_ context.Context, uri string) {
 	entry.refCount--
 	if entry.refCount <= 0 {
 		entry.pool.Close()
-		delete(poolMap, uri)
+		delete(poolMap, key)
 	}
 }

--- a/retriever/postgresqlretriever/postgres_pool_test.go
+++ b/retriever/postgresqlretriever/postgres_pool_test.go
@@ -20,23 +20,23 @@ func TestPoolConfig_IsZero(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "max open conns set",
-			cfg:  PoolConfig{MaxOpenConns: 10},
+			name: "max conns set",
+			cfg:  PoolConfig{MaxConns: 10},
 			want: false,
 		},
 		{
-			name: "max idle conns set",
-			cfg:  PoolConfig{MaxIdleConns: 2},
+			name: "min conns set",
+			cfg:  PoolConfig{MinConns: 2},
 			want: false,
 		},
 		{
-			name: "conn max lifetime set",
-			cfg:  PoolConfig{ConnMaxLifetime: time.Hour},
+			name: "max conn lifetime set",
+			cfg:  PoolConfig{MaxConnLifetime: time.Hour},
 			want: false,
 		},
 		{
-			name: "conn max idle time set",
-			cfg:  PoolConfig{ConnMaxIdleTime: 5 * time.Minute},
+			name: "max conn idle time set",
+			cfg:  PoolConfig{MaxConnIdleTime: 5 * time.Minute},
 			want: false,
 		},
 	}
@@ -56,10 +56,10 @@ func TestNewPool_AppliesConfig(t *testing.T) {
 	uri := "postgres://postgres:password@localhost:5432/postgres?sslmode=disable"
 
 	cfg := PoolConfig{
-		MaxOpenConns:    25,
-		MaxIdleConns:    5,
-		ConnMaxLifetime: 90 * time.Minute,
-		ConnMaxIdleTime: 10 * time.Minute,
+		MaxConns:        25,
+		MinConns:        5,
+		MaxConnLifetime: 90 * time.Minute,
+		MaxConnIdleTime: 10 * time.Minute,
 	}
 
 	pool, err := newPool(ctx, uri, cfg)
@@ -74,13 +74,21 @@ func TestNewPool_AppliesConfig(t *testing.T) {
 	assert.Equal(t, 10*time.Minute, applied.MaxConnIdleTime)
 }
 
+func TestNewPool_InvalidMinConnsGreaterThanMaxConns(t *testing.T) {
+	ctx := context.Background()
+	uri := "postgres://postgres:password@localhost:5432/postgres?sslmode=disable"
+
+	_, err := newPool(ctx, uri, PoolConfig{MaxConns: 5, MinConns: 10})
+	assert.EqualError(t, err, "invalid pool configuration: minConns (10) must not exceed maxConns (5)")
+}
+
 // TestNewPool_PartialConfig verifies that only the explicitly set fields are
 // overridden and the rest keep the pgxpool/URI defaults.
 func TestNewPool_PartialConfig(t *testing.T) {
 	ctx := context.Background()
 	uri := "postgres://postgres:password@localhost:5432/postgres?sslmode=disable&pool_max_conns=8"
 
-	pool, err := newPool(ctx, uri, PoolConfig{ConnMaxLifetime: 2 * time.Hour})
+	pool, err := newPool(ctx, uri, PoolConfig{MaxConnLifetime: 2 * time.Hour})
 	assert.NoError(t, err)
 	assert.NotNil(t, pool)
 	defer pool.Close()
@@ -95,7 +103,7 @@ func TestNewPool_PartialConfig(t *testing.T) {
 // configured against an unparseable URI.
 func TestNewPool_InvalidURI(t *testing.T) {
 	ctx := context.Background()
-	_, err := newPool(ctx, "://not-a-valid-uri", PoolConfig{MaxOpenConns: 4})
+	_, err := newPool(ctx, "://not-a-valid-uri", PoolConfig{MaxConns: 4})
 	assert.Error(t, err)
 }
 
@@ -107,13 +115,13 @@ func TestCacheKey(t *testing.T) {
 	assert.Equal(t, uri, cacheKey(uri, PoolConfig{}),
 		"zero config should key on the URI alone for backward compatibility")
 
-	a := cacheKey(uri, PoolConfig{MaxOpenConns: 10})
-	b := cacheKey(uri, PoolConfig{MaxOpenConns: 20})
+	a := cacheKey(uri, PoolConfig{MaxConns: 10})
+	b := cacheKey(uri, PoolConfig{MaxConns: 20})
 	assert.NotEqual(t, a, b, "different settings must produce different keys")
 	assert.NotEqual(t, uri, a, "a configured pool must not collide with the default key")
 
 	// Same settings yield the same key (stable).
 	assert.Equal(t,
-		cacheKey(uri, PoolConfig{MaxOpenConns: 10, ConnMaxLifetime: time.Hour}),
-		cacheKey(uri, PoolConfig{MaxOpenConns: 10, ConnMaxLifetime: time.Hour}))
+		cacheKey(uri, PoolConfig{MaxConns: 10, MaxConnLifetime: time.Hour}),
+		cacheKey(uri, PoolConfig{MaxConns: 10, MaxConnLifetime: time.Hour}))
 }

--- a/retriever/postgresqlretriever/postgres_pool_test.go
+++ b/retriever/postgresqlretriever/postgres_pool_test.go
@@ -1,0 +1,119 @@
+package postgresqlretriever
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPoolConfig_IsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  PoolConfig
+		want bool
+	}{
+		{
+			name: "empty config is zero",
+			cfg:  PoolConfig{},
+			want: true,
+		},
+		{
+			name: "max open conns set",
+			cfg:  PoolConfig{MaxOpenConns: 10},
+			want: false,
+		},
+		{
+			name: "max idle conns set",
+			cfg:  PoolConfig{MaxIdleConns: 2},
+			want: false,
+		},
+		{
+			name: "conn max lifetime set",
+			cfg:  PoolConfig{ConnMaxLifetime: time.Hour},
+			want: false,
+		},
+		{
+			name: "conn max idle time set",
+			cfg:  PoolConfig{ConnMaxIdleTime: 5 * time.Minute},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.cfg.IsZero())
+		})
+	}
+}
+
+// TestNewPool_AppliesConfig verifies that an explicit pool block is reflected in
+// the resulting pgxpool configuration. Building a pool does not open a
+// connection (that happens on Ping/Acquire), so this test does not need a live
+// database.
+func TestNewPool_AppliesConfig(t *testing.T) {
+	ctx := context.Background()
+	uri := "postgres://postgres:password@localhost:5432/postgres?sslmode=disable"
+
+	cfg := PoolConfig{
+		MaxOpenConns:    25,
+		MaxIdleConns:    5,
+		ConnMaxLifetime: 90 * time.Minute,
+		ConnMaxIdleTime: 10 * time.Minute,
+	}
+
+	pool, err := newPool(ctx, uri, cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, pool)
+	defer pool.Close()
+
+	applied := pool.Config()
+	assert.Equal(t, int32(25), applied.MaxConns)
+	assert.Equal(t, int32(5), applied.MinConns)
+	assert.Equal(t, 90*time.Minute, applied.MaxConnLifetime)
+	assert.Equal(t, 10*time.Minute, applied.MaxConnIdleTime)
+}
+
+// TestNewPool_PartialConfig verifies that only the explicitly set fields are
+// overridden and the rest keep the pgxpool/URI defaults.
+func TestNewPool_PartialConfig(t *testing.T) {
+	ctx := context.Background()
+	uri := "postgres://postgres:password@localhost:5432/postgres?sslmode=disable&pool_max_conns=8"
+
+	pool, err := newPool(ctx, uri, PoolConfig{ConnMaxLifetime: 2 * time.Hour})
+	assert.NoError(t, err)
+	assert.NotNil(t, pool)
+	defer pool.Close()
+
+	applied := pool.Config()
+	// MaxConns keeps the value from the URI since it was not overridden.
+	assert.Equal(t, int32(8), applied.MaxConns)
+	assert.Equal(t, 2*time.Hour, applied.MaxConnLifetime)
+}
+
+// TestNewPool_InvalidURI surfaces parse errors when an explicit pool block is
+// configured against an unparseable URI.
+func TestNewPool_InvalidURI(t *testing.T) {
+	ctx := context.Background()
+	_, err := newPool(ctx, "://not-a-valid-uri", PoolConfig{MaxOpenConns: 4})
+	assert.Error(t, err)
+}
+
+// TestCacheKey ensures retrievers sharing a URI but with different pool settings
+// resolve to distinct cache keys, while a zero config keeps the URI-only key.
+func TestCacheKey(t *testing.T) {
+	uri := "postgres://user:pass@localhost:5432/db"
+
+	assert.Equal(t, uri, cacheKey(uri, PoolConfig{}),
+		"zero config should key on the URI alone for backward compatibility")
+
+	a := cacheKey(uri, PoolConfig{MaxOpenConns: 10})
+	b := cacheKey(uri, PoolConfig{MaxOpenConns: 20})
+	assert.NotEqual(t, a, b, "different settings must produce different keys")
+	assert.NotEqual(t, uri, a, "a configured pool must not collide with the default key")
+
+	// Same settings yield the same key (stable).
+	assert.Equal(t,
+		cacheKey(uri, PoolConfig{MaxOpenConns: 10, ConnMaxLifetime: time.Hour}),
+		cacheKey(uri, PoolConfig{MaxOpenConns: 10, ConnMaxLifetime: time.Hour}))
+}

--- a/retriever/postgresqlretriever/postgres_test.go
+++ b/retriever/postgresqlretriever/postgres_test.go
@@ -42,11 +42,11 @@ func TestGetPool_MultipleURIsAndReuse(t *testing.T) {
 	uri2 := baseURI + "&application_name=B"
 
 	// First Calls (RefCount = 1)
-	pool1a, err := rr.GetPool(ctx, uri1)
+	pool1a, err := rr.GetPool(ctx, uri1, rr.PoolConfig{})
 	assert.NoError(t, err)
 	assert.NotNil(t, pool1a)
 
-	pool2a, err := rr.GetPool(ctx, uri2)
+	pool2a, err := rr.GetPool(ctx, uri2, rr.PoolConfig{})
 	assert.NoError(t, err)
 	assert.NotNil(t, pool2a)
 
@@ -54,32 +54,32 @@ func TestGetPool_MultipleURIsAndReuse(t *testing.T) {
 	assert.NotEqual(t, pool1a, pool2a)
 
 	// Reuse Logic (RefCount = 2 for URI1)
-	pool1b, err := rr.GetPool(ctx, uri1)
+	pool1b, err := rr.GetPool(ctx, uri1, rr.PoolConfig{})
 	assert.NoError(t, err)
 	assert.Equal(t, pool1a, pool1b, "Should return exact same pool instance")
 
 	// Release Logic
 	// URI1 RefCount: 2 -> 1
-	rr.ReleasePool(ctx, uri1)
+	rr.ReleasePool(ctx, uri1, rr.PoolConfig{})
 
 	// URI1 RefCount: 1 -> 0 (Closed & Removed)
-	rr.ReleasePool(ctx, uri1)
+	rr.ReleasePool(ctx, uri1, rr.PoolConfig{})
 
 	// Recreation Logic
 	// URI1 should now create a NEW pool
-	pool1c, err := rr.GetPool(ctx, uri1)
+	pool1c, err := rr.GetPool(ctx, uri1, rr.PoolConfig{})
 	assert.NoError(t, err)
 	assert.NotEqual(t, pool1a, pool1c, "Should be a new pool instance after full release")
 
 	// Cleanup new pool
-	rr.ReleasePool(ctx, uri1)
+	rr.ReleasePool(ctx, uri1, rr.PoolConfig{})
 
 	// URI2 Cleanup verification
-	rr.ReleasePool(ctx, uri2) // RefCount -> 0
+	rr.ReleasePool(ctx, uri2, rr.PoolConfig{}) // RefCount -> 0
 
-	pool2b, err := rr.GetPool(ctx, uri2)
+	pool2b, err := rr.GetPool(ctx, uri2, rr.PoolConfig{})
 	assert.NoError(t, err)
 	assert.NotEqual(t, pool2a, pool2b, "URI2 should be recreated")
 
-	rr.ReleasePool(ctx, uri2)
+	rr.ReleasePool(ctx, uri2, rr.PoolConfig{})
 }

--- a/retriever/postgresqlretriever/retriever.go
+++ b/retriever/postgresqlretriever/retriever.go
@@ -24,6 +24,10 @@ type Retriever struct {
 	Table   string
 	Columns map[string]string
 
+	// Pool holds the optional connection pool settings. When left at its zero
+	// value, the pool is created with pgxpool defaults exactly as before.
+	Pool PoolConfig
+
 	logger  *fflog.FFLogger
 	status  retriever.Status
 	columns map[string]string
@@ -45,7 +49,7 @@ func (r *Retriever) Init(ctx context.Context, logger *fflog.FFLogger, flagset *s
 		r.logger.Info("Initializing PostgreSQL retriever")
 		r.logger.Debug("Using columns", "columns", r.columns)
 
-		pool, err := GetPool(ctx, r.URI)
+		pool, err := GetPool(ctx, r.URI, r.Pool)
 		if err != nil {
 			r.status = retriever.RetrieverError
 			return err
@@ -69,7 +73,7 @@ func (r *Retriever) Status() retriever.Status {
 // Shutdown closes the database connection.
 func (r *Retriever) Shutdown(ctx context.Context) error {
 	if r.pool != nil {
-		ReleasePool(ctx, r.URI)
+		ReleasePool(ctx, r.URI, r.Pool)
 		r.pool = nil
 	}
 	return nil

--- a/website/docs/integrations/store-flags-configuration/postgresql.mdx
+++ b/website/docs/integrations/store-flags-configuration/postgresql.mdx
@@ -90,6 +90,10 @@ retrievers:
 | `uri`      |  <Mandatory />   | string | **none** | Connection URI of your postgres instance.                                                                                                                              |
 | `table`    |  <Mandatory />   | string | **none** | Name of the table where your flags are stored.                                                                                                                      |
 | `columns`  | <NotMandatory /> | object | **none** | Custom column name mapping. See [How to use custom column names](#how-to-use-custom-column-names) for more details.                                                                                                                       |
+| `maxOpenConns`    | <NotMandatory /> | int    | _driver default_ | Maximum number of open connections in the pool. See [How to configure the connection pool](#how-to-configure-the-connection-pool). |
+| `maxIdleConns`    | <NotMandatory /> | int    | _driver default_ | Minimum number of connections the pool keeps open (the pool floor). Must not be greater than `maxOpenConns`. |
+| `connMaxLifetime` | <NotMandatory /> | string | _driver default_ | Maximum lifetime of a connection, as a Go duration string (e.g. `1h`, `30m`). |
+| `connMaxIdleTime` | <NotMandatory /> | string | _driver default_ | Maximum idle time of a connection before it is closed, as a Go duration string (e.g. `5m`). |
 
 ### How to use custom column names
 
@@ -111,6 +115,27 @@ retrievers:
 
 The `columns` field, is a map of the default column names to the custom column names in your postgres table.
 
+### How to configure the connection pool
+
+By default the retriever relies on the driver defaults for connection pool sizing
+and lifetimes. For production workloads you can tune the pool by adding the
+optional pool settings. When a setting is omitted, the corresponding default is
+kept, so existing configurations are unaffected.
+
+```yaml title="goff-proxy.yaml"
+# ...
+retrievers:
+  - kind: postgresql
+    uri: "postgres://user:password@localhost:5432/dbname"
+    table: "go_feature_flag"
+    // highlight-start
+    maxOpenConns: 25
+    maxIdleConns: 5
+    connMaxLifetime: "1h"
+    connMaxIdleTime: "30m"
+    // highlight-end
+```
+
 
 ## Configure the GO Module
 To configure your GO module to use the {retrieverName} retriever, you need to add the following
@@ -127,6 +152,12 @@ err := ffclient.Init(ffclient.Config{
         "flagset": "namespace",
         "config": "settings",
       },
+      Pool: postgresqlretriever.PoolConfig{
+        MaxOpenConns:    25,
+        MaxIdleConns:    5,
+        ConnMaxLifetime: 1 * time.Hour,
+        ConnMaxIdleTime: 30 * time.Minute,
+      },
     },
 })
 defer ffclient.Close()
@@ -135,6 +166,7 @@ defer ffclient.Close()
 
 | Field         |    Mandatory     | Description                                                                                                                                      |
 |---------------|:----------------:|--------------------------------------------------------------------------------------------------------------------------------------------------|
-| `uri`      |  <Mandatory />   | Connection URI of your postgres instance.                                                                                                                              |
-| `table`    |  <Mandatory />   | Name of the table where your flags are stored.                                                                                                                      |
-| `columns`  | <NotMandatory /> | Custom column name mapping. See [How to use custom column names](#how-to-use-custom-column-names) for more details.                                                                                                                       |
+| `URI`      |  <Mandatory />   | Connection URI of your postgres instance.                                                                                                                              |
+| `Table`    |  <Mandatory />   | Name of the table where your flags are stored.                                                                                                                      |
+| `Columns`  | <NotMandatory /> | Custom column name mapping. See [How to use custom column names](#how-to-use-custom-column-names) for more details.                                                                                                                       |
+| `Pool`     | <NotMandatory /> | Optional connection pool settings (`MaxOpenConns`, `MaxIdleConns`, `ConnMaxLifetime`, `ConnMaxIdleTime`). When omitted, driver defaults are used. |

--- a/website/docs/integrations/store-flags-configuration/postgresql.mdx
+++ b/website/docs/integrations/store-flags-configuration/postgresql.mdx
@@ -90,10 +90,10 @@ retrievers:
 | `uri`      |  <Mandatory />   | string | **none** | Connection URI of your postgres instance.                                                                                                                              |
 | `table`    |  <Mandatory />   | string | **none** | Name of the table where your flags are stored.                                                                                                                      |
 | `columns`  | <NotMandatory /> | object | **none** | Custom column name mapping. See [How to use custom column names](#how-to-use-custom-column-names) for more details.                                                                                                                       |
-| `maxOpenConns`    | <NotMandatory /> | int    | _driver default_ | Maximum number of open connections in the pool. See [How to configure the connection pool](#how-to-configure-the-connection-pool). |
-| `maxIdleConns`    | <NotMandatory /> | int    | _driver default_ | Minimum number of connections the pool keeps open (the pool floor). Must not be greater than `maxOpenConns`. |
-| `connMaxLifetime` | <NotMandatory /> | string | _driver default_ | Maximum lifetime of a connection, as a Go duration string (e.g. `1h`, `30m`). |
-| `connMaxIdleTime` | <NotMandatory /> | string | _driver default_ | Maximum idle time of a connection before it is closed, as a Go duration string (e.g. `5m`). |
+| `maxConns`        | <NotMandatory /> | int    | _driver default_ | Maximum number of connections in the pool. See [How to configure the connection pool](#how-to-configure-the-connection-pool). |
+| `minConns`        | <NotMandatory /> | int    | _driver default_ | Minimum number of connections the pool keeps open. Must not be greater than `maxConns`. |
+| `maxConnLifetime` | <NotMandatory /> | string | _driver default_ | Maximum lifetime of a connection, as a Go duration string (e.g. `1h`, `30m`). |
+| `maxConnIdleTime` | <NotMandatory /> | string | _driver default_ | Maximum idle time of a connection before it is closed, as a Go duration string (e.g. `5m`). |
 
 ### How to use custom column names
 
@@ -129,10 +129,10 @@ retrievers:
     uri: "postgres://user:password@localhost:5432/dbname"
     table: "go_feature_flag"
     # highlight-start
-    maxOpenConns: 25
-    maxIdleConns: 5
-    connMaxLifetime: "1h"
-    connMaxIdleTime: "30m"
+    maxConns: 25
+    minConns: 5
+    maxConnLifetime: "1h"
+    maxConnIdleTime: "30m"
     # highlight-end
 ```
 
@@ -153,10 +153,10 @@ err := ffclient.Init(ffclient.Config{
         "config": "settings",
       },
       Pool: postgresqlretriever.PoolConfig{
-        MaxOpenConns:    25,
-        MaxIdleConns:    5,
-        ConnMaxLifetime: 1 * time.Hour,
-        ConnMaxIdleTime: 30 * time.Minute,
+        MaxConns:        25,
+        MinConns:        5,
+        MaxConnLifetime: 1 * time.Hour,
+        MaxConnIdleTime: 30 * time.Minute,
       },
     },
 })
@@ -169,4 +169,4 @@ defer ffclient.Close()
 | `URI`      |  <Mandatory />   | Connection URI of your postgres instance.                                                                                                                              |
 | `Table`    |  <Mandatory />   | Name of the table where your flags are stored.                                                                                                                      |
 | `Columns`  | <NotMandatory /> | Custom column name mapping. See [How to use custom column names](#how-to-use-custom-column-names) for more details.                                                                                                                       |
-| `Pool`     | <NotMandatory /> | Optional connection pool settings (`MaxOpenConns`, `MaxIdleConns`, `ConnMaxLifetime`, `ConnMaxIdleTime`). When omitted, driver defaults are used. |
+| `Pool`     | <NotMandatory /> | Optional connection pool settings (`MaxConns`, `MinConns`, `MaxConnLifetime`, `MaxConnIdleTime`). When omitted, driver defaults are used. |

--- a/website/docs/integrations/store-flags-configuration/postgresql.mdx
+++ b/website/docs/integrations/store-flags-configuration/postgresql.mdx
@@ -128,12 +128,12 @@ retrievers:
   - kind: postgresql
     uri: "postgres://user:password@localhost:5432/dbname"
     table: "go_feature_flag"
-    // highlight-start
+    # highlight-start
     maxOpenConns: 25
     maxIdleConns: 5
     connMaxLifetime: "1h"
     connMaxIdleTime: "30m"
-    // highlight-end
+    # highlight-end
 ```
 
 


### PR DESCRIPTION
## Description

The PostgreSQL retriever previously exposed only `uri`, `table`, and custom
column names, leaving the connection pool entirely at the driver defaults.
Production workloads on managed Postgres need control over pool sizing and
connection lifetimes for performance and resource safety.

This PR adds optional, per-retriever connection pool settings, following the
design the maintainer selected in #4835:

- `maxOpenConns` -> pgxpool `MaxConns`
- `maxIdleConns` -> pgxpool `MinConns` (the pool floor; pgxpool has no separate
  idle ceiling, idle connections are bounded by `MaxConns`)
- `connMaxLifetime` -> pgxpool `MaxConnLifetime`
- `connMaxIdleTime` -> pgxpool `MaxConnIdleTime`

How it works:

- A new `PoolConfig` is threaded through the `pgxpool` pool builder at the
  existing `GetPool` / `poolMap` seam in `postgres.go`. When no pool block is
  configured, the pool is built exactly as before (`pgxpool.New`), so existing
  configurations are byte-for-byte unaffected. When a pool block is present, the
  URI is parsed with `pgxpool.ParseConfig` and only the explicitly set fields are
  overridden.
- The cached `poolMap` is now keyed by URI **and** the pool config, so two
  retrievers that share a URI but request different pool settings no longer
  silently reuse the first pool created.
- The same fields are surfaced on `RetrieverConf` (relay proxy / config files)
  with validation in `validatePostgreSQLRetriever()` (negative values,
  `maxIdleConns` greater than `maxOpenConns`, and unparseable durations are
  rejected with a clear error) and wired through `createPostgreSQLRetriever`.
- Documentation for the new block is added to the PostgreSQL retriever docs.

How to test: see the new unit tests in
`retriever/postgresqlretriever/postgres_pool_test.go`,
`cmdhelpers/retrieverconf/retriever_conf_test.go`, and
`cmdhelpers/retrieverconf/init/retriever_init_test.go`. Building a pool does not
open a connection, so the pool-config tests run without a live database; the
existing testcontainers-backed pool test continues to cover end-to-end behavior.

No breaking change to configuration behavior: every new field is optional and
defaults preserve the current behavior.

## Closes issue(s)

Resolve #4835

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)

Fixes #4835
