### PR TITLE
ci: Re-enable govulncheck scoped to the relay proxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,24 +282,24 @@ jobs:
           cache: false
       - run: make tidy-check
 
-  # Govulncheck:
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-  #       with:
-  #         fetch-depth: 1
-  #         persist-credentials: false
-  #     - name: Setup go
-  #       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-  #       with:
-  #         go-version-file: go.mod
-  #         check-latest: true
-  #         cache: false
-  #     - name: Run govulncheck
-  #       run: make vuln-check
+  Govulncheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Setup go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: false
+      - name: Run govulncheck
+        run: make vuln-check-relayproxy
 
   WasmBuild:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,10 @@ vuln-check: ## Run govulncheck on all modules in the workspace
 		cd - >/dev/null; \
 	done
 
+vuln-check-relayproxy: ## Run govulncheck on the relay proxy only
+	@which govulncheck > /dev/null 2>&1 || $(GOCMD) install golang.org/x/vuln/cmd/govulncheck@latest
+	$(GOWORK_ENV) govulncheck ./cmd/relayproxy/...
+
 ## Help:
 help: ## Show this help.
 	@echo ''


### PR DESCRIPTION
## Description

This PR re-enables the `Govulncheck` CI job, which was previously commented out.

Running `govulncheck` across the entire Go workspace was noisy and slow, so this scopes the scan to the relay proxy — the deployed artifact where vulnerability signal matters most.

This PR contains the following changes:
- Uncomments the `Govulncheck` job in `.github/workflows/ci.yml`.
- Points the job at a new `make vuln-check-relayproxy` target.
- Adds `vuln-check-relayproxy` to the `Makefile`, running `govulncheck ./cmd/relayproxy/...`.

The existing `vuln-check` target (full workspace) is left untouched for local use. No breaking changes.

## Closes issue(s)

Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
