### PR TITLE
fix(python-provider): use logger.exception in refresh error handler (Sonar S8572)

### DIFF
--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/evaluator/inprocess_evaluator.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/evaluator/inprocess_evaluator.py
@@ -93,10 +93,7 @@ class InProcessEvaluator(AbstractEvaluator):
         try:
             response = self._api.retrieve_flag_configuration(etag=etag)
         except Exception:
-            logger.error(
-                "Failed to refresh flag configuration",
-                exc_info=True,
-            )
+            logger.exception("Failed to refresh flag configuration")
             return
         with self._lock:
             if response.flags:


### PR DESCRIPTION
## Description

Fixes the SonarCloud **new code** issue `python:S8572` on `gofeatureflag_python_provider/evaluator/inprocess_evaluator.py:96` — *"Use `logging.exception()` instead."*

- **What was the problem?** Inside the `except Exception:` handler of `_refresh_flag_configuration`, the code logged with `logger.error("…", exc_info=True)`.
- **How is it resolved?** Replaced it with `logger.exception("Failed to refresh flag configuration")`. `logger.exception()` is the idiomatic call inside an `except` block — it logs at ERROR level and automatically attaches the active exception's traceback, so it is behavior-equivalent and clearer.
- **How can we test the change?** `uv run pytest tests/test_inprocess_evaluator.py` — 28 tests pass, including `test_poll_error_keeps_previous_state`, which drives this exact `except` path. `python3 -m py_compile` and `uv run black --check` both pass.

## Closes issue(s)

SonarCloud new-code cleanup — no tracked GitHub issue.

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code <!-- existing error-path test covers this handler -->
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
