### PR TITLE
test: reduce cognitive complexity in six test functions (Sonar S3776)

### DIFF
--- a/cmd/cli/evaluate/evaluate_test.go
+++ b/cmd/cli/evaluate/evaluate_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/cmdhelpers/retrieverconf"
 	retrieverInit "github.com/thomaspoignant/go-feature-flag/cmdhelpers/retrieverconf/init"
 	"github.com/thomaspoignant/go-feature-flag/modules/core/model"
+	"github.com/thomaspoignant/go-feature-flag/retriever"
 	"github.com/thomaspoignant/go-feature-flag/retriever/bitbucketretriever"
 	"github.com/thomaspoignant/go-feature-flag/retriever/gcstorageretriever"
 	"github.com/thomaspoignant/go-feature-flag/retriever/githubretriever"
@@ -20,30 +21,67 @@ import (
 	"google.golang.org/api/option"
 )
 
+// evaluateTestCase describes a single Test_Evaluate scenario.
+type evaluateTestCase struct {
+	name           string
+	initEvaluate   func() (evaluate, error)
+	wantErr        assert.ErrorAssertionFunc
+	expectedErr    string
+	expectedResult map[string]model.RawVarResult
+}
+
+// buildEvaluate initializes a retriever from the given configuration and wraps
+// it into an evaluate ready to be executed. The optional customize callback is
+// invoked on the freshly initialized retriever (e.g. to inject a mocked client)
+// before the evaluate is returned.
+func buildEvaluate(
+	conf *retrieverconf.RetrieverConf,
+	flag string,
+	evaluationCtx string,
+	customize func(r retriever.Retriever),
+) (evaluate, error) {
+	r, err := retrieverInit.InitRetriever(conf)
+	if err != nil {
+		return evaluate{}, err
+	}
+	if customize != nil {
+		customize(r)
+	}
+	return evaluate{
+		retriever:     r,
+		fileFormat:    "yaml",
+		flag:          flag,
+		evaluationCtx: evaluationCtx,
+	}, nil
+}
+
+// assertEvaluate runs a single evaluateTestCase and verifies its outcome.
+func assertEvaluate(t *testing.T, tt evaluateTestCase) {
+	e, err := tt.initEvaluate()
+	if err != nil {
+		tt.wantErr(t, err)
+		return
+	}
+	m, err := e.Evaluate()
+	tt.wantErr(t, err)
+
+	if tt.expectedErr != "" {
+		assert.Equal(t, tt.expectedErr, err.Error())
+	}
+	if tt.expectedResult != nil {
+		assert.Equal(t, tt.expectedResult, m)
+	}
+}
+
 func Test_Evaluate(t *testing.T) {
-	tests := []struct {
-		name           string
-		initEvaluate   func() (evaluate, error)
-		wantErr        assert.ErrorAssertionFunc
-		expectedErr    string
-		expectedResult map[string]model.RawVarResult
-	}{
+	tests := []evaluateTestCase{
 		{
 			name: "Should error is config file does not exist",
 			initEvaluate: func() (evaluate, error) {
-				r, err := retrieverInit.InitRetriever(&retrieverconf.RetrieverConf{
+				return buildEvaluate(&retrieverconf.RetrieverConf{
 					Kind: "file",
 					Path: "testdata/invalid.yaml",
-				})
-				if err != nil {
-					return evaluate{}, err
-				}
-				return evaluate{
-					retriever:     r,
-					fileFormat:    "yaml",
-					flag:          "test-flag",
-					evaluationCtx: `{"targetingKey": "user-123"}`,
-				}, nil
+				}, "test-flag", `{"targetingKey": "user-123"}`, nil)
 			},
 			wantErr:     assert.Error,
 			expectedErr: "impossible to initialize the retrievers, please check your configuration: impossible to retrieve the flags, please check your configuration: open testdata/invalid.yaml: no such file or directory",
@@ -51,15 +89,9 @@ func Test_Evaluate(t *testing.T) {
 		{
 			name: "Should error if no evaluation context provided with flag containing percentage rules",
 			initEvaluate: func() (evaluate, error) {
-				r, err := retrieverInit.InitRetriever(&retrieverconf.RetrieverConf{Kind: "file", Path: "testdata/flag.goff.yaml"})
-				if err != nil {
-					return evaluate{}, err
-				}
-				return evaluate{
-					retriever:  r,
-					fileFormat: "yaml",
-					flag:       "simple-flag",
-				}, nil
+				return buildEvaluate(
+					&retrieverconf.RetrieverConf{Kind: "file", Path: "testdata/flag.goff.yaml"},
+					"simple-flag", "", nil)
 			},
 			wantErr: assert.NoError,
 			expectedResult: map[string]model.RawVarResult{
@@ -81,15 +113,9 @@ func Test_Evaluate(t *testing.T) {
 		{
 			name: "Should perform evaluation if no evaluation context and compatible flag",
 			initEvaluate: func() (evaluate, error) {
-				r, err := retrieverInit.InitRetriever(&retrieverconf.RetrieverConf{Kind: "file", Path: "testdata/flag.goff.yaml"})
-				if err != nil {
-					return evaluate{}, err
-				}
-				return evaluate{
-					retriever:  r,
-					fileFormat: "yaml",
-					flag:       "simple-flag",
-				}, nil
+				return buildEvaluate(
+					&retrieverconf.RetrieverConf{Kind: "file", Path: "testdata/flag.goff.yaml"},
+					"simple-flag", "", nil)
 			},
 			wantErr: assert.NoError,
 			expectedResult: map[string]model.RawVarResult{
@@ -111,16 +137,9 @@ func Test_Evaluate(t *testing.T) {
 		{
 			name: "Should error if evaluation context provided has no targeting key",
 			initEvaluate: func() (evaluate, error) {
-				r, err := retrieverInit.InitRetriever(&retrieverconf.RetrieverConf{Kind: "file", Path: "testdata/flag.goff.yaml"})
-				if err != nil {
-					return evaluate{}, err
-				}
-				return evaluate{
-					retriever:     r,
-					fileFormat:    "yaml",
-					flag:          "test-flag",
-					evaluationCtx: `{"id": "user-123"}`,
-				}, nil
+				return buildEvaluate(
+					&retrieverconf.RetrieverConf{Kind: "file", Path: "testdata/flag.goff.yaml"},
+					"test-flag", `{"id": "user-123"}`, nil)
 			},
 			wantErr: assert.NoError,
 			expectedResult: map[string]model.RawVarResult{
@@ -144,16 +163,9 @@ func Test_Evaluate(t *testing.T) {
 		{
 			name: "Should evaluate a single flag if flag name is provided",
 			initEvaluate: func() (evaluate, error) {
-				r, err := retrieverInit.InitRetriever(&retrieverconf.RetrieverConf{Kind: "file", Path: "testdata/flag.goff.yaml"})
-				if err != nil {
-					return evaluate{}, err
-				}
-				return evaluate{
-					retriever:     r,
-					fileFormat:    "yaml",
-					flag:          "test-flag",
-					evaluationCtx: `{"targetingKey": "user-123"}`,
-				}, nil
+				return buildEvaluate(
+					&retrieverconf.RetrieverConf{Kind: "file", Path: "testdata/flag.goff.yaml"},
+					"test-flag", `{"targetingKey": "user-123"}`, nil)
 			},
 			wantErr: assert.NoError,
 			expectedResult: map[string]model.RawVarResult{
@@ -177,15 +189,9 @@ func Test_Evaluate(t *testing.T) {
 		{
 			name: "Should evaluate all flags if flag name is not provided",
 			initEvaluate: func() (evaluate, error) {
-				r, err := retrieverInit.InitRetriever(&retrieverconf.RetrieverConf{Kind: "file", Path: "testdata/flag.goff.yaml"})
-				if err != nil {
-					return evaluate{}, err
-				}
-				return evaluate{
-					retriever:     r,
-					fileFormat:    "yaml",
-					evaluationCtx: `{"targetingKey": "user-123"}`,
-				}, nil
+				return buildEvaluate(
+					&retrieverconf.RetrieverConf{Kind: "file", Path: "testdata/flag.goff.yaml"},
+					"", `{"targetingKey": "user-123"}`, nil)
 			},
 			wantErr: assert.NoError,
 			expectedResult: map[string]model.RawVarResult{
@@ -235,26 +241,16 @@ func Test_Evaluate(t *testing.T) {
 		{
 			name: "Should evaluate a flag from a github repository",
 			initEvaluate: func() (evaluate, error) {
-				r, err := retrieverInit.InitRetriever(
-					&retrieverconf.RetrieverConf{
-						Kind:           "github",
-						RepositorySlug: "thomaspoignant/go-feature-flag",
-						GithubToken:    "XXX_GH_TOKEN",
-						Path:           "testdata/flag-config.yaml"})
-				if err != nil {
-					return evaluate{}, err
-				}
-
-				gitHubRetriever, ok := r.(*githubretriever.Retriever)
-				assert.True(t, ok, "failed to assert retriever to *githubretriever.Retriever")
-				gitHubRetriever.SetHTTPClient(&mock.HTTP{})
-
-				return evaluate{
-					retriever:     gitHubRetriever,
-					fileFormat:    "yaml",
-					flag:          "test-flag",
-					evaluationCtx: `{"targetingKey": "user-123"}`,
-				}, nil
+				return buildEvaluate(&retrieverconf.RetrieverConf{
+					Kind:           "github",
+					RepositorySlug: "thomaspoignant/go-feature-flag",
+					GithubToken:    "XXX_GH_TOKEN",
+					Path:           "testdata/flag-config.yaml",
+				}, "test-flag", `{"targetingKey": "user-123"}`, func(r retriever.Retriever) {
+					gitHubRetriever, ok := r.(*githubretriever.Retriever)
+					assert.True(t, ok, "failed to assert retriever to *githubretriever.Retriever")
+					gitHubRetriever.SetHTTPClient(&mock.HTTP{})
+				})
 			},
 			wantErr: assert.NoError,
 			expectedResult: map[string]model.RawVarResult{
@@ -275,27 +271,17 @@ func Test_Evaluate(t *testing.T) {
 		{
 			name: "Should evaluate a flag from a gitlab repository",
 			initEvaluate: func() (evaluate, error) {
-				r, err := retrieverInit.InitRetriever(
-					&retrieverconf.RetrieverConf{
-						Kind:           "gitlab",
-						BaseURL:        "https://gitlab.com/api/v4/",
-						RepositorySlug: "thomaspoignant/go-feature-flag",
-						AuthToken:      "XXX",
-						Path:           "testdata/flag-config.yaml"})
-				if err != nil {
-					return evaluate{}, err
-				}
-
-				gitLabRetriever, ok := r.(*gitlabretriever.Retriever)
-				assert.True(t, ok, "failed to assert retriever to *gitlabretriever.Retriever")
-				gitLabRetriever.SetHTTPClient(&mock.HTTP{})
-
-				return evaluate{
-					retriever:     gitLabRetriever,
-					fileFormat:    "yaml",
-					flag:          "test-flag",
-					evaluationCtx: `{"targetingKey": "user-123"}`,
-				}, nil
+				return buildEvaluate(&retrieverconf.RetrieverConf{
+					Kind:           "gitlab",
+					BaseURL:        "https://gitlab.com/api/v4/",
+					RepositorySlug: "thomaspoignant/go-feature-flag",
+					AuthToken:      "XXX",
+					Path:           "testdata/flag-config.yaml",
+				}, "test-flag", `{"targetingKey": "user-123"}`, func(r retriever.Retriever) {
+					gitLabRetriever, ok := r.(*gitlabretriever.Retriever)
+					assert.True(t, ok, "failed to assert retriever to *gitlabretriever.Retriever")
+					gitLabRetriever.SetHTTPClient(&mock.HTTP{})
+				})
 			},
 			wantErr: assert.NoError,
 			expectedResult: map[string]model.RawVarResult{
@@ -316,27 +302,17 @@ func Test_Evaluate(t *testing.T) {
 		{
 			name: "Should evaluate a flag from a bitbucket repository",
 			initEvaluate: func() (evaluate, error) {
-				r, err := retrieverInit.InitRetriever(
-					&retrieverconf.RetrieverConf{
-						Kind:           "bitbucket",
-						BaseURL:        "https://bitbucket.com/api/v4/",
-						RepositorySlug: "thomaspoignant/go-feature-flag",
-						AuthToken:      "XXX",
-						Path:           "testdata/flag-config.yaml"})
-				if err != nil {
-					return evaluate{}, err
-				}
-
-				bitBucketRetriever, ok := r.(*bitbucketretriever.Retriever)
-				assert.True(t, ok, "failed to assert retriever to *bitbucketretriever.Retriever")
-				bitBucketRetriever.SetHTTPClient(&mock.HTTP{})
-
-				return evaluate{
-					retriever:     bitBucketRetriever,
-					fileFormat:    "yaml",
-					flag:          "test-flag",
-					evaluationCtx: `{"targetingKey": "user-123"}`,
-				}, nil
+				return buildEvaluate(&retrieverconf.RetrieverConf{
+					Kind:           "bitbucket",
+					BaseURL:        "https://bitbucket.com/api/v4/",
+					RepositorySlug: "thomaspoignant/go-feature-flag",
+					AuthToken:      "XXX",
+					Path:           "testdata/flag-config.yaml",
+				}, "test-flag", `{"targetingKey": "user-123"}`, func(r retriever.Retriever) {
+					bitBucketRetriever, ok := r.(*bitbucketretriever.Retriever)
+					assert.True(t, ok, "failed to assert retriever to *bitbucketretriever.Retriever")
+					bitBucketRetriever.SetHTTPClient(&mock.HTTP{})
+				})
 			},
 			wantErr: assert.NoError,
 			expectedResult: map[string]model.RawVarResult{
@@ -360,30 +336,16 @@ func Test_Evaluate(t *testing.T) {
 				downloader := &testutils.S3ManagerV2Mock{
 					TestDataLocation: "./testdata",
 				}
-
-				r, err := retrieverInit.InitRetriever(
-					&retrieverconf.RetrieverConf{
-						Kind:   "s3",
-						Bucket: "Bucket",
-						Item:   "valid",
-					})
-
-				if err != nil {
-					return evaluate{}, err
-				}
-
-				s3Retriever, ok := r.(*s3retrieverv2.Retriever)
-				assert.True(t, ok, "failed to assert retriever to *s3retrieverv2.Retriever")
-				s3Retriever.SetDownloader(downloader)
-
-				_ = s3Retriever.Init(context.Background(), nil)
-
-				return evaluate{
-					retriever:     s3Retriever,
-					fileFormat:    "yaml",
-					flag:          "test-flag",
-					evaluationCtx: `{"targetingKey": "user-123"}`,
-				}, nil
+				return buildEvaluate(&retrieverconf.RetrieverConf{
+					Kind:   "s3",
+					Bucket: "Bucket",
+					Item:   "valid",
+				}, "test-flag", `{"targetingKey": "user-123"}`, func(r retriever.Retriever) {
+					s3Retriever, ok := r.(*s3retrieverv2.Retriever)
+					assert.True(t, ok, "failed to assert retriever to *s3retrieverv2.Retriever")
+					s3Retriever.SetDownloader(downloader)
+					_ = s3Retriever.Init(context.Background(), nil)
+				})
 			},
 			wantErr: assert.NoError,
 			expectedResult: map[string]model.RawVarResult{
@@ -405,29 +367,17 @@ func Test_Evaluate(t *testing.T) {
 		{
 			name: "Should evaluate a flag from a HTTP endpoint",
 			initEvaluate: func() (evaluate, error) {
-				r, err := retrieverInit.InitRetriever(
-					&retrieverconf.RetrieverConf{
-						Kind:        "http",
-						URL:         "http://localhost.example/file",
-						HTTPMethod:  http.MethodGet,
-						HTTPBody:    "",
-						HTTPHeaders: nil,
-					})
-
-				if err != nil {
-					return evaluate{}, err
-				}
-
-				httpRetriever, ok := r.(*httpretriever.Retriever)
-				assert.True(t, ok, "failed to assert retriever to *httpretriever.Retriever")
-				httpRetriever.SetHTTPClient(&mock.HTTP{})
-
-				return evaluate{
-					retriever:     httpRetriever,
-					fileFormat:    "yaml",
-					flag:          "test-flag",
-					evaluationCtx: `{"targetingKey": "user-123"}`,
-				}, nil
+				return buildEvaluate(&retrieverconf.RetrieverConf{
+					Kind:        "http",
+					URL:         "http://localhost.example/file",
+					HTTPMethod:  http.MethodGet,
+					HTTPBody:    "",
+					HTTPHeaders: nil,
+				}, "test-flag", `{"targetingKey": "user-123"}`, func(r retriever.Retriever) {
+					httpRetriever, ok := r.(*httpretriever.Retriever)
+					assert.True(t, ok, "failed to assert retriever to *httpretriever.Retriever")
+					httpRetriever.SetHTTPClient(&mock.HTTP{})
+				})
 			},
 			wantErr: assert.NoError,
 			expectedResult: map[string]model.RawVarResult{
@@ -450,31 +400,18 @@ func Test_Evaluate(t *testing.T) {
 			initEvaluate: func() (evaluate, error) {
 				mockedStorage := testutils.NewMockedGCS(t)
 				mockedStorage.WithFiles(t, "flags", map[string]string{"testdata/flag-config.yaml": "flag-config.yaml"})
-
-				r, err := retrieverInit.InitRetriever(
-					&retrieverconf.RetrieverConf{
-						Kind:   "googleStorage",
-						Bucket: "flags",
-						Object: "flag-config.yaml",
+				return buildEvaluate(&retrieverconf.RetrieverConf{
+					Kind:   "googleStorage",
+					Bucket: "flags",
+					Object: "flag-config.yaml",
+				}, "test-flag", `{"targetingKey": "user-123"}`, func(r retriever.Retriever) {
+					gcsRetriever, ok := r.(*gcstorageretriever.Retriever)
+					assert.True(t, ok, "failed to assert retriever to *gcstorageretriever.Retriever")
+					gcsRetriever.SetOptions([]option.ClientOption{
+						option.WithoutAuthentication(),
+						option.WithHTTPClient(mockedStorage.Server.HTTPClient()),
 					})
-
-				if err != nil {
-					return evaluate{}, err
-				}
-
-				gcsRetriever, ok := r.(*gcstorageretriever.Retriever)
-				assert.True(t, ok, "failed to assert retriever to *gcstorageretriever.Retriever")
-				gcsRetriever.SetOptions([]option.ClientOption{
-					option.WithoutAuthentication(),
-					option.WithHTTPClient(mockedStorage.Server.HTTPClient()),
 				})
-
-				return evaluate{
-					retriever:     gcsRetriever,
-					fileFormat:    "yaml",
-					flag:          "test-flag",
-					evaluationCtx: `{"targetingKey": "user-123"}`,
-				}, nil
 			},
 			wantErr: assert.NoError,
 			expectedResult: map[string]model.RawVarResult{
@@ -496,21 +433,7 @@ func Test_Evaluate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			e, err := tt.initEvaluate()
-			if err != nil {
-				tt.wantErr(t, err)
-				return
-			}
-			m, err := e.Evaluate()
-			tt.wantErr(t, err)
-
-			if tt.expectedErr != "" {
-				assert.Equal(t, tt.expectedErr, err.Error())
-			}
-
-			if tt.expectedResult != nil {
-				assert.Equal(t, tt.expectedResult, m)
-			}
+			assertEvaluate(t, tt)
 		})
 	}
 }

--- a/cmd/cli/generate/generate_cmd_test.go
+++ b/cmd/cli/generate/generate_cmd_test.go
@@ -5,23 +5,26 @@ import (
 	"testing"
 
 	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thomaspoignant/go-feature-flag/cmd/cli/generate"
 )
 
+type generateCmdTestCase struct {
+	name          string
+	args          []string
+	wantErr       bool
+	expectedErr   string
+	expectedOut   string
+	checkManifest bool
+}
+
 func TestNewGenerateCmd(t *testing.T) {
 	pterm.DisableStyling()
 	pterm.DisableColor()
 
-	tests := []struct {
-		name          string
-		args          []string
-		wantErr       bool
-		expectedErr   string
-		expectedOut   string
-		checkManifest bool
-	}{
+	tests := []generateCmdTestCase{
 		{
 			name:        "no subcommand provided",
 			args:        []string{},
@@ -48,27 +51,46 @@ func TestNewGenerateCmd(t *testing.T) {
 
 			err := cmd.Execute()
 
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.expectedErr)
-			} else {
-				require.NoError(t, err)
-			}
-
-			if tt.expectedOut != "" {
-				assert.Equal(t, tt.expectedOut, buf.String())
-			}
-
-			if tt.checkManifest {
-				found := false
-				for _, c := range cmd.Commands() {
-					if c.Name() == "manifest" {
-						found = true
-						break
-					}
-				}
-				assert.True(t, found, "manifest subcommand should be wired into generate")
-			}
+			verifyGenerateCmdResult(t, tt, cmd, &buf, err)
 		})
 	}
+}
+
+// verifyGenerateCmdResult asserts the outcome of executing the generate command
+// for a single test case. Keeping it flat (no deep nesting) avoids inflating the
+// cognitive complexity of the parent test.
+func verifyGenerateCmdResult(
+	t *testing.T,
+	tt generateCmdTestCase,
+	cmd *cobra.Command,
+	buf *bytes.Buffer,
+	err error,
+) {
+	t.Helper()
+
+	if tt.wantErr {
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), tt.expectedErr)
+	} else {
+		require.NoError(t, err)
+	}
+
+	if tt.expectedOut != "" {
+		assert.Equal(t, tt.expectedOut, buf.String())
+	}
+
+	if tt.checkManifest {
+		assert.True(t, hasManifestSubcommand(cmd),
+			"manifest subcommand should be wired into generate")
+	}
+}
+
+// hasManifestSubcommand reports whether the manifest subcommand is wired into cmd.
+func hasManifestSubcommand(cmd *cobra.Command) bool {
+	for _, c := range cmd.Commands() {
+		if c.Name() == "manifest" {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/relayproxy/api/server_test.go
+++ b/cmd/relayproxy/api/server_test.go
@@ -344,11 +344,7 @@ func Test_VersionHeader_Disabled(t *testing.T) {
 
 func Test_AuthenticationMiddleware(t *testing.T) {
 	t.Run("Non Admin Endpoint", func(t *testing.T) {
-		tests := []struct {
-			name          string
-			configAPIKeys *config.APIKeys
-			want          int // http status code
-		}{
+		tests := []authMiddlewareTestCase{
 			{
 				name:          "Authentication disabled",
 				configAPIKeys: nil,
@@ -371,66 +367,15 @@ func Test_AuthenticationMiddleware(t *testing.T) {
 			},
 		}
 
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				proxyConf := &config.Config{
-					CommonFlagSet: config.CommonFlagSet{
-						Retrievers: &[]retrieverconf.RetrieverConf{
-							{
-								Kind: "file",
-								Path: "../../../testdata/flag-config.yaml",
-							},
-						},
-					},
-					Server: config.Server{
-						Mode: config.ServerModeHTTP,
-						Port: 11024,
-					},
-					DisableVersionHeader: true,
-				}
-				if tt.configAPIKeys != nil {
-					proxyConf.AuthorizedKeys = *tt.configAPIKeys
-				}
-				proxyConf.ForceReloadAPIKeys()
-
-				log := log.InitLogger()
-				defer func() { _ = log.ZapLogger.Sync() }()
-
-				metricsV2, err := metric.NewMetrics()
-				require.NoError(t, err)
-				wsService := stream.NewWebsocketService()
-				defer wsService.Close()
-				flagsetManager, err := service.NewFlagsetManager(proxyConf, log.ZapLogger, nil, nil)
-				require.NoError(t, err)
-
-				services := service.Services{
-					MonitoringService: service.NewMonitoring(flagsetManager),
-					WebsocketService:  wsService,
-					FlagsetManager:    flagsetManager,
-					Metrics:           metricsV2,
-				}
-
-				s := api.New(proxyConf, services, log.ZapLogger)
-				go func() { s.StartWithContext(context.Background()) }()
-				defer s.Stop(context.Background())
-				time.Sleep(10 * time.Millisecond)
-
-				response, err := http.Post("http://localhost:11024/ofrep/v1/evaluate/flags/test-flag", "application/json",
-					strings.NewReader(`{"context":{"targetingKey":"some-key"}}`),
-				)
-				assert.NoError(t, err)
-				defer func() { _ = response.Body.Close() }()
-				assert.Equal(t, tt.want, response.StatusCode)
-			})
-		}
+		runAuthMiddlewareTests(t, tests, func(_ *testing.T, _ authMiddlewareTestCase) (*http.Response, error) {
+			return http.Post("http://localhost:11024/ofrep/v1/evaluate/flags/test-flag", "application/json",
+				strings.NewReader(`{"context":{"targetingKey":"some-key"}}`),
+			)
+		})
 	})
 
 	t.Run("Admin Endpoint", func(t *testing.T) {
-		tests := []struct {
-			name          string
-			configAPIKeys *config.APIKeys
-			want          int // http status code
-		}{
+		tests := []authMiddlewareTestCase{
 			{
 				name:          "Authentication disabled",
 				configAPIKeys: nil,
@@ -453,63 +398,83 @@ func Test_AuthenticationMiddleware(t *testing.T) {
 			},
 		}
 
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				proxyConf := &config.Config{
-					CommonFlagSet: config.CommonFlagSet{
-						Retrievers: &[]retrieverconf.RetrieverConf{
-							{
-								Kind: "file",
-								Path: "../../../testdata/flag-config.yaml",
-							},
+		runAuthMiddlewareTests(t, tests, func(t *testing.T, tt authMiddlewareTestCase) (*http.Response, error) {
+			request, err := http.NewRequest("POST", "http://localhost:11024/admin/v1/retriever/refresh", nil)
+			assert.NoError(t, err)
+			request.Header.Add("Content-Type", "application/json")
+			if tt.configAPIKeys != nil && len(tt.configAPIKeys.Admin) > 0 {
+				request.Header.Add("Authorization", "Bearer "+tt.configAPIKeys.Admin[0])
+			}
+			return http.DefaultClient.Do(request)
+		})
+	})
+}
+
+type authMiddlewareTestCase struct {
+	name          string
+	configAPIKeys *config.APIKeys
+	want          int // http status code
+}
+
+// runAuthMiddlewareTests starts a relay proxy for each test case, issues the
+// request returned by doRequest, and asserts the resulting HTTP status code.
+// It holds the shared table-test setup so Test_AuthenticationMiddleware stays flat.
+func runAuthMiddlewareTests(
+	t *testing.T,
+	tests []authMiddlewareTestCase,
+	doRequest func(t *testing.T, tt authMiddlewareTestCase) (*http.Response, error),
+) {
+	t.Helper()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxyConf := &config.Config{
+				CommonFlagSet: config.CommonFlagSet{
+					Retrievers: &[]retrieverconf.RetrieverConf{
+						{
+							Kind: "file",
+							Path: "../../../testdata/flag-config.yaml",
 						},
 					},
-					Server: config.Server{
-						Mode: config.ServerModeHTTP,
-						Port: 11024,
-					},
-					DisableVersionHeader: true,
-				}
-				if tt.configAPIKeys != nil {
-					proxyConf.AuthorizedKeys = *tt.configAPIKeys
-				}
-				proxyConf.ForceReloadAPIKeys()
+				},
+				Server: config.Server{
+					Mode: config.ServerModeHTTP,
+					Port: 11024,
+				},
+				DisableVersionHeader: true,
+			}
+			if tt.configAPIKeys != nil {
+				proxyConf.AuthorizedKeys = *tt.configAPIKeys
+			}
+			proxyConf.ForceReloadAPIKeys()
 
-				log := log.InitLogger()
-				defer func() { _ = log.ZapLogger.Sync() }()
+			log := log.InitLogger()
+			defer func() { _ = log.ZapLogger.Sync() }()
 
-				metricsV2, err := metric.NewMetrics()
-				require.NoError(t, err)
-				wsService := stream.NewWebsocketService()
-				defer wsService.Close()
-				flagsetManager, err := service.NewFlagsetManager(proxyConf, log.ZapLogger, nil, nil)
-				require.NoError(t, err)
+			metricsV2, err := metric.NewMetrics()
+			require.NoError(t, err)
+			wsService := stream.NewWebsocketService()
+			defer wsService.Close()
+			flagsetManager, err := service.NewFlagsetManager(proxyConf, log.ZapLogger, nil, nil)
+			require.NoError(t, err)
 
-				services := service.Services{
-					MonitoringService: service.NewMonitoring(flagsetManager),
-					WebsocketService:  wsService,
-					FlagsetManager:    flagsetManager,
-					Metrics:           metricsV2,
-				}
+			services := service.Services{
+				MonitoringService: service.NewMonitoring(flagsetManager),
+				WebsocketService:  wsService,
+				FlagsetManager:    flagsetManager,
+				Metrics:           metricsV2,
+			}
 
-				s := api.New(proxyConf, services, log.ZapLogger)
-				go func() { s.StartWithContext(context.Background()) }()
-				defer s.Stop(context.Background())
-				time.Sleep(10 * time.Millisecond)
+			s := api.New(proxyConf, services, log.ZapLogger)
+			go func() { s.StartWithContext(context.Background()) }()
+			defer s.Stop(context.Background())
+			time.Sleep(10 * time.Millisecond)
 
-				request, err := http.NewRequest("POST", "http://localhost:11024/admin/v1/retriever/refresh", nil)
-				assert.NoError(t, err)
-				request.Header.Add("Content-Type", "application/json")
-				if tt.configAPIKeys != nil && len(tt.configAPIKeys.Admin) > 0 {
-					request.Header.Add("Authorization", "Bearer "+tt.configAPIKeys.Admin[0])
-				}
-				response, err := http.DefaultClient.Do(request)
-				assert.NoError(t, err)
-				defer func() { _ = response.Body.Close() }()
-				assert.Equal(t, tt.want, response.StatusCode)
-			})
-		}
-	})
+			response, err := doRequest(t, tt)
+			assert.NoError(t, err)
+			defer func() { _ = response.Body.Close() }()
+			assert.Equal(t, tt.want, response.StatusCode)
+		})
+	}
 }
 
 // Helper function to create an HTTP client that can connect via Unix socket

--- a/cmd/relayproxy/handler/goff/collect_eval_data_test.go
+++ b/cmd/relayproxy/handler/goff/collect_eval_data_test.go
@@ -243,26 +243,7 @@ func Test_collect_eval_data_Handler(t *testing.T) {
 			assert.NoError(t, err)
 			defer os.Remove(exporterFile.Name())
 
-			if len(tt.config.FlagSets) > 0 {
-				out := make([]config.FlagSet, len(tt.config.FlagSets))
-				for index, flagSet := range tt.config.FlagSets {
-					flagSet.Exporters = &[]config.ExporterConf{
-						{
-							Kind:     "file",
-							Filename: exporterFile.Name(),
-						},
-					}
-					out[index] = flagSet
-				}
-				tt.config.FlagSets = out
-			} else {
-				tt.config.Exporters = &[]config.ExporterConf{
-					{
-						Kind:     "file",
-						Filename: exporterFile.Name(),
-					},
-				}
-			}
+			setCollectEvalDataFileExporter(&tt.config, exporterFile.Name())
 
 			flagsetManager, err := service.NewFlagsetManager(&tt.config, zap.NewNop(), []notifier.Notifier{}, nil)
 			assert.NoError(t, err)
@@ -292,14 +273,7 @@ func Test_collect_eval_data_Handler(t *testing.T) {
 			handlerErr := ctrl.Handler(c)
 
 			if tt.want.handlerErr {
-				assert.Error(t, handlerErr, "handler should return an error")
-				he, ok := handlerErr.(*echo.HTTPError)
-				if ok {
-					assert.Equal(t, tt.want.errorCode, he.Code)
-					assert.Equal(t, tt.want.errorMsg, he.Message)
-				} else {
-					assert.Equal(t, tt.want.errorMsg, handlerErr.Error())
-				}
+				assertCollectEvalDataHandlerError(t, handlerErr, tt.want.errorCode, tt.want.errorMsg)
 				return
 			}
 			flagsetManager.Close()
@@ -321,6 +295,39 @@ func Test_collect_eval_data_Handler(t *testing.T) {
 			assert.JSONEq(t, string(wantCollectData), string(exportedData), "Invalid exported data")
 		})
 	}
+}
+
+// setCollectEvalDataFileExporter configures cfg to export collected data to the
+// given file, handling both the flag-set and the legacy single-config layouts.
+func setCollectEvalDataFileExporter(cfg *config.Config, filename string) {
+	exporter := config.ExporterConf{
+		Kind:     "file",
+		Filename: filename,
+	}
+	if len(cfg.FlagSets) == 0 {
+		cfg.Exporters = &[]config.ExporterConf{exporter}
+		return
+	}
+	out := make([]config.FlagSet, len(cfg.FlagSets))
+	for index, flagSet := range cfg.FlagSets {
+		flagSet.Exporters = &[]config.ExporterConf{exporter}
+		out[index] = flagSet
+	}
+	cfg.FlagSets = out
+}
+
+// assertCollectEvalDataHandlerError asserts that the handler returned the
+// expected error, supporting both echo.HTTPError and plain error values.
+func assertCollectEvalDataHandlerError(t *testing.T, handlerErr error, errorCode int, errorMsg string) {
+	t.Helper()
+	assert.Error(t, handlerErr, "handler should return an error")
+	he, ok := handlerErr.(*echo.HTTPError)
+	if !ok {
+		assert.Equal(t, errorMsg, handlerErr.Error())
+		return
+	}
+	assert.Equal(t, errorCode, he.Code)
+	assert.Equal(t, errorMsg, he.Message)
 }
 
 func TestCollectEvalData_Handler_cancellation(t *testing.T) {

--- a/exporter/fileexporter/exporter_test.go
+++ b/exporter/fileexporter/exporter_test.go
@@ -466,53 +466,79 @@ func TestFile_Export(t *testing.T) {
 			assert.Equal(t, 1, len(files), "Directory %s should have only one file", outputDir)
 			assert.Regexp(t, tt.expected.fileNameRegex, files[0].Name(), "Invalid file name")
 
-			if tt.fields.Format == "parquet" {
-				switch tt.fields.EventType {
-				case "tracking":
-					fr, err := local.NewLocalFileReader(outputDir + "/" + files[0].Name())
-					assert.NoError(t, err)
-					defer fr.Close()
-					pr, err := reader.NewParquetReader(
-						fr,
-						new(exporter.TrackingEvent),
-						int64(runtime.NumCPU()),
-					)
-					assert.NoError(t, err)
-					defer pr.ReadStop()
-					gotFeatureEvents := make([]exporter.TrackingEvent, pr.GetNumRows())
-					err = pr.Read(&gotFeatureEvents)
-					assert.NoError(t, err)
-					assert.ElementsMatch(t, tt.expected.trackingEvents, gotFeatureEvents)
-					return
-				default:
-					fr, err := local.NewLocalFileReader(outputDir + "/" + files[0].Name())
-					assert.NoError(t, err)
-					defer fr.Close()
-					pr, err := reader.NewParquetReader(
-						fr,
-						new(exporter.FeatureEvent),
-						int64(runtime.NumCPU()),
-					)
-					assert.NoError(t, err)
-					defer pr.ReadStop()
-					gotFeatureEvents := make([]exporter.FeatureEvent, pr.GetNumRows())
-					err = pr.Read(&gotFeatureEvents)
-					assert.NoError(t, err)
-					assert.ElementsMatch(t, tt.expected.featureEvents, gotFeatureEvents)
-					return
-				}
-			}
-
-			expectedContent, _ := os.ReadFile(tt.expected.content)
-			gotContent, _ := os.ReadFile(outputDir + "/" + files[0].Name())
-			assert.Equal(
+			assertExportOutput(
 				t,
-				string(expectedContent),
-				string(gotContent),
-				"Wrong content in the output file",
+				tt.fields.Format,
+				tt.fields.EventType,
+				outputDir+"/"+files[0].Name(),
+				tt.expected.content,
+				tt.expected.featureEvents,
+				tt.expected.trackingEvents,
 			)
 		})
 	}
+}
+
+// readParquetFeatureEvents reads the parquet file at filePath and returns the
+// FeatureEvent records it contains.
+func readParquetFeatureEvents(t *testing.T, filePath string) []exporter.FeatureEvent {
+	t.Helper()
+	fr, err := local.NewLocalFileReader(filePath)
+	assert.NoError(t, err)
+	defer fr.Close()
+	pr, err := reader.NewParquetReader(fr, new(exporter.FeatureEvent), int64(runtime.NumCPU()))
+	assert.NoError(t, err)
+	defer pr.ReadStop()
+	gotFeatureEvents := make([]exporter.FeatureEvent, pr.GetNumRows())
+	err = pr.Read(&gotFeatureEvents)
+	assert.NoError(t, err)
+	return gotFeatureEvents
+}
+
+// readParquetTrackingEvents reads the parquet file at filePath and returns the
+// TrackingEvent records it contains.
+func readParquetTrackingEvents(t *testing.T, filePath string) []exporter.TrackingEvent {
+	t.Helper()
+	fr, err := local.NewLocalFileReader(filePath)
+	assert.NoError(t, err)
+	defer fr.Close()
+	pr, err := reader.NewParquetReader(fr, new(exporter.TrackingEvent), int64(runtime.NumCPU()))
+	assert.NoError(t, err)
+	defer pr.ReadStop()
+	gotTrackingEvents := make([]exporter.TrackingEvent, pr.GetNumRows())
+	err = pr.Read(&gotTrackingEvents)
+	assert.NoError(t, err)
+	return gotTrackingEvents
+}
+
+// assertExportOutput validates the exported file. Parquet output is decoded and
+// compared against the expected feature or tracking events depending on the
+// event type; any other format is compared byte-for-byte against the expected
+// content file.
+func assertExportOutput(
+	t *testing.T,
+	format, eventType, filePath, expectedContentPath string,
+	expectedFeatureEvents []exporter.FeatureEvent,
+	expectedTrackingEvents []exporter.TrackingEvent,
+) {
+	t.Helper()
+	if format == "parquet" {
+		if eventType == "tracking" {
+			assert.ElementsMatch(t, expectedTrackingEvents, readParquetTrackingEvents(t, filePath))
+			return
+		}
+		assert.ElementsMatch(t, expectedFeatureEvents, readParquetFeatureEvents(t, filePath))
+		return
+	}
+
+	expectedContent, _ := os.ReadFile(expectedContentPath)
+	gotContent, _ := os.ReadFile(filePath)
+	assert.Equal(
+		t,
+		string(expectedContent),
+		string(gotContent),
+		"Wrong content in the output file",
+	)
 }
 
 func TestFile_IsBulk(t *testing.T) {

--- a/retriever/manager_test.go
+++ b/retriever/manager_test.go
@@ -136,39 +136,53 @@ func TestManagerInit_AllRetrieverTypes(t *testing.T) {
 			}
 
 			// Verify that Init was called on the expected retrievers
-			for retrieverName, shouldBeCalled := range tt.expectedInitCalls {
-				retrieverFound := false
-				for _, r := range tt.retrievers {
-					if mockRetriever, ok := r.(interface{ GetName() string }); ok {
-						if mockRetriever.GetName() == retrieverName {
-							retrieverFound = true
-							if legacyRetriever, ok := r.(*mockretriever.InitializableRetrieverLegacy); ok {
-								if shouldBeCalled {
-									assert.True(t, legacyRetriever.InitCalled, "Init should have been called on %s", retrieverName)
-								}
-							}
-							if standardRetriever, ok := r.(*mockretriever.InitializableRetriever); ok {
-								if shouldBeCalled {
-									assert.True(t, standardRetriever.InitCalled, "Init should have been called on %s", retrieverName)
-								}
-							}
-							if flagsetRetriever, ok := r.(*mockretriever.InitializableRetrieverWithFlagset); ok {
-								if shouldBeCalled {
-									assert.True(t, flagsetRetriever.InitCalled, "Init should have been called on %s", retrieverName)
-								}
-							}
-							break
-						}
-					}
-				}
-				if shouldBeCalled {
-					assert.True(t, retrieverFound, "Retriever %s should have been found", retrieverName)
-				}
-			}
+			assertInitCalls(t, tt.retrievers, tt.expectedInitCalls)
 
 			// Clean up
 			_ = manager.Shutdown(ctx)
 		})
+	}
+}
+
+// findRetrieverByName returns the first retriever exposing GetName() == name,
+// or nil when none matches.
+func findRetrieverByName(retrievers []retriever.Retriever, name string) retriever.Retriever {
+	for _, r := range retrievers {
+		if named, ok := r.(interface{ GetName() string }); ok && named.GetName() == name {
+			return r
+		}
+	}
+	return nil
+}
+
+// initCalled reports whether Init was recorded as called on a mock retriever.
+// The second return value is false when r is not an initializable mock type.
+func initCalled(r retriever.Retriever) (called bool, ok bool) {
+	switch v := r.(type) {
+	case *mockretriever.InitializableRetrieverLegacy:
+		return v.InitCalled, true
+	case *mockretriever.InitializableRetriever:
+		return v.InitCalled, true
+	case *mockretriever.InitializableRetrieverWithFlagset:
+		return v.InitCalled, true
+	default:
+		return false, false
+	}
+}
+
+// assertInitCalls verifies that Init was called on each retriever that the test
+// case expects to have been initialized.
+func assertInitCalls(t *testing.T, retrievers []retriever.Retriever, expected map[string]bool) {
+	t.Helper()
+	for name, shouldBeCalled := range expected {
+		if !shouldBeCalled {
+			continue
+		}
+		r := findRetrieverByName(retrievers, name)
+		assert.NotNil(t, r, "Retriever %s should have been found", name)
+		if called, ok := initCalled(r); ok {
+			assert.True(t, called, "Init should have been called on %s", name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Fixes 6 SonarCloud **new code** `go:S3776` issues — *"Refactor this method to reduce its Cognitive Complexity … to the 15 allowed."* — one per test function across six packages.

- **What was the problem?** Six table-driven test functions inlined deeply-nested setup/assertion logic (nested loops, type-assertion ladders, format `switch`es, conditional setup), pushing cognitive complexity above the limit of 15.
- **How is it resolved?** Each function keeps its full test table and assertions, but the nested per-case logic is extracted into focused, package-private helper functions, flattening nesting. **No behavior or assertion is changed.**

  | File | Complexity | Helpers extracted |
  |---|---|---|
  | `retriever/manager_test.go` | 72 → ~5 | `findRetrieverByName`, `initCalled`, `assertInitCalls` |
  | `cmd/cli/evaluate/evaluate_test.go` | 34 → ~2 | `buildEvaluate`, `assertEvaluate` (+ named case type) |
  | `cmd/relayproxy/handler/goff/collect_eval_data_test.go` | 23 → ~10 | `setCollectEvalDataFileExporter`, `assertCollectEvalDataHandlerError` |
  | `exporter/fileexporter/exporter_test.go` | 21 → ~14 | `readParquetFeatureEvents`, `readParquetTrackingEvents`, `assertExportOutput` |
  | `cmd/cli/generate/generate_cmd_test.go` | 20 → ~2 | `verifyGenerateCmdResult`, `hasManifestSubcommand` |
  | `cmd/relayproxy/api/server_test.go` | 17 → <15 | `runAuthMiddlewareTests` (+ named case type) |

- **How can we test the change?** `go test ./retriever/ ./cmd/cli/evaluate/ ./cmd/relayproxy/api/ ./cmd/cli/generate/ ./cmd/relayproxy/handler/goff/ ./exporter/fileexporter/` — all pass; `golangci-lint run` over the six packages reports 0 issues; `gofmt -l` clean.

## Closes issue(s)

SonarCloud new-code cleanup — no tracked GitHub issue.

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code <!-- test-only refactor; existing assertions preserved -->
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
