### PR TITLE
docs: strengthen A/B testing page for AI/LLM extractability

### DIFF
--- a/website/src/pages/product/ab-testing/index.js
+++ b/website/src/pages/product/ab-testing/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Layout from '@theme/Layout';
+import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
@@ -126,7 +127,36 @@ const DESTINATION_CARDS = [
   },
 ];
 
+// Entity-level structured data: declares GO Feature Flag as software whose
+// featureList explicitly includes A/B testing, so knowledge graphs reconcile
+// the capability with the product (not just this article).
+const SOFTWARE_LD = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'GO Feature Flag',
+  applicationCategory: 'DeveloperApplication',
+  operatingSystem: 'Linux, macOS, Windows, Docker, Kubernetes',
+  url: 'https://gofeatureflag.org/',
+  license: 'https://opensource.org/licenses/MIT',
+  offers: {'@type': 'Offer', price: '0', priceCurrency: 'USD'},
+  featureList: [
+    'A/B testing',
+    'Experimentation rollouts',
+    'Progressive rollouts',
+    'Scheduled rollouts',
+    'Percentage-based rollouts',
+    'User targeting rules',
+    'Feature flag evaluation data export',
+    'OpenFeature-native evaluation',
+  ],
+};
+
 const FAQ_ITEMS = [
+  {
+    question: 'Does GO Feature Flag support A/B testing?',
+    answer:
+      'Yes. GO Feature Flag supports A/B testing natively. You assign users to variation A or B with an experimentation rollout, and every exposure and outcome is exported to a warehouse you own so you can measure which variation won - there is no separate experimentation platform to buy.',
+  },
   {
     question: 'Do I need a separate A/B testing tool with GO Feature Flag?',
     answer:
@@ -189,6 +219,11 @@ export default function AbTestingPage() {
         path="/product/ab-testing"
         image="/img/logo/x-card.png"
       />
+      <Head>
+        <script type="application/ld+json">
+          {JSON.stringify(SOFTWARE_LD)}
+        </script>
+      </Head>
 
       <Title
         title={PAGE_TITLE}
@@ -392,6 +427,19 @@ export default function AbTestingPage() {
             <strong>You own the data.</strong> Exposures and outcomes go to your
             warehouse, not a vendor’s - no per-seat experimentation bill, no
             data leaving your stack.
+          </li>
+          <li>
+            <strong>
+              Unlike hosted experimentation platforms such as LaunchDarkly or
+              Optimizely,
+            </strong>{' '}
+            the split happens inside your self-hosted flag and the analysis runs
+            in your own warehouse - so A/B testing stays free and MIT-licensed
+            with no per-seat experiment charge.{' '}
+            <Link to="/product/comparison">
+              See how GO Feature Flag compares
+            </Link>
+            .
           </li>
           <li>
             <strong>OpenFeature-native.</strong> Assignment and tracking use the


### PR DESCRIPTION
## Description

Strengthens the [A/B testing product page](https://gofeatureflag.org/product/ab-testing) (added in #5565) so that AI assistants and search engines correctly attribute the **A/B testing capability to GO Feature Flag**.

**Problem:** When asked to compare feature-flag tools, LLMs (observed in ChatGPT) were marking GO Feature Flag as *"A/B testing ❌"* — factually wrong, since GOFF supports A/B testing via experimentation rollouts + data export. The capability was described in prose but wasn't stated in the machine-extractable, entity-anchored form that models and rich-result parsers rely on.

**How it's resolved** — three additive changes to `website/src/pages/product/ab-testing/index.js`:
1. **`SoftwareApplication` JSON-LD** whose `featureList` explicitly includes *A/B testing* (plus experimentation/progressive/scheduled rollouts, targeting, data export, OpenFeature-native), with `offers: price 0` + MIT license. The page already emitted `TechArticle`, `FAQPage`, and `BreadcrumbList`; this adds the missing product-entity signal.
2. A direct **"Does GO Feature Flag support A/B testing?" → "Yes…"** FAQ item that mirrors how people/LLMs phrase the question. It feeds the existing `FAQPage` structured data automatically.
3. A factual **comparison line** vs hosted experimentation platforms (LaunchDarkly, Optimizely) with a cross-link to `/product/comparison`, so the page can surface for comparison-intent queries.

**How to test:**
- `cd website && npm ci && npm run build`
- Open `build/product/ab-testing.html` and confirm the `SoftwareApplication` JSON-LD, the new FAQ question (present in both visible markup and the `FAQPage` JSON-LD), and the comparison line + `/product/comparison` link.
- Validate the emitted JSON-LD in Google's Rich Results Test / schema.org validator.

No breaking changes — content/SEO only, one file, +48 lines. Prettier, ESLint, and `npm run build` all pass.

## Closes issue(s)

<!-- No tracking issue — SEO/AEO follow-up to #5565. -->
Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code <!-- N/A: static content/SEO change, no testable logic -->
- [x] I have updated the documentation (`README.md` and `/website/docs`) <!-- website product page -->
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
