### PR TITLE
docs: add A/B testing product landing page

### DIFF
--- a/website/src/components/navbar/product.js
+++ b/website/src/components/navbar/product.js
@@ -2,6 +2,7 @@ import {
   FaFlag,
   FaToggleOn,
   FaVial,
+  FaFlask,
   FaRobot,
   FaCode,
   FaPuzzlePiece,
@@ -28,6 +29,7 @@ export function generateProductDropdownHTML() {
           icon: FaToggleOn,
         },
         {label: 'Rollouts', href: '/product/rollouts', icon: MdRocketLaunch},
+        {label: 'A/B Testing', href: '/product/ab-testing', icon: FaFlask},
         {
           label: 'Test in Production',
           href: '/product/test_in_production',

--- a/website/src/pages/product/ab-testing/index.js
+++ b/website/src/pages/product/ab-testing/index.js
@@ -164,6 +164,10 @@ export default function AbTestingPage() {
   const githubUrl =
     siteConfig.customFields?.github ??
     'https://github.com/thomaspoignant/go-feature-flag';
+  const imgOverview = useBaseUrl('/img/landing/ab-testing/schema-overview.svg');
+  const imgSplit = useBaseUrl('/img/landing/ab-testing/schema-split.svg');
+  const imgCollect = useBaseUrl('/img/landing/ab-testing/schema-collect.svg');
+  const imgMeasure = useBaseUrl('/img/landing/ab-testing/schema-measure.svg');
 
   return (
     <Layout
@@ -207,7 +211,7 @@ export default function AbTestingPage() {
       <FeatureRow
         eyebrow="The idea"
         title="Test two versions, let the data pick the winner"
-        imageSrc={useBaseUrl('/img/landing/ab-testing/schema-overview.svg')}
+        imageSrc={imgOverview}
         imageAlt="Users are split into variation A and variation B; every evaluation and outcome is exported to a database, where a comparison shows which variation won."
         imageWidth={800}
         imageHeight={600}
@@ -248,7 +252,7 @@ export default function AbTestingPage() {
       <FeatureRow
         eyebrow="Step 1 · Evaluation"
         title="Split your users into A and B"
-        imageSrc={useBaseUrl('/img/landing/ab-testing/schema-split.svg')}
+        imageSrc={imgSplit}
         imageAlt="A crowd of users is deterministically routed through a hashing node into two equal groups, A and B, inside a bounded time window."
         imageWidth={800}
         imageHeight={600}
@@ -292,7 +296,7 @@ export default function AbTestingPage() {
         eyebrow="Step 2 · Exporters"
         title="Capture who saw which variation"
         reverse
-        imageSrc={useBaseUrl('/img/landing/ab-testing/schema-collect.svg')}
+        imageSrc={imgCollect}
         imageAlt="Evaluation events stream through an exporter and fan out to destinations: a database, object storage, and a message queue."
         imageWidth={800}
         imageHeight={600}
@@ -330,7 +334,7 @@ export default function AbTestingPage() {
       <FeatureRow
         eyebrow="Step 3 · Tracking"
         title="Record what your users did"
-        imageSrc={useBaseUrl('/img/landing/ab-testing/schema-measure.svg')}
+        imageSrc={imgMeasure}
         imageAlt="Each variation's exposures are joined with its outcomes; a comparison chart highlights the winning variation."
         imageWidth={800}
         imageHeight={600}

--- a/website/src/pages/product/ab-testing/index.js
+++ b/website/src/pages/product/ab-testing/index.js
@@ -1,0 +1,461 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {
+  FaRocket,
+  FaBook,
+  FaGithub,
+  FaRandom,
+  FaLock,
+  FaClock,
+  FaDatabase,
+  FaCloud,
+  FaStream,
+  FaBolt,
+} from 'react-icons/fa';
+import {CodeCard} from '@site/src/components/home/HomepageQuickStart/CodeCard';
+import SeoHead from '../../../components/landingPage/seo';
+import Title from '../../../components/landingPage/title';
+import Cards from '../../../components/landingPage/cards';
+import FeatureRow from '../../../components/landingPage/featureRow';
+import CtaBand from '../../../components/landingPage/ctaBand';
+import Faq from '../../../components/landingPage/faq';
+
+const PAGE_TITLE = 'A/B testing with feature flags';
+const PAGE_DESCRIPTION =
+  'How to run A/B tests with GO Feature Flag: split users into A and B with the ' +
+  'evaluation engine, then export the data so you can measure which variation won.';
+
+const EXPERIMENTATION_DOCS =
+  '/docs/configure_flag/rollout-strategies/experimentation';
+const EXPORTER_DOCS = '/docs/concepts/exporter';
+const TRACKING_DOCS = '/docs/tracking/tracking-api';
+
+// Step 1 - evaluation: a deterministic 50/50 split, bounded to a test window.
+const SPLIT_YAML = `checkout-experiment:
+  variations:
+    control: "current-checkout"
+    candidate: "new-checkout"
+  defaultRule:
+    percentage:
+      control: 50
+      candidate: 50
+  # only run the experiment inside this window
+  experimentation:
+    start: 2026-04-01T00:00:00.1-05:00
+    end: 2026-04-15T00:00:00.1-05:00`;
+
+// Step 2 - exporters: two destinations, one per event type.
+const EXPORTER_YAML = `# goff-proxy.yaml
+exporters:
+  # exposures: which user saw which variation
+  - kind: bigquery
+    projectID: "my-project"
+    datasetID: "goff_experiments"
+    tableName: "feature_flag_evaluations"
+    eventType: "feature"
+  # outcomes: what each user actually did
+  - kind: bigquery
+    projectID: "my-project"
+    datasetID: "goff_experiments"
+    tableName: "tracking_events"
+    eventType: "tracking"`;
+
+// Step 3 - tracking: record the outcome against the same targeting key.
+const TRACKING_CODE = `// When the user completes the action you care about,
+// record it against the SAME context you evaluate flags with.
+client.track("checkout-completed", evaluationContext, {
+  value: 99.77,
+  currencyCode: "USD",
+});`;
+
+const sectionHeading =
+  'mb-4 text-3xl font-bold text-gray-800 dark:text-gray-50 sm:text-4xl';
+const prose = 'mb-4 text-lg leading-relaxed text-gray-700 dark:text-gray-300';
+const codeWrap = 'mx-auto w-full max-w-3xl';
+const docLink =
+  'mt-4 inline-flex items-center gap-1 font-semibold text-[color:var(--ifm-color-primary-dark)] dark:text-[color:var(--ifm-color-primary)] no-underline hover:no-underline hover:opacity-80';
+
+const CAPABILITY_CARDS = [
+  {
+    icon: <FaRandom />,
+    title: 'A stable, deterministic split',
+    description:
+      'Users are bucketed by hashing the targeting key, so the same person stays in the same group for the whole test - no flicker between A and B.',
+  },
+  {
+    icon: <FaLock />,
+    title: 'Your data, your warehouse',
+    description:
+      'Exposures and outcomes are exported to a destination you own - BigQuery, S3, Kafka, a webhook - so you analyse results with the tools you already trust.',
+  },
+  {
+    icon: <FaClock />,
+    title: 'Time-boxed and reversible',
+    description:
+      'An experimentation rollout runs the split only inside a window you set, then falls back to the default automatically - no cleanup redeploy.',
+  },
+];
+
+const DESTINATION_CARDS = [
+  {
+    icon: <FaDatabase />,
+    title: 'Data warehouses',
+    description:
+      'Stream feature and tracking events straight into BigQuery for SQL analysis per variation.',
+  },
+  {
+    icon: <FaCloud />,
+    title: 'Object storage',
+    description:
+      'Batch events to AWS S3, Google Cloud Storage, Azure Blob Storage, or the local file system as JSON, CSV, or Parquet.',
+  },
+  {
+    icon: <FaStream />,
+    title: 'Streaming & queues',
+    description:
+      'Push events in near real time to Kafka, AWS Kinesis, Google Cloud Pub/Sub, or AWS SQS.',
+  },
+  {
+    icon: <FaBolt />,
+    title: 'Webhook & OpenTelemetry',
+    description:
+      'Send events to any HTTP endpoint, or emit them as OpenTelemetry signals for your observability stack.',
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    question: 'Do I need a separate A/B testing tool with GO Feature Flag?',
+    answer:
+      'No. GO Feature Flag already gives you the two halves of an experiment: the evaluation engine assigns each user to a variation, and exporters ship the data out. You run the analysis in whatever analytics tool or warehouse you already use - there is no extra experimentation SaaS to buy.',
+  },
+  {
+    question: 'How does GO Feature Flag decide which users are in A vs B?',
+    answer:
+      'It hashes the evaluation context’s targeting key deterministically. The same user always lands in the same variation as long as the percentages do not change, so their experience stays consistent for the whole test - and it is consistent across servers and restarts.',
+  },
+  {
+    question: 'Where does my experiment data go?',
+    answer:
+      'Wherever you point your exporters. Every evaluation emits a feature event (who saw which variation) and the Tracking API emits tracking events (what they did). Both flow through exporters to destinations you control: BigQuery, S3, GCS, Azure Blob, Kafka, Kinesis, Pub/Sub, SQS, a webhook, or OpenTelemetry.',
+  },
+  {
+    question: 'How is an A/B test different from a progressive rollout?',
+    answer:
+      'A progressive rollout is about shipping a change gradually - you are not measuring, you are ramping. An A/B test holds a fixed split for a fixed window so you can compare outcomes cleanly. Use the experimentation rollout (not a percentage you keep re-tuning) when you need a stable measurement group.',
+  },
+  {
+    question: 'How long should I run an A/B test?',
+    answer:
+      'Long enough to reach statistical significance for the metric you care about - stopping early (peeking) leads to false winners. A duration calculator such as vwo’s helps you size the window before you start, which you then set as the experimentation start and end dates.',
+  },
+  {
+    question: 'Does this work with the relay proxy and any SDK?',
+    answer:
+      'Yes. A/B testing is built on the standard evaluation and export paths, so it works the same across every OpenFeature SDK talking to the relay proxy. Exposures are captured automatically on evaluation, and outcomes are recorded through the OpenFeature Tracking API in your SDK.',
+  },
+];
+
+export default function AbTestingPage() {
+  const {siteConfig} = useDocusaurusContext();
+  const githubUrl =
+    siteConfig.customFields?.github ??
+    'https://github.com/thomaspoignant/go-feature-flag';
+
+  return (
+    <Layout
+      title={PAGE_TITLE}
+      description={PAGE_DESCRIPTION}
+      keywords={[
+        'A/B testing',
+        'feature flag A/B testing',
+        'experimentation',
+        'split testing',
+        'feature experimentation',
+        'export evaluation data',
+        'conversion tracking',
+        'OpenFeature tracking',
+      ]}>
+      <SeoHead
+        title={PAGE_TITLE}
+        description={PAGE_DESCRIPTION}
+        path="/product/ab-testing"
+        image="/img/logo/x-card.png"
+      />
+
+      <Title
+        title={PAGE_TITLE}
+        description="Ship two versions, measure the winner. GO Feature Flag splits your users into A and B, then exports the data so your own analytics can tell you which one actually performed better."
+        actions={[
+          {
+            label: 'Get started',
+            href: '/docs/getting-started',
+            icon: <FaRocket />,
+          },
+          {
+            label: 'Experimentation docs',
+            href: EXPERIMENTATION_DOCS,
+            icon: <FaBook />,
+            variant: 'secondary',
+          },
+        ]}
+      />
+
+      <FeatureRow
+        eyebrow="The idea"
+        title="Test two versions, let the data pick the winner"
+        imageSrc={useBaseUrl('/img/landing/ab-testing/schema-overview.svg')}
+        imageAlt="Users are split into variation A and variation B; every evaluation and outcome is exported to a database, where a comparison shows which variation won."
+        imageWidth={800}
+        imageHeight={600}
+        placeholderLabel="A/B testing loop - split, export, measure the winner">
+        <p className={prose}>
+          A/B test is the shorthand for a simple controlled experiment: two
+          versions, <strong>A</strong> and <strong>B</strong>, are shown to
+          comparable groups of users, and you measure which one moves the metric
+          you care about.
+        </p>
+        <p className="mb-0">
+          You do not need a separate experimentation platform for this. GO
+          Feature Flag already gives you the two building blocks:{' '}
+          <strong>evaluation</strong> to split users into A and B, and{' '}
+          <strong>exporters</strong> to capture what happened - so you can
+          decide the winner with the analytics you already own.
+        </p>
+      </FeatureRow>
+
+      <Cards title="What you get" cards={CAPABILITY_CARDS} />
+
+      {/* How it works - the recipe */}
+      <section className="px-6 py-12 max-w-[1400px] mx-auto">
+        <h2 className={`${sectionHeading} text-center`}>
+          A/B testing in three steps
+        </h2>
+        <p className={`${prose} mx-auto max-w-3xl text-center`}>
+          The recipe is the same one the docs recommend: an{' '}
+          <Link to={EXPERIMENTATION_DOCS}>experimentation rollout</Link>{' '}
+          combined with the <Link to={EXPORTER_DOCS}>export of your data</Link>.
+          Split your users, capture who saw what, record what they did - then
+          read the result. Every step lives in configuration or a single SDK
+          call, so there is no redeploy to start or stop a test.
+        </p>
+      </section>
+
+      {/* Step 1 - evaluation */}
+      <FeatureRow
+        eyebrow="Step 1 · Evaluation"
+        title="Split your users into A and B"
+        imageSrc={useBaseUrl('/img/landing/ab-testing/schema-split.svg')}
+        imageAlt="A crowd of users is deterministically routed through a hashing node into two equal groups, A and B, inside a bounded time window."
+        imageWidth={800}
+        imageHeight={600}
+        placeholderLabel="Deterministic 50/50 split inside a start-end window">
+        <p className="mb-4">
+          A{' '}
+          <Link to="/docs/configure_flag/rollout-strategies/percentage">
+            percentage rollout
+          </Link>{' '}
+          sends a share of traffic to each variation - say 50/50. The split is
+          deterministic on the{' '}
+          <Link to="/docs/configure_flag/custom-bucketing">targeting key</Link>,
+          so a user keeps the same variation for the whole test instead of
+          flipping between requests.
+        </p>
+        <p className="mb-0">
+          Wrap it in an <strong>experimentation rollout</strong> to bound the
+          test to a start and end date. Inside the window users get the split;
+          outside it, everyone falls back to the default - a clean measurement
+          period with an automatic end.
+        </p>
+      </FeatureRow>
+      <section className="px-6 pb-12 max-w-[1400px] mx-auto">
+        <div className={codeWrap}>
+          <CodeCard
+            filename="flags.goff.yaml"
+            language="yaml"
+            code={SPLIT_YAML}
+            callout="A deterministic 50/50 split that only runs for two weeks, then returns to the control."
+          />
+        </div>
+        <p className="mx-auto max-w-3xl text-center">
+          <Link className={docLink} to={EXPERIMENTATION_DOCS}>
+            Experimentation rollout docs <span aria-hidden="true">→</span>
+          </Link>
+        </p>
+      </section>
+
+      {/* Step 2 - exporters */}
+      <FeatureRow
+        eyebrow="Step 2 · Exporters"
+        title="Capture who saw which variation"
+        reverse
+        imageSrc={useBaseUrl('/img/landing/ab-testing/schema-collect.svg')}
+        imageAlt="Evaluation events stream through an exporter and fan out to destinations: a database, object storage, and a message queue."
+        imageWidth={800}
+        imageHeight={600}
+        placeholderLabel="Events exported to a warehouse, storage, and a queue">
+        <p className="mb-4">
+          Every flag evaluation emits a <strong>feature event</strong> - the
+          targeting key, the flag, and the variation that user received. An{' '}
+          <Link to={EXPORTER_DOCS}>exporter</Link> ships those events to a
+          destination you own, so you have a record of exactly who was exposed
+          to A and who was exposed to B.
+        </p>
+        <p className="mb-0">
+          You wire one exporter per event type. Point them at the same warehouse
+          - one table for exposures, one for outcomes - and your experiment data
+          lands where your analysts can query it.
+        </p>
+      </FeatureRow>
+      <section className="px-6 pb-12 max-w-[1400px] mx-auto">
+        <div className={codeWrap}>
+          <CodeCard
+            filename="goff-proxy.yaml"
+            language="yaml"
+            code={EXPORTER_YAML}
+            callout="Two BigQuery exporters on the relay proxy: exposures (feature) and outcomes (tracking) into the same dataset."
+          />
+        </div>
+        <p className="mx-auto max-w-3xl text-center">
+          <Link className={docLink} to={EXPORTER_DOCS}>
+            Exporter docs <span aria-hidden="true">→</span>
+          </Link>
+        </p>
+      </section>
+
+      {/* Step 3 - tracking */}
+      <FeatureRow
+        eyebrow="Step 3 · Tracking"
+        title="Record what your users did"
+        imageSrc={useBaseUrl('/img/landing/ab-testing/schema-measure.svg')}
+        imageAlt="Each variation's exposures are joined with its outcomes; a comparison chart highlights the winning variation."
+        imageWidth={800}
+        imageHeight={600}
+        placeholderLabel="Join exposure and outcome per variation to pick a winner">
+        <p className="mb-4">
+          Exposure alone does not tell you who won - you also need the{' '}
+          <em>outcome</em>. The{' '}
+          <Link to={TRACKING_DOCS}>OpenFeature Tracking API</Link> lets you
+          record a conversion, a purchase amount, or any action against the{' '}
+          <strong>same targeting key</strong> you evaluate with. Those tracking
+          events flow through the tracking exporter you configured in step 2.
+        </p>
+        <p className="mb-0">
+          Now you can join the two in your analytics: for each variation, how
+          many users converted and how much they were worth. That comparison is
+          your A/B test result.
+        </p>
+      </FeatureRow>
+      <section className="px-6 pb-12 max-w-[1400px] mx-auto">
+        <div className={codeWrap}>
+          <CodeCard
+            filename="checkout.js"
+            language="javascript"
+            code={TRACKING_CODE}
+            callout="Recorded against the same context as the flag evaluation, so exposure and outcome join on the targeting key."
+          />
+        </div>
+        <p className="mx-auto max-w-3xl text-center">
+          <Link className={docLink} to={TRACKING_DOCS}>
+            Tracking API docs <span aria-hidden="true">→</span>
+          </Link>
+        </p>
+      </section>
+
+      <Cards
+        title="Where your experiment data can go"
+        cards={DESTINATION_CARDS}
+        columns={4}
+      />
+      <section className="px-6 pb-12 max-w-[1400px] mx-auto">
+        <p className="mx-auto max-w-3xl text-center">
+          <Link className={docLink} to="/docs/tracking/flag-usage-tracking">
+            See the full event format <span aria-hidden="true">→</span>
+          </Link>
+        </p>
+      </section>
+
+      {/* Why GOFF */}
+      <section className="px-6 py-12 max-w-[1400px] mx-auto">
+        <h2 className={`${sectionHeading} text-center`}>
+          Why run your A/B tests on GO Feature Flag
+        </h2>
+        <ul className="mx-auto mb-0 max-w-3xl list-disc space-y-2 pl-6 text-lg leading-relaxed text-gray-700 dark:text-gray-300">
+          <li>
+            <strong>You own the data.</strong> Exposures and outcomes go to your
+            warehouse, not a vendor’s - no per-seat experimentation bill, no
+            data leaving your stack.
+          </li>
+          <li>
+            <strong>OpenFeature-native.</strong> Assignment and tracking use the
+            standard API, so any OpenFeature SDK and the relay proxy work the
+            same way.
+          </li>
+          <li>
+            <strong>It composes with your rollouts.</strong> An experiment is
+            just one more thing a{' '}
+            <Link to="/product/rollouts">feature flag</Link> can do - target a
+            segment first, then split within it.
+          </li>
+          <li>
+            <strong>The same recipe compares AI models or prompts.</strong> Swap
+            the variations and you are A/B testing{' '}
+            <Link to="/product/ai">features for AI</Link> instead of UI.
+          </li>
+        </ul>
+      </section>
+
+      {/* Pitfalls */}
+      <section className="px-6 py-12 max-w-[1400px] mx-auto">
+        <h2 className={`${sectionHeading} text-center`}>
+          A/B testing pitfalls to avoid
+        </h2>
+        <ul className="mx-auto mb-0 max-w-3xl list-disc space-y-2 pl-6 text-lg leading-relaxed text-gray-700 dark:text-gray-300">
+          <li>
+            <strong>Re-tuning the percentage mid-test.</strong> Changing the
+            split reshuffles some users between A and B. Use an experimentation
+            rollout when you need a stable group for the whole window.
+          </li>
+          <li>
+            <strong>Bucketing on an unstable key.</strong> Consistency rides on
+            the targeting key; a value that changes per request makes users flip
+            variations and pollutes your results.
+          </li>
+          <li>
+            <strong>Exporting exposures but not outcomes.</strong> Knowing who
+            saw A or B is only half of it - without tracking events you cannot
+            say which variation actually won.
+          </li>
+          <li>
+            <strong>Stopping the moment it looks good.</strong> Peeking at an
+            experiment before it reaches significance produces false winners.
+            Size the window up front and let it run.
+          </li>
+        </ul>
+      </section>
+
+      <CtaBand
+        title="Run your next experiment on your own data"
+        description="Self-hosted, OpenFeature-native, MIT-licensed. Split with a YAML file, export to your warehouse, measure the winner - no experimentation SaaS required."
+        actions={[
+          {
+            label: 'Get started',
+            href: '/docs/getting-started',
+            icon: <FaRocket />,
+          },
+          {
+            label: 'View on GitHub',
+            href: githubUrl,
+            icon: <FaGithub />,
+            variant: 'secondary',
+          },
+        ]}
+      />
+
+      <Faq title="Frequently asked questions" items={FAQ_ITEMS} withJsonLd />
+    </Layout>
+  );
+}

--- a/website/static/img/landing/ab-testing/schema-collect.svg
+++ b/website/static/img/landing/ab-testing/schema-collect.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <defs>
+    <marker id="collect-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0 0 L6 3 L0 6 Z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <!-- streaming event records (feature = mint, tracking = coral) -->
+  <g stroke="#64748b" stroke-width="3">
+    <rect x="55" y="150" width="120" height="52" rx="12" fill="#cdf7e7"/>
+    <rect x="90" y="230" width="120" height="52" rx="12" fill="#f4845f"/>
+    <rect x="55" y="310" width="120" height="52" rx="12" fill="#cdf7e7"/>
+    <rect x="90" y="390" width="120" height="52" rx="12" fill="#f4845f"/>
+    <rect x="55" y="470" width="120" height="52" rx="12" fill="#cdf7e7"/>
+  </g>
+
+  <!-- flow into funnel -->
+  <g stroke="#64748b" stroke-width="3">
+    <path d="M230 240 L300 290" marker-end="url(#collect-arrow)"/>
+    <path d="M230 336 L300 320" marker-end="url(#collect-arrow)"/>
+    <path d="M230 416 L300 350" marker-end="url(#collect-arrow)"/>
+  </g>
+
+  <!-- funnel -->
+  <path d="M310 250 L470 250 L405 330 L405 380 L375 380 L375 330 Z" fill="#9fbeb3" stroke="#64748b" stroke-width="4"/>
+
+  <!-- fan out to destinations -->
+  <g stroke="#64748b" stroke-width="3">
+    <path d="M420 300 L600 180" marker-end="url(#collect-arrow)"/>
+    <path d="M470 355 L600 355" marker-end="url(#collect-arrow)"/>
+    <path d="M420 375 L600 500" marker-end="url(#collect-arrow)"/>
+  </g>
+
+  <!-- destination 1: database cylinder -->
+  <g stroke="#64748b" stroke-width="4">
+    <path d="M620 150 a55 18 0 0 0 110 0 l0 90 a55 18 0 0 1 -110 0 Z" fill="#cdf7e7"/>
+    <ellipse cx="675" cy="150" rx="55" ry="18" fill="#cdf7e7"/>
+  </g>
+
+  <!-- destination 2: cloud storage (stacked disks) -->
+  <g stroke="#64748b" stroke-width="4">
+    <ellipse cx="675" cy="335" rx="55" ry="16" fill="#cdf7e7"/>
+    <path d="M620 335 l0 24 a55 16 0 0 0 110 0 l0 -24" fill="#cdf7e7"/>
+    <path d="M620 359 l0 24 a55 16 0 0 0 110 0 l0 -24" fill="#9fbeb3"/>
+  </g>
+
+  <!-- destination 3: stream / queue (signal bars) -->
+  <g fill="#f4845f" stroke="#64748b" stroke-width="3">
+    <rect x="625" y="510" width="20" height="30" rx="4"/>
+    <rect x="653" y="490" width="20" height="50" rx="4"/>
+    <rect x="681" y="470" width="20" height="70" rx="4"/>
+    <rect x="709" y="500" width="20" height="40" rx="4"/>
+  </g>
+</svg>

--- a/website/static/img/landing/ab-testing/schema-measure.svg
+++ b/website/static/img/landing/ab-testing/schema-measure.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <defs>
+    <marker id="measure-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0 0 L6 3 L0 6 Z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <!-- variation A panel (mint) -->
+  <rect x="70" y="60" width="250" height="230" rx="22" fill="#cdf7e7" stroke="#64748b" stroke-width="4"/>
+  <path d="M150 105 L240 105 L205 150 L205 185 L185 185 L185 150 Z" fill="#9fbeb3" stroke="#64748b" stroke-width="3"/>
+  <rect x="175" y="215" width="40" height="55" rx="6" fill="#9fbeb3" stroke="#64748b" stroke-width="3"/>
+
+  <!-- variation B panel (coral) -->
+  <rect x="480" y="60" width="250" height="230" rx="22" fill="#f9d2c4" stroke="#64748b" stroke-width="4"/>
+  <path d="M560 105 L650 105 L615 150 L615 185 L595 185 L595 150 Z" fill="#f4845f" stroke="#64748b" stroke-width="3"/>
+  <rect x="585" y="230" width="40" height="40" rx="6" fill="#f4845f" stroke="#64748b" stroke-width="3"/>
+
+  <!-- join / analyze connectors down to comparison chart -->
+  <g stroke="#64748b" stroke-width="3">
+    <path d="M195 290 C 220 380, 300 380, 350 415" marker-end="url(#measure-arrow)"/>
+    <path d="M605 290 C 580 390, 500 400, 452 455" marker-end="url(#measure-arrow)"/>
+  </g>
+
+  <!-- comparison chart -->
+  <path d="M300 540 L520 540" stroke="#64748b" stroke-width="4"/>
+  <rect x="330" y="400" width="70" height="140" rx="6" fill="#9fbeb3" stroke="#64748b" stroke-width="4"/>
+  <rect x="430" y="455" width="70" height="85" rx="6" fill="#f4845f" stroke="#64748b" stroke-width="4"/>
+
+  <!-- winner badge on the taller (mint) bar -->
+  <circle cx="365" cy="375" r="26" fill="#43a047" stroke="#64748b" stroke-width="3"/>
+  <path d="M352 375 L362 386 L380 364" stroke="#ffffff" stroke-width="5"/>
+</svg>

--- a/website/static/img/landing/ab-testing/schema-overview.svg
+++ b/website/static/img/landing/ab-testing/schema-overview.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <defs>
+    <marker id="ov-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0 0 L6 3 L0 6 Z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <!-- users -->
+  <g fill="#9fbeb3" stroke="#64748b" stroke-width="3">
+    <circle cx="65" cy="150" r="18"/>
+    <circle cx="112" cy="180" r="18"/>
+    <circle cx="65" cy="215" r="18"/>
+    <circle cx="112" cy="248" r="18"/>
+  </g>
+
+  <!-- users -> fork -->
+  <path d="M135 200 L152 202" stroke="#64748b" stroke-width="3" marker-end="url(#ov-arrow)"/>
+
+  <!-- fork / evaluation node -->
+  <rect x="156" y="172" width="60" height="60" rx="14" fill="#ffffff" stroke="#64748b" stroke-width="4"/>
+  <path d="M180 190 L200 202 L180 214" stroke="#64748b" stroke-width="4"/>
+
+  <!-- fork -> lanes -->
+  <g stroke="#64748b" stroke-width="3">
+    <path d="M220 190 C 244 162, 250 158, 256 158" marker-end="url(#ov-arrow)"/>
+    <path d="M220 216 C 244 250, 250 254, 256 254" marker-end="url(#ov-arrow)"/>
+  </g>
+
+  <!-- variation A lane (mint) -->
+  <rect x="260" y="118" width="220" height="80" rx="16" fill="#cdf7e7" stroke="#64748b" stroke-width="4"/>
+  <rect x="288" y="136" width="62" height="45" rx="6" fill="#ffffff" stroke="#64748b" stroke-width="3"/>
+  <path d="M288 150 L350 150" stroke="#64748b" stroke-width="3"/>
+  <circle cx="332" cy="168" r="7" fill="#43a047" stroke="#64748b" stroke-width="2"/>
+
+  <!-- variation B lane (coral) -->
+  <rect x="260" y="214" width="220" height="80" rx="16" fill="#f9d2c4" stroke="#64748b" stroke-width="4"/>
+  <rect x="288" y="232" width="62" height="45" rx="6" fill="#ffffff" stroke="#64748b" stroke-width="3"/>
+  <path d="M288 246 L350 246" stroke="#64748b" stroke-width="3"/>
+  <rect x="300" y="256" width="38" height="13" rx="4" fill="#f4845f" stroke="#64748b" stroke-width="2"/>
+
+  <!-- lanes -> event stack -->
+  <g stroke="#64748b" stroke-width="3">
+    <path d="M480 168 C 500 330, 470 380, 448 402" marker-end="url(#ov-arrow)"/>
+    <path d="M480 262 C 495 340, 475 390, 452 438" marker-end="url(#ov-arrow)"/>
+  </g>
+
+  <!-- collected event records -->
+  <g stroke="#64748b" stroke-width="3">
+    <rect x="330" y="392" width="110" height="30" rx="8" fill="#cdf7e7"/>
+    <rect x="345" y="428" width="110" height="30" rx="8" fill="#f4845f"/>
+    <rect x="330" y="464" width="110" height="30" rx="8" fill="#cdf7e7"/>
+  </g>
+
+  <!-- events -> storage -->
+  <path d="M460 448 L500 440" stroke="#64748b" stroke-width="3" marker-end="url(#ov-arrow)"/>
+
+  <!-- database cylinder -->
+  <g stroke="#64748b" stroke-width="4">
+    <path d="M508 400 a52 16 0 0 0 104 0 l0 78 a52 16 0 0 1 -104 0 Z" fill="#cdf7e7"/>
+    <ellipse cx="560" cy="400" rx="52" ry="16" fill="#cdf7e7"/>
+  </g>
+
+  <!-- storage -> results -->
+  <path d="M618 440 L652 440" stroke="#64748b" stroke-width="3" marker-end="url(#ov-arrow)"/>
+
+  <!-- results: winning variation -->
+  <path d="M650 505 L790 505" stroke="#64748b" stroke-width="4"/>
+  <rect x="668" y="368" width="42" height="137" rx="6" fill="#9fbeb3" stroke="#64748b" stroke-width="4"/>
+  <rect x="728" y="415" width="42" height="90" rx="6" fill="#f4845f" stroke="#64748b" stroke-width="4"/>
+  <circle cx="689" cy="345" r="24" fill="#43a047" stroke="#64748b" stroke-width="3"/>
+  <path d="M677 345 L686 355 L703 335" stroke="#ffffff" stroke-width="5"/>
+</svg>

--- a/website/static/img/landing/ab-testing/schema-split.svg
+++ b/website/static/img/landing/ab-testing/schema-split.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <defs>
+    <marker id="split-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0 0 L6 3 L0 6 Z" fill="#64748b"/>
+    </marker>
+  </defs>
+
+  <!-- time-window brackets -->
+  <path d="M70 90 L45 90 L45 510 L70 510" stroke="#64748b" stroke-width="5"/>
+  <path d="M730 90 L755 90 L755 510 L730 510" stroke="#64748b" stroke-width="5"/>
+
+  <!-- connectors: users -> router -->
+  <g stroke="#64748b" stroke-width="3">
+    <path d="M205 240 L345 295" marker-end="url(#split-arrow)"/>
+    <path d="M215 300 L345 300" marker-end="url(#split-arrow)"/>
+    <path d="M205 380 L345 310" marker-end="url(#split-arrow)"/>
+  </g>
+
+  <!-- connectors: router -> groups -->
+  <g stroke="#64748b" stroke-width="3">
+    <path d="M505 280 L585 215" marker-end="url(#split-arrow)"/>
+    <path d="M505 320 L585 390" marker-end="url(#split-arrow)"/>
+  </g>
+
+  <!-- incoming users -->
+  <g fill="#9fbeb3" stroke="#64748b" stroke-width="3">
+    <circle cx="130" cy="215" r="20"/>
+    <circle cx="185" cy="255" r="20"/>
+    <circle cx="120" cy="300" r="20"/>
+    <circle cx="180" cy="345" r="20"/>
+    <circle cx="135" cy="385" r="20"/>
+    <circle cx="160" cy="435" r="20"/>
+  </g>
+
+  <!-- deterministic router / hashing node -->
+  <path d="M430 235 L500 300 L430 365 L360 300 Z" fill="#ffffff" stroke="#64748b" stroke-width="4"/>
+  <g stroke="#64748b" stroke-width="4">
+    <path d="M400 285 L460 285"/>
+    <path d="M395 300 L465 300"/>
+    <path d="M400 315 L460 315"/>
+  </g>
+
+  <!-- variation A group (mint) -->
+  <g fill="#cdf7e7" stroke="#64748b" stroke-width="3">
+    <circle cx="630" cy="175" r="20"/>
+    <circle cx="685" cy="210" r="20"/>
+    <circle cx="600" cy="235" r="20"/>
+    <circle cx="660" cy="250" r="20"/>
+  </g>
+
+  <!-- variation B group (coral) -->
+  <g fill="#f4845f" stroke="#64748b" stroke-width="3">
+    <circle cx="600" cy="360" r="20"/>
+    <circle cx="660" cy="345" r="20"/>
+    <circle cx="630" cy="415" r="20"/>
+    <circle cx="688" cy="400" r="20"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Description
Adds a new `/product/ab-testing` landing page explaining how to run A/B tests with GO Feature Flag using the combination of **evaluation** (a deterministic percentage split bounded by an `experimentation` window) and **exporters** (feature + tracking events shipped to a data destination you own, so you measure the winner in your own analytics). The page reuses the existing product landing-page pattern (shared `landingPage/*` components, Tailwind, SEO + JSON-LD FAQ) and is linked from the Product navbar mega-menu. It ships with four hand-authored SVG schema diagrams that read in both light and dark mode (no text, no shadows). Verified with `npm run build` (green, no broken links) and ESLint/Prettier.

## Closes issue(s)
Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
