### PR TITLE
fix: apply scheduled rollout steps in chronological order so the most recent step wins

### DIFF
--- a/modules/core/flag/internal_flag.go
+++ b/modules/core/flag/internal_flag.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"sort"
 	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/modules/core/ffcontext"
@@ -219,43 +220,56 @@ func (f *InternalFlag) applyScheduledRolloutSteps(evaluationDate time.Time) (*In
 		return &InternalFlag{}, err
 	}
 
+	// We only keep the steps that are already active (date in the past or now).
+	dueSteps := make([]ScheduledStep, 0, len(*f.Scheduled))
+	for _, step := range *f.Scheduled {
+		if step.Date != nil &&
+			(step.Date.Before(evaluationDate) || step.Date.Equal(evaluationDate)) {
+			dueSteps = append(dueSteps, step)
+		}
+	}
+
+	// We apply the steps in chronological order (oldest first) so that, when
+	// several steps edit the same rule/field, the most recent step always wins
+	// regardless of the order they are declared in the configuration.
+	// The sort is stable so that steps sharing the exact same date keep their
+	// declaration order (the last one declared is applied last, and wins).
+	sort.SliceStable(dueSteps, func(i, j int) bool {
+		return dueSteps[i].Date.Before(*dueSteps[j].Date)
+	})
+
 	// We apply the scheduled rollout
