### PR TITLE
refactor(s3retrieverv2): rename DownloaderAPI interface to Downloader (Sonar S8196)

### DIFF
--- a/retriever/s3retrieverv2/downloader_api.go
+++ b/retriever/s3retrieverv2/downloader_api.go
@@ -6,10 +6,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 )
 
-var _ DownloaderAPI = (*transfermanager.Client)(nil)
+var _ Downloader = (*transfermanager.Client)(nil)
 
-// DownloaderAPI provides methods to manage downloads from an S3 bucket.
-type DownloaderAPI interface {
+// Downloader provides methods to manage downloads from an S3 bucket.
+type Downloader interface {
 	// DownloadObject downloads an object from S3.
 	DownloadObject(
 		ctx context.Context,

--- a/retriever/s3retrieverv2/retriever.go
+++ b/retriever/s3retrieverv2/retriever.go
@@ -33,7 +33,7 @@ type Retriever struct {
 	S3ClientOptions []func(*s3.Options)
 
 	// downloader is an internal field, it is the downloader use by the AWS-SDK
-	downloader DownloaderAPI
+	downloader Downloader
 	status     retriever.Status
 }
 
@@ -96,6 +96,6 @@ func (s *Retriever) Retrieve(ctx context.Context) ([]byte, error) {
 	return writerAt.Bytes(), nil
 }
 
-func (s *Retriever) SetDownloader(downloader DownloaderAPI) {
+func (s *Retriever) SetDownloader(downloader Downloader) {
 	s.downloader = downloader
 }

--- a/retriever/s3retrieverv2/retriever_test.go
+++ b/retriever/s3retrieverv2/retriever_test.go
@@ -14,7 +14,7 @@ import (
 
 func Test_s3Retriever_Retrieve(t *testing.T) {
 	type fields struct {
-		downloader      DownloaderAPI
+		downloader      Downloader
 		bucket          string
 		item            string
 		context         context.Context


### PR DESCRIPTION
## Description

Fixes the SonarCloud **new code** issue `godre:S8196` on `retriever/s3retrieverv2/downloader_api.go:12` — *"Rename this interface to follow Go naming conventions for single-method interfaces."*

- **What was the problem?** The single-method interface was named `DownloaderAPI`. Go convention names single-method interfaces with an `-er` suffix (and the `API` suffix is discouraged).
- **How is it resolved?** Renamed the interface `DownloaderAPI` → `Downloader` and updated all references:
  - `retriever/s3retrieverv2/downloader_api.go` (interface declaration, compile-time assertion, doc comment)
  - `retriever/s3retrieverv2/retriever.go` (`downloader` field type and `SetDownloader` parameter)
  - `retriever/s3retrieverv2/retriever_test.go` (mock field type)

  Pure rename — no behavior change. `Downloader` ends in `-er` and reads idiomatically.
- **How can we test the change?** `go build ./retriever/s3retrieverv2/...`; `go test ./retriever/s3retrieverv2/...` (10 tests pass); `golangci-lint run ./retriever/s3retrieverv2/...` reports 0 issues. A repo-wide grep confirms no remaining `DownloaderAPI` references.

## Closes issue(s)

SonarCloud new-code cleanup — no tracked GitHub issue.

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code <!-- pure rename; existing tests cover behavior -->
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
