### PR TITLE
fix(website): raise doc-card button contrast to WCAG AA (Sonar S7924)

### DIFF
--- a/website/src/components/doc/cards/styles.module.css
+++ b/website/src/components/doc/cards/styles.module.css
@@ -40,7 +40,7 @@
     padding: 12px 24px;
     border-radius: 50px;
     font-weight: 600;
-    color: #0077ff;
+    color: #0055cc;
     background-color: #e0efff;
     margin: 0 auto;
     display: block;
@@ -56,7 +56,7 @@
 
 .button:focus,
 .button:hover {
-    background-color: #0077ff;
+    background-color: #0055cc;
     color: #e0efff;
 }
 

--- a/website/src/components/doc/configCardContent/styles.module.css
+++ b/website/src/components/doc/configCardContent/styles.module.css
@@ -4,7 +4,7 @@
     padding: 0.5rem 1rem;
     border-radius: 0.5rem;
     font-weight: 600;
-    color: #0077ff;
+    color: #0055cc;
     background-color: #e0efff;
     display: block;
 
@@ -14,7 +14,7 @@
 
 .button:focus,
 .button:hover {
-    background-color: #0077ff;
+    background-color: #0055cc;
     color: #e0efff;
 }
 


### PR DESCRIPTION
## Description

Fixes 4 SonarCloud **new code** `css:S7924` issues — *"Text does not meet the minimal contrast requirement with its background."* — on the documentation card buttons.

- **What was the problem?** The `.button` style used blue `#0077ff` text on a light-blue `#e0efff` background (and the inverse on hover/focus). That pairing measures **3.53:1**, below the WCAG AA minimum of **4.5:1** for normal text. Affected: `doc/configCardContent/styles.module.css` (default + `:hover`/`:focus`) and `doc/cards/styles.module.css` (same).
- **How is it resolved?** Darkened the blue from `#0077ff` to **`#0055cc`** (one symmetric change covering both states, since the default text color and the hover background were the same value). Both states now measure **5.66:1 — PASS AA**, while keeping the same blue-button design language. The light `#e0efff` accent is unchanged.
- **How can we test the change?** Computed WCAG contrast: `#0055cc`↔`#e0efff` = 5.66:1 (was 3.53:1). `npx prettier --check` on both files passes.

> Design note (per the agreed conservative approach): this changes the button blue slightly. Visually it remains the same inverted light/dark-blue button — please confirm the shade in review.

## Closes issue(s)

SonarCloud new-code cleanup — no tracked GitHub issue.

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code <!-- CSS color/contrast change -->
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
