### PR TITLE
docs: redirect removed old doc versions to the current docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -320,7 +320,16 @@ const config = {
         sitemap: {
           changefreq: 'weekly',
           priority: 0.5,
-          ignorePatterns: ['/tags/**'],
+          ignorePatterns: [
+            '/tags/**',
+            '/docs/next/**',
+            '/docs/v2*',
+            '/docs/v2*/**',
+            '/docs/v1*',
+            '/docs/v1*/**',
+            '/docs/v0*',
+            '/docs/v0*/**',
+          ],
           filename: 'sitemap.xml',
         },
       }),

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,8 +1,8 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 // Versions still built & served (small rolling window, kept for build speed).
 const builtVersions = require('./versions.json');

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -11,9 +11,9 @@ const builtVersions = require('./versions.json');
 // URLs would 404; we 200-redirect each page to its current-docs equivalent
 // (see createRedirects in the client-redirects plugin below).
 const removedVersions = fs
-  .readdirSync(path.join(__dirname, 'versioned_docs'))
-  .filter(name => name.startsWith('version-'))
-  .map(name => name.replace(/^version-/, ''))
+  .readdirSync(path.join(__dirname, 'versioned_docs'), {withFileTypes: true})
+  .filter(entry => entry.isDirectory() && entry.name.startsWith('version-'))
+  .map(entry => entry.name.replace(/^version-/, ''))
   .filter(version => !builtVersions.includes(version));
 
 const {sdk} = require('./data/sdk');

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,6 +1,21 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
+const fs = require('fs');
+const path = require('path');
+
+// Versions still built & served (small rolling window, kept for build speed).
+const builtVersions = require('./versions.json');
+
+// Versions that once shipped docs but are no longer built. Their /docs/vX.Y.Z/…
+// URLs would 404; we 200-redirect each page to its current-docs equivalent
+// (see createRedirects in the client-redirects plugin below).
+const removedVersions = fs
+  .readdirSync(path.join(__dirname, 'versioned_docs'))
+  .filter(name => name.startsWith('version-'))
+  .map(name => name.replace(/^version-/, ''))
+  .filter(version => !builtVersions.includes(version));
+
 const {sdk} = require('./data/sdk');
 const {generateSdksDropdownHTML} = require('./src/components/navbar/sdks');
 const {
@@ -205,7 +220,47 @@ const config = {
             from: '/docs/relay_proxy/install_relay_proxy',
             to: '/docs/relay-proxy/install_relay_proxy',
           },
+          // --- Removed-version documentation redirects (renamed/moved slugs) ---
+          // createRedirects (below) auto-covers removed-version URLs whose path
+          // is UNCHANGED in the current docs. The entries here handle old URLs
+          // whose slug CHANGED between versions (e.g. underscore -> hyphen), so
+          // they don't match a current path and createRedirects can't generate
+          // them. Every `to` must be a real current docs path.
+          // TODO: extend this list from the Google Search Console
+          // "Not found (404)" report.
+          {from: '/docs/v1.30.0/getting_started', to: '/docs/getting-started'},
+          {from: '/docs/v1.0.0/getting_started', to: '/docs/getting-started'},
+          {from: '/docs/v0.28.2/getting_started', to: '/docs/getting-started'},
+          {from: '/docs/v0.28.1/getting_started', to: '/docs/getting-started'},
         ],