-	for _, steps := range *f.Scheduled {
-		if steps.Date != nil &&
-			(steps.Date.Before(evaluationDate) || steps.Date.Equal(evaluationDate)) {
-			flagCopy.Rules = MergeSetOfRules(f.GetRules(), steps.GetRules())
-			if steps.Disable != nil {
-				flagCopy.Disable = steps.Disable
-			}
+	for _, steps := range dueSteps {
+		flagCopy.Rules = MergeSetOfRules(flagCopy.GetRules(), steps.GetRules())
+		if steps.Disable != nil {
+			flagCopy.Disable = steps.Disable
+		}
 
-			if steps.TrackEvents != nil {
-				flagCopy.TrackEvents = steps.TrackEvents
-			}
+		if steps.TrackEvents != nil {
+			flagCopy.TrackEvents = steps.TrackEvents
+		}
 
-			if steps.DefaultRule != nil {
-				flagCopy.DefaultRule.MergeRules(*steps.DefaultRule)
-			}
+		if steps.DefaultRule != nil {
+			flagCopy.DefaultRule.MergeRules(*steps.DefaultRule)
+		}
 
-			if steps.Variations != nil {
-				for key, value := range steps.GetVariations() {
-					flagCopy.GetVariations()[key] = value
-				}
-			}
+		if steps.Variations != nil {
+			maps.Copy(flagCopy.GetVariations(), steps.GetVariations())
+		}
 
-			if steps.Version != nil {
-				flagCopy.Version = steps.Version
-			}
+		if steps.Version != nil {
+			flagCopy.Version = steps.Version
+		}
 
-			if steps.Experimentation != nil {
-				if flagCopy.Experimentation == nil {
-					flagCopy.Experimentation = &ExperimentationRollout{}
-				}
-				if steps.Experimentation.Start != nil {
-					flagCopy.Experimentation.Start = steps.Experimentation.Start
-				}
-				if steps.Experimentation.End != nil {
-					flagCopy.Experimentation.End = steps.Experimentation.End
-				}
+		if steps.Experimentation != nil {
+			if flagCopy.Experimentation == nil {
+				flagCopy.Experimentation = &ExperimentationRollout{}
+			}
+			if steps.Experimentation.Start != nil {
+				flagCopy.Experimentation.Start = steps.Experimentation.Start
+			}
+			if steps.Experimentation.End != nil {
+				flagCopy.Experimentation.End = steps.Experimentation.End
 			}
 		}
 	}

--- a/modules/core/flag/internal_flag_test.go
+++ b/modules/core/flag/internal_flag_test.go
@@ -1075,6 +1075,154 @@ func TestInternalFlag_Value(t *testing.T) {
 			},
 		},
 		{
+			name: "Should apply the most recent scheduled step when two steps edit the same rule name (newest date wins)",
+			flag: flag.InternalFlag{
+				Variations: &map[string]*any{
+					"variationTrue":  testconvert.Interface(true),
+					"variationFalse": testconvert.Interface(false),
+				},
+				Rules: &[]flag.Rule{
+					{
+						Name:            testconvert.String("DEV environment"),
+						Query:           testconvert.String(`{"===":[{"var":"EnvironmentUUID"},"0ffcc8da-1f70-4229-8ef7-b5a3130cdd52"]}`),
+						VariationResult: testconvert.String("variationFalse"),
+					},
+				},
+				DefaultRule: &flag.Rule{
+					Name:            testconvert.String("Default"),
+					VariationResult: testconvert.String("variationFalse"),
+				},
+				Metadata: &map[string]any{
+					"type":       "ADVANCED_FLAG",
+					"metadataId": "5cbd0920-7b2c-4186-9cca-3313de925fe2",
+				},
+				Scheduled: &[]flag.ScheduledStep{
+					{ // newest date, listed first
+						InternalFlag: flag.InternalFlag{
+							Rules: &[]flag.Rule{
+								{
+									Name:            testconvert.String("DEV environment"),
+									Query:           testconvert.String(`{"===":[{"var":"EnvironmentUUID"},"0ffcc8da-1f70-4229-8ef7-b5a3130cdd52"]}`),
+									VariationResult: testconvert.String("variationFalse"),
+								},
+							},
+						},
+						Date: testconvert.Time(time.Date(2026, 6, 11, 9, 50, 0, 0, time.UTC)),
+					},
+					{ // oldest date, listed second
+						InternalFlag: flag.InternalFlag{
+							Rules: &[]flag.Rule{
+								{
+									Name:            testconvert.String("DEV environment"),
+									Query:           testconvert.String(`{"===":[{"var":"EnvironmentUUID"},"0ffcc8da-1f70-4229-8ef7-b5a3130cdd52"]}`),
+									VariationResult: testconvert.String("variationTrue"),
+								},
+							},
+						},
+						Date: testconvert.Time(time.Date(2026, 6, 11, 9, 49, 0, 0, time.UTC)),
+					},
+				},
+			},
+			args: args{
+				flagName: "my-flag",
+				user: ffcontext.NewEvaluationContextBuilder("user-key").
+					AddCustom("EnvironmentUUID", "0ffcc8da-1f70-4229-8ef7-b5a3130cdd52").
+					AddCustom("gofeatureflag", ffcontext.GoffContextSpecifics{
+						CurrentDateTime: testconvert.Time(
+							time.Date(2026, 6, 11, 9, 51, 0, 0, time.UTC),
+						),
+					}).
+					Build(),
+				flagContext: flag.Context{
+					DefaultSdkValue: false,
+				},
+			},
+			// Newest scheduled step (09:50, variationFalse) must win over the
+			// older one (09:49, variationTrue).
+			want: false,
+			want1: flag.ResolutionDetails{
+				Variant:   "variationFalse",
+				Reason:    flag.ReasonTargetingMatch,
+				RuleIndex: testconvert.Int(0),
+				RuleName:  testconvert.String("DEV environment"),
+				Metadata: map[string]any{
+					"type":              "ADVANCED_FLAG",
+					"metadataId":        "5cbd0920-7b2c-4186-9cca-3313de925fe2",
+					"evaluatedRuleName": "DEV environment",
+				},
+			},
+		},
+		{
+			name: "Should keep rules added by an earlier scheduled step when a later step adds another rule",
+			flag: flag.InternalFlag{
+				Variations: &map[string]*any{
+					"variation_A": testconvert.Interface("value_A"),
+					"variation_B": testconvert.Interface("value_B"),
+					"variation_C": testconvert.Interface("value_C"),
+				},
+				DefaultRule: &flag.Rule{
+					VariationResult: testconvert.String("variation_A"),
+				},
+				Metadata: &map[string]any{
+					"description": "this is a flag",
+					"issue-link":  "https://issue.link/GOFF-1",
+				},
+				Scheduled: &[]flag.ScheduledStep{
+					{ // older step adds rule-a
+						InternalFlag: flag.InternalFlag{
+							Rules: &[]flag.Rule{
+								{
+									Name:            testconvert.String("rule-a"),
+									Query:           testconvert.String("key eq \"user-a\""),
+									VariationResult: testconvert.String("variation_B"),
+								},
+							},
+						},
+						Date: testconvert.Time(time.Date(2026, 6, 11, 9, 49, 0, 0, time.UTC)),
+					},
+					{ // newer step adds a different rule-b
+						InternalFlag: flag.InternalFlag{
+							Rules: &[]flag.Rule{
+								{
+									Name:            testconvert.String("rule-b"),
+									Query:           testconvert.String("key eq \"user-b\""),
+									VariationResult: testconvert.String("variation_C"),
+								},
+							},
+						},
+						Date: testconvert.Time(time.Date(2026, 6, 11, 9, 50, 0, 0, time.UTC)),
+					},
+				},
+			},
+			args: args{
+				flagName: "my-flag",
+				user: ffcontext.NewEvaluationContextBuilder("user-a").
+					AddCustom("gofeatureflag", ffcontext.GoffContextSpecifics{
+						CurrentDateTime: testconvert.Time(
+							time.Date(2026, 6, 11, 9, 51, 0, 0, time.UTC),
+						),
+					}).
+					Build(),
+				flagContext: flag.Context{
+					DefaultSdkValue: "value_default",
+				},
+			},
+			// rule-a (added by the older step) must survive after the newer step
+			// adds rule-b, so a "user-a" context still matches rule-a.
+			want: "value_B",
+			want1: flag.ResolutionDetails{
+				Variant:   "variation_B",
+				Reason:    flag.ReasonTargetingMatch,
+				RuleIndex: testconvert.Int(0),
+				RuleName:  testconvert.String("rule-a"),
+				Metadata: map[string]any{
+					"description":       "this is a flag",
+					"issue-link":        "https://issue.link/GOFF-1",
+					"evaluatedRuleName": "rule-a",
+				},
+			},
+		},
+		{
 			name: "Should ignore scheduled steps with no dates",
 			flag: flag.InternalFlag{
 				Variations: &map[string]*any{


### PR DESCRIPTION
## Description

**What was the problem?**
When a flag has multiple scheduled rollout steps that edit the **same targeting rule name**, the step with the **older date** could win over the one with the newer date. A user reported that "the old date is always overriding the new date."

Root cause: `InternalFlag.applyScheduledRolloutSteps` iterated over the scheduled steps **in the order they were declared in the configuration**, applying every step whose `date <= evaluationDate`. It never ordered them by date, so whichever step appeared **last in the array won** on conflicts. When the config lists the newest step first and the oldest second, the oldest step was applied last and overrode the newer one.

**How it is resolved?**
- Collect the due steps (`date != nil && date <= evaluationDate`) and **sort them by date ascending** (stable sort) before applying, so the most recent step is always applied last and wins on conflicts, regardless of declaration order.
- Accumulate rule edits onto the working copy (`MergeSetOfRules(flagCopy.GetRules(), ...)`) instead of resetting from the original flag each iteration, so successive edits build on each other — consistent with how `Disable`, `DefaultRule`, `Variations`, etc. are already merged. This also removes a latent bug where the original flag's rule slice was mutated in place on every evaluation.

**How can we test the change?**
Two regression tests were added in `modules/core/flag/internal_flag_test.go`:
- `Should apply the most recent scheduled step when two steps edit the same rule name (newest date wins)` — reproduces the reported case (newest date declared first, oldest second); asserts the newest step wins.
- `Should keep rules added by an earlier scheduled step when a later step adds another rule` — locks in the cross-step rule accumulation.

Run: `cd modules/core && go test ./flag/ -run TestInternalFlag_Value`

No breaking changes.

## Closes issue(s)
Resolve #5533

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`) <!-- N/A: internal evaluation-logic fix, no user-facing behavior/config change -->
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
