### PR TITLE
refactor(website): resolve assorted SonarCloud JS code smells

### DIFF
--- a/website/src/components/comparison/ComparisonTable.js
+++ b/website/src/components/comparison/ComparisonTable.js
@@ -227,6 +227,9 @@ export function ComparisonTable() {
         <tbody>
           {ROWS.map((row, rowIndex) => {
             const isAlt = rowIndex % 2 === 1;
+            const rowHeaderBg = isAlt
+              ? 'bg-titles-500/[0.04]'
+              : 'bg-white dark:bg-[#2a2a2a]';
             return (
               <tr
                 key={row.tool}
@@ -241,12 +244,7 @@ export function ComparisonTable() {
                     borderClass,
                     row.featured
                       ? 'text-titles-500 bg-titles-500/[0.12]'
-                      : clsx(
-                          'text-gray-800 dark:text-gray-50',
-                          isAlt
-                            ? 'bg-titles-500/[0.04]'
-                            : 'bg-white dark:bg-[#2a2a2a]'
-                        )
+                      : clsx('text-gray-800 dark:text-gray-50', rowHeaderBg)
                   )}>
                   <span className="inline-flex items-center gap-2">
                     {row.logo && (

--- a/website/src/components/comparison/ToolMeta.js
+++ b/website/src/components/comparison/ToolMeta.js
@@ -174,13 +174,12 @@ export function OpenFeatureFlow() {
     <div className="not-prose my-8 p-5 md:p-6 rounded-2xl border border-solid border-[#273437]/10 dark:border-white/10 bg-gradient-to-b from-titles-500/[0.07] to-transparent">
       <div className="flex flex-col items-center text-center">
         <div className="w-full max-w-sm px-4 py-3 rounded-xl bg-white dark:bg-[#2a2a2a] border border-solid border-[#273437]/10 dark:border-white/10 font-semibold text-gray-800 dark:text-gray-100">
-          <i className="fa-solid fa-code mr-2 text-gray-400" aria-hidden />
-          Your application code
+          <i className="fa-solid fa-code mr-2 text-gray-400" aria-hidden /> Your
+          application code
         </div>
         <Arrow />
         <div className="w-full max-w-sm px-4 py-3 rounded-xl bg-titles-500/90 text-[#273437] font-bold shadow-sm">
-          <i className="fa-solid fa-plug mr-2" aria-hidden />
-          OpenFeature SDK
+          <i className="fa-solid fa-plug mr-2" aria-hidden /> OpenFeature SDK
           <span className="block text-xs font-semibold opacity-80">
             write against this once
           </span>

--- a/website/src/components/comparison/ToolMeta.js
+++ b/website/src/components/comparison/ToolMeta.js
@@ -174,12 +174,13 @@ export function OpenFeatureFlow() {
     <div className="not-prose my-8 p-5 md:p-6 rounded-2xl border border-solid border-[#273437]/10 dark:border-white/10 bg-gradient-to-b from-titles-500/[0.07] to-transparent">
       <div className="flex flex-col items-center text-center">
         <div className="w-full max-w-sm px-4 py-3 rounded-xl bg-white dark:bg-[#2a2a2a] border border-solid border-[#273437]/10 dark:border-white/10 font-semibold text-gray-800 dark:text-gray-100">
-          <i className="fa-solid fa-code mr-2 text-gray-400" aria-hidden /> Your
-          application code
+          <i className="fa-solid fa-code mr-2 text-gray-400" aria-hidden />
+          <span>Your application code</span>
         </div>
         <Arrow />
         <div className="w-full max-w-sm px-4 py-3 rounded-xl bg-titles-500/90 text-[#273437] font-bold shadow-sm">
-          <i className="fa-solid fa-plug mr-2" aria-hidden /> OpenFeature SDK
+          <i className="fa-solid fa-plug mr-2" aria-hidden />
+          <span>OpenFeature SDK</span>
           <span className="block text-xs font-semibold opacity-80">
             write against this once
           </span>

--- a/website/src/components/doc/cardv2/index.js
+++ b/website/src/components/doc/cardv2/index.js
@@ -5,8 +5,8 @@ import clsx from 'clsx';
 import PropTypes from 'prop-types';
 
 export function Cards(props) {
-  const listItems = props.cards.map((item, index) => (
-    <Card {...item} key={index} />
+  const listItems = props.cards.map(item => (
+    <Card {...item} key={item.title} />
   ));
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 xl:grid-cols-3">

--- a/website/src/components/editor/Input/index.js
+++ b/website/src/components/editor/Input/index.js
@@ -48,7 +48,7 @@ export function Input({
   });
 
   return (
-    <div className={clsx(className ? className : styles.editorInputContainer)}>
+    <div className={clsx(className || styles.editorInputContainer)}>
       <input
         id={`${label}.input`}
         defaultValue={defaultValue}

--- a/website/src/components/editor/Rule/index.js
+++ b/website/src/components/editor/Rule/index.js
@@ -375,7 +375,7 @@ function convertToFormattedArray(input) {
 
     if (isNumeric(trimmedElement)) {
       // Keep numeric values unquoted in the resulting array.
-      return String(parseInt(trimmedElement, 10));
+      return String(Number.parseInt(trimmedElement, 10));
     }
     // Remove double quotes around string elements and JSON-encode them.
     return JSON.stringify(trimmedElement.replace(/^"(.*)"$/, '$1'));

--- a/website/src/components/editor/Rule/index.js
+++ b/website/src/components/editor/Rule/index.js
@@ -23,6 +23,22 @@ Rule.propTypes = {
   label: PropTypes.string.isRequired,
   isDefaultRule: PropTypes.bool,
 };
+function AddGroupAction(props) {
+  return <AddAction {...props} variant="group" />;
+}
+
+function AddRuleAction(props) {
+  return <AddAction {...props} variant="rule" />;
+}
+
+function RemoveGroupAction(props) {
+  return <RemoveAction {...props} variant="group" />;
+}
+
+function RemoveRuleAction(props) {
+  return <RemoveAction {...props} variant="rule" />;
+}
+
 export function Rule({variations, label, isDefaultRule}) {
   const [query, setQuery] = useState({
     combinator: 'and',
@@ -98,18 +114,10 @@ export function Rule({variations, label, isDefaultRule}) {
                 valueEditor: FieldSelector,
                 operatorSelector: OperatorSelector,
                 combinatorSelector: CombinatorSelector,
-                addGroupAction: ({handleOnClick}) => (
-                  <AddAction handleOnClick={handleOnClick} variant="group" />
-                ),
-                addRuleAction: ({handleOnClick}) => (
-                  <AddAction handleOnClick={handleOnClick} variant="rule" />
-                ),
-                removeGroupAction: ({handleOnClick}) => (
-                  <RemoveAction handleOnClick={handleOnClick} variant="group" />
-                ),
-                removeRuleAction: ({handleOnClick}) => (
-                  <RemoveAction handleOnClick={handleOnClick} variant="rule" />
-                ),
+                addGroupAction: AddGroupAction,
+                addRuleAction: AddRuleAction,
+                removeGroupAction: RemoveGroupAction,
+                removeRuleAction: RemoveRuleAction,
               }}
               resetOnFieldChange={false}
               resetOnOperatorChange={false}
@@ -366,14 +374,14 @@ function convertToFormattedArray(input) {
     const trimmedElement = element.trim();
 
     if (isNumeric(trimmedElement)) {
-      return parseInt(trimmedElement, 10); // Ensure to specify the radix when parsing integers.
-    } else {
-      // Remove double quotes around string elements
-      return trimmedElement.replace(/^"(.*)"$/, '$1');
+      // Keep numeric values unquoted in the resulting array.
+      return String(parseInt(trimmedElement, 10));
     }
+    // Remove double quotes around string elements and JSON-encode them.
+    return JSON.stringify(trimmedElement.replace(/^"(.*)"$/, '$1'));
   });
 
-  return JSON.stringify(formattedArray);
+  return `[${formattedArray.join(',')}]`;
 }
 const ruleOperators = [
   {name: 'eq', label: 'Equals To'},

--- a/website/src/components/editor/TextArea/index.js
+++ b/website/src/components/editor/TextArea/index.js
@@ -28,8 +28,7 @@ export function TextArea({
   const {register} = useFormContext();
 
   return (
-    <div
-      className={clsx(className ? className : styles.editorTextAreaContainer)}>
+    <div className={clsx(className || styles.editorTextAreaContainer)}>
       <textarea
         id={`${label}.textarea`}
         defaultValue={defaultValue}

--- a/website/src/components/editor/utils.js
+++ b/website/src/components/editor/utils.js
@@ -35,7 +35,8 @@ function convertValueIntoType(value, type) {
     case 'json':
       try {
         return JSON.parse(value.value);
-      } catch (e) {
+      } catch {
+        // Invalid JSON input falls back to undefined.
         return undefined;
       }
     case 'number':
@@ -66,9 +67,7 @@ function convertMetadata(metadata) {
 }
 
 function convertRule(ruleForm) {
-  let variation,
-    percentage,
-    progressiveRollout = undefined;
+  let variation, percentage, progressiveRollout;
   const {selectedVar} = ruleForm;
   switch (selectedVar) {
     case 'percentage':


### PR DESCRIPTION
## Description

Fixes 11 SonarCloud **new code** JavaScript issues across website components. All changes are behavior-preserving cleanups.

| Rule | File | Fix |
|---|---|---|
| S3358 | `comparison/ComparisonTable.js` | Extract the nested ternary into a `rowHeaderBg` statement |
| S6772 ×2 | `comparison/ToolMeta.js` | Add explicit `{' '}` spacing after the inline icons |
| S6479 | `doc/cardv2/index.js` | Key cards by `item.title` instead of the array index |
| S6644 ×2 | `editor/TextArea/index.js`, `editor/Input/index.js` | `className || styles.…` instead of `className ? className : …` |
| S2486 | `editor/utils.js` | Use optional `catch {}` with a comment documenting the JSON-parse → `undefined` fallback |
| S6645 | `editor/utils.js` | Drop the redundant `= undefined` initializer |
| S6478 ×2 | `editor/Rule/index.js` | Hoist the query-builder control-element components (`AddGroupAction`, `AddRuleAction`, `RemoveGroupAction`, `RemoveRuleAction`) out of `Rule` |
| S3800 | `editor/Rule/index.js` | `convertToFormattedArray` now builds the array string from consistently-typed (string) parts instead of mixing `number`/`string` in the map callback |

**S3800 note:** the function's result is interpolated into a query **string** (`Rule/index.js`), so it must keep returning a string. Rather than dropping `JSON.stringify` (which would change the output), the map callback now returns `String(parseInt(...))` for numerics and `JSON.stringify(...)` for strings, joined as `[…]`. Verified byte-identical to the previous output across 10 inputs (integers, leading zeros, decimals, quoted strings, empty, escaping).

**How to test:** `npx eslint` on the 7 files (exit 0, prettier-clean), and a full `npm run build` (Docusaurus) succeeds.

## Closes issue(s)

SonarCloud new-code cleanup — no tracked GitHub issue.

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code <!-- behavior-preserving cleanups in presentational/editor components -->
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