+        // For every current-docs page, emit a redirect from the same path under
+        // each removed version, so old deep links (e.g.
+        // /docs/v1.30.0/sdk/client_providers/openfeature_javascript) 200-redirect
+        // to the current page instead of 404-ing. Only the current version is
+        // served at /docs/<path> with no version segment; built versioned paths
+        // (/docs/v1.54.1/…) and the /docs/next tree are skipped. Old URLs whose
+        // slug changed between versions won't match a current path and are
+        // handled by the 404 page (src/theme/NotFound/Content) plus the explicit
+        // entries above.
+        /** @param {string} existingPath */
+        createRedirects(existingPath) {
+          // Bare docs landing -> emit /docs/<version> for old bare version roots.
+          if (existingPath === '/docs') {
+            return removedVersions.map(version => `/docs/${version}`);
+          }
+          if (!existingPath.startsWith('/docs/')) {
+            return undefined;
+          }
+          const subPath = existingPath.slice('/docs/'.length);
+          const firstSegment = subPath.split('/')[0];
+          if (
+            firstSegment === 'next' ||
+            /^v\d+\.\d+\.\d+(?:-rc\.\d+)?$/.test(firstSegment)
+          ) {
+            return undefined;
+          }
+          return removedVersions.map(version => `/docs/${version}/${subPath}`);
+        },
       },
     ],
     require('./plugins/tailwind-plugin.cjs'),

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -220,18 +220,6 @@ const config = {
             from: '/docs/relay_proxy/install_relay_proxy',
             to: '/docs/relay-proxy/install_relay_proxy',
           },
-          // --- Removed-version documentation redirects (renamed/moved slugs) ---
-          // createRedirects (below) auto-covers removed-version URLs whose path
-          // is UNCHANGED in the current docs. The entries here handle old URLs
-          // whose slug CHANGED between versions (e.g. underscore -> hyphen), so
-          // they don't match a current path and createRedirects can't generate
-          // them. Every `to` must be a real current docs path.
-          // TODO: extend this list from the Google Search Console
-          // "Not found (404)" report.
-          {from: '/docs/v1.30.0/getting_started', to: '/docs/getting-started'},
-          {from: '/docs/v1.0.0/getting_started', to: '/docs/getting-started'},
-          {from: '/docs/v0.28.2/getting_started', to: '/docs/getting-started'},
-          {from: '/docs/v0.28.1/getting_started', to: '/docs/getting-started'},
         ],
         // For every current-docs page, emit a redirect from the same path under
         // each removed version, so old deep links (e.g.

--- a/website/src/theme/NotFound/Content/index.js
+++ b/website/src/theme/NotFound/Content/index.js
@@ -1,11 +1,53 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
 import Heading from '@theme/Heading';
 import Link from '@docusaurus/Link';
