### PR TITLE
refactor(bigqueryexporter): reduce buildRows cognitive complexity (Sonar S3776)

### DIFF
--- a/exporter/bigqueryexporter/exporter.go
+++ b/exporter/bigqueryexporter/exporter.go
@@ -153,40 +153,55 @@ func (e *Exporter) initClient(ctx context.Context) error {
 func (e *Exporter) buildRows(events []exporter.ExportableEvent) ([]rowSaver, bigquery.Schema, error) {
 	rows := make([]rowSaver, 0, len(events))
 	eventType := ""
-	var schema bigquery.Schema
 
 	for _, event := range events {
-		switch e := event.(type) {
-		case exporter.FeatureEvent:
-			if eventType == "" {
-				eventType = featureEventType
-				schema = featureEventSchema()
-			}
-			if eventType != featureEventType {
-				return nil, nil, fmt.Errorf("bigquery exporter received mixed event types")
-			}
-			row, err := featureEventRow(e)
-			if err != nil {
-				return nil, nil, err
-			}
-			rows = append(rows, row)
-		case exporter.TrackingEvent:
-			if eventType == "" {
-				eventType = trackingEventType
-				schema = trackingEventSchema()
-			}
-			if eventType != trackingEventType {
-				return nil, nil, fmt.Errorf("bigquery exporter received mixed event types")
-			}
-			row, err := trackingEventRow(e)
-			if err != nil {
-				return nil, nil, err
-			}
-			rows = append(rows, row)
+		row, rowType, err := buildRow(event)
+		if err != nil {
+			return nil, nil, err
 		}
+		if rowType == "" {
+			// Skip events this exporter does not handle.
+			continue
+		}
+		if eventType == "" {
+			eventType = rowType
+		}
+		if eventType != rowType {
+			return nil, nil, errors.New("bigquery exporter received mixed event types")
+		}
+		rows = append(rows, row)
 	}
 
-	return rows, schema, nil
+	return rows, schemaForEventType(eventType), nil
+}
+
+// buildRow converts a single exportable event into a BigQuery row and reports
+// the event type it belongs to. The returned event type is empty for events
+// this exporter does not handle.
+func buildRow(event exporter.ExportableEvent) (rowSaver, string, error) {
+	switch evt := event.(type) {
+	case exporter.FeatureEvent:
+		row, err := featureEventRow(evt)
+		return row, featureEventType, err
+	case exporter.TrackingEvent:
+		row, err := trackingEventRow(evt)
+		return row, trackingEventType, err
+	default:
+		return rowSaver{}, "", nil
+	}
+}
+
+// schemaForEventType returns the BigQuery schema matching the resolved event
+// type, or nil when no rows were produced.
+func schemaForEventType(eventType string) bigquery.Schema {
+	switch eventType {
+	case featureEventType:
+		return featureEventSchema()
+	case trackingEventType:
+		return trackingEventSchema()
+	default:
+		return nil
+	}
 }
 
 func (e *Exporter) exportRows(


### PR DESCRIPTION
## Description

Fixes the SonarCloud **new code** issue `go:S3776` on `exporter/bigqueryexporter/exporter.go:153` — *"Refactor this method to reduce its Cognitive Complexity from 21 to the 15 allowed."*

- **What was the problem?** `buildRows` validated event-type consistency and built rows inside a two-branch type `switch`, with each branch repeating the same `if eventType == ""` / `if eventType != …` / error-handling nesting. Cognitive complexity was 21 (limit 15).
- **How is it resolved?** Extracted two free helper functions:
  - `buildRow(event)` — converts a single event to a row and reports its event type (empty for unhandled types),
  - `schemaForEventType(eventType)` — resolves the schema once from the final event type.

  `buildRows` now loops, delegates, and performs the consistency check once at a single nesting level (complexity ~9). **Behavior is unchanged** — same rows, same schema, same `"bigquery exporter received mixed event types"` error on mixed batches, same skip of unhandled event types.
- **How can we test the change?** `go test ./exporter/bigqueryexporter/...` (42 tests pass); `golangci-lint run ./exporter/bigqueryexporter/...` reports 0 issues.

## Closes issue(s)

SonarCloud new-code cleanup — no tracked GitHub issue.

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code <!-- pure refactor; existing tests cover behavior -->
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
