### PR TITLE
feat(website): set per-page sitemap priorities

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -307,7 +307,7 @@ const config = {
         },
         sitemap: {
           changefreq: 'weekly',
-          priority: 0.5,
+          priority: 0.5, // default fallback for pages not matched below
           ignorePatterns: [
             '/tags/**',
             '/docs/next/**',
@@ -319,6 +319,20 @@ const config = {
             '/docs/v0*/**',
           ],
           filename: 'sitemap.xml',
+          createSitemapItems: async params => {
+            const {defaultCreateSitemapItems, ...rest} = params;
+            const items = await defaultCreateSitemapItems(rest);
+            return items.map(item => {
+              const {pathname} = new URL(item.url);
+              if (pathname === '/' || pathname === '/blog') {
+                return {...item, priority: 1.0};
+              }
+              if (pathname.startsWith('/product/')) {
+                return {...item, priority: 0.8};
+              }
+              return item; // keeps default 0.5
+            });
+          },
         },
       }),
     ],


### PR DESCRIPTION
## Description

The sitemap emitted every URL with the same `priority: 0.5`, giving crawlers no signal about relative page importance. This PR adds a `createSitemapItems` hook to the Docusaurus sitemap config in `website/docusaurus.config.js` that raises priority to `1.0` for `/` and `/blog`, `0.8` for `/product/*`, and keeps the existing `0.5` default for everything else. Verified by running `npm run build` and inspecting `build/sitemap.xml` (`/` and `/blog` → `1.0`, 12 `/product/*` pages → `0.8`, all other pages → `0.5`).

## Closes issue(s)
<!--
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)