+import {useAllDocsData} from '@docusaurus/plugin-content-docs/client';
+import versions from '@site/versions.json';
+
+// Captures the version token and the trailing sub-path:
+//   /docs/v1.50.0/sdk/foo -> ["…", "v1.50.0", "/sdk/foo"]
+//   /docs/v1.30.0         -> ["…", "v1.30.0", undefined]
+const OLD_VERSION_DOCS_PATH = /^\/docs\/(v\d+\.\d+\.\d+(?:-rc\.\d+)?)(\/.*)?$/;
+const stripTrailingSlash = path =>
+  path.length > 1 ? path.replace(/\/$/, '') : path;
 
 export default function NotFoundContent({className}) {
+  const allDocsData = useAllDocsData();
+
+  // Old doc versions are pruned from versions.json to keep build times down, so
+  // their previously-indexed URLs now 404. When we land on the 404 page for one
+  // of those removed-version URLs, strip the version segment and send the visitor
+  // to the equivalent page in the current docs — falling back to the docs home
+  // when that page no longer exists (e.g. the slug was renamed between versions),
+  // so we never dead-end on a second 404.
+  useEffect(() => {
+    const match = window.location.pathname.match(OLD_VERSION_DOCS_PATH);
+    // Bail unless this is a versioned docs URL whose version is no longer built.
+    if (!match || versions.includes(match[1])) {
+      return;
+    }
+
+    // Version-strip, e.g. /docs/v1.50.0/sdk/foo -> /docs/sdk/foo
+    const target = stripTrailingSlash(`/docs${match[2] || '/'}`);
+
+    // Only deep-link if that page still exists in the current docs.
+    const currentDocs = Object.values(allDocsData)
+      .flatMap(data => data.versions)
+      .find(version => version.isLast);
+    const exists = currentDocs?.docs?.some(
+      doc => stripTrailingSlash(doc.path) === target
+    );
+
+    window.location.replace(
+      (exists ? target : '/docs/') +
+        window.location.search +
+        window.location.hash
+    );
+  }, [allDocsData]);
+
   return (
     <main className={clsx('container margin-vert--xl', className)}>
       <div className="row">

--- a/website/src/theme/NotFound/Content/index.js
+++ b/website/src/theme/NotFound/Content/index.js
@@ -33,10 +33,12 @@ export default function NotFoundContent({className}) {
     // Version-strip, e.g. /docs/v1.50.0/sdk/foo -> /docs/sdk/foo
     const target = stripTrailingSlash(`/docs${match[2] || '/'}`);
 
-    // Only deep-link if that page still exists in the current docs.
-    const currentDocs = Object.values(allDocsData)
-      .flatMap(data => data.versions)
-      .find(version => version.isLast);
+    // Only deep-link if that page still exists in the current docs. Scope to the
+    // default docs instance (the one serving /docs) rather than searching every
+    // plugin instance, so a future second docs plugin can't shadow it.
+    const currentDocs = allDocsData['default']?.versions.find(
+      version => version.isLast
+    );
     const exists = currentDocs?.docs?.some(
       doc => stripTrailingSlash(doc.path) === target
     );

--- a/website/src/theme/NotFound/Content/index.js
+++ b/website/src/theme/NotFound/Content/index.js
@@ -24,7 +24,7 @@ export default function NotFoundContent({className}) {
   // when that page no longer exists (e.g. the slug was renamed between versions),
   // so we never dead-end on a second 404.
   useEffect(() => {
-    const match = window.location.pathname.match(OLD_VERSION_DOCS_PATH);
+    const match = OLD_VERSION_DOCS_PATH.exec(window.location.pathname);
     // Bail unless this is a versioned docs URL whose version is no longer built.
     if (!match || versions.includes(match[1])) {
       return;


### PR DESCRIPTION
## Description

Old doc versions are pruned from `versions.json` to keep build times down, so their previously-indexed `/docs/vX.Y.Z/...` URLs now hard-404 (heavy 404 traffic in Analytics), and GitHub Pages can't issue server-side 301s. This PR sends those visitors to the equivalent page in the current docs via two layers: (1) the swizzled 404 page (`src/theme/NotFound/Content`) strips the removed version segment and client-side-redirects to the current page, falling back to `/docs/` when the page no longer exists (e.g. a renamed/restructured slug) so it never dead-ends on a second 404; and (2) a `createRedirects()` callback in `docusaurus.config.js` emits a build-time HTTP-200 redirect from every current page's URL under each removed version. Renamed/moved slugs that don't match a current path are covered by the layer-(1) runtime handler rather than a hand-maintained list.

It also cleans up the sitemap, which was advertising 631 old built-version pages plus 91 `/docs/next` pages (all self-canonical and indexable, inviting duplicate-content indexing) — `sitemap.ignorePatterns` now excludes old versions and `/docs/next`, dropping `sitemap.xml` from 922 to 199 URLs so only the current version is listed.

Finally, it resolves the code-quality issues SonarCloud flagged on the new code: use the `node:` import protocol for `fs`/`path`, and `RegExp.exec()` instead of `String.match()` for the version-path regex.

No versions were removed from `versioned_docs/`/`versions.json` and no dependencies were added. To test: run `npm run build` in `website/` (succeeds, no broken-link errors) then `npm run serve` and visit e.g. `/docs/v1.40.0/sdk/client_providers/openfeature_javascript` — it should redirect to `/docs/sdk/client_providers/openfeature_javascript`.

## Closes issue(s)

_N/A — no tracking issue_

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
