### PR TITLE
style(website): remove commented-out CSS (Sonar S125)

### DIFF
--- a/website/src/components/editor/Select/styles.module.css
+++ b/website/src/components/editor/Select/styles.module.css
@@ -19,7 +19,6 @@
     );
   color: var(--goff-editor-input-placeholder);
   border-radius: 0.25em;
-  /*box-shadow: 0 0 1em 0 rgba(0, 0, 0, 0.2);*/
   cursor: pointer;
 }
 .selector select option {

--- a/website/src/components/editor/Switch/styles.module.css
+++ b/website/src/components/editor/Switch/styles.module.css
@@ -56,7 +56,6 @@
   height: 0.35rem;
   color: #fff;
   font-weight: bold;
-  /*text-align: center;*/
   line-height: 1;
   padding: 0.55rem 0.25rem;
   background-color: var(--goff-message-error);

--- a/website/src/pages/API_relayproxy/index.module.css
+++ b/website/src/pages/API_relayproxy/index.module.css
@@ -4,10 +4,5 @@
  */
 
 .redocContainer {
-  /*background-color: var(--goff-sponsor-bg);*/
   background-color: white;
-}
-
-.redocContainer h1 {
-  /*font-size: 13rem;*/
 }


### PR DESCRIPTION
## Description

Fixes 4 SonarCloud **new code** `css:S125` issues — *"Remove this commented out code."*

- **What was the problem?** Four blocks of dead, commented-out CSS were left in the codebase.
- **How is it resolved?** Removed them:
  - `editor/Select/styles.module.css` — `/*box-shadow: 0 0 1em 0 rgba(0, 0, 0, 0.2);*/`
  - `editor/Switch/styles.module.css` — `/*text-align: center;*/`
  - `pages/API_relayproxy/index.module.css` — `/*background-color: var(--goff-sponsor-bg);*/` and `/*font-size: 13rem;*/`. The latter left `.redocContainer h1 { }` empty, so the whole now-dead rule is removed too.

  The legitimate header doc-comment in `index.module.css` is kept. No rendered styles change (only dead comments removed).
- **How can we test the change?** `npx prettier --check` on the three files passes; no functional CSS was touched.

## Closes issue(s)

SonarCloud new-code cleanup — no tracked GitHub issue.

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code <!-- dead-comment removal, no behavior change -->
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
