### PR TITLE
feat(website): add lastmod to sitemap

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -306,6 +306,7 @@ const config = {
           customCss: [require.resolve('./src/css/custom.css')],
         },
         sitemap: {
+          lastmod: 'datetime',
           changefreq: 'weekly',
           priority: 0.5, // default fallback for pages not matched below
           ignorePatterns: [


### PR DESCRIPTION
## Description
The generated `sitemap.xml` did not include a `<lastmod>` element, so search engines had no signal for when each page was last changed. This PR sets `lastmod: 'datetime'` on the `@docusaurus/plugin-sitemap` config in `website/docusaurus.config.js`, adding a full ISO 8601 datetime `<lastmod>` to every URL, derived from each page's last git-commit/file-modification date. It can be tested by running `npm run build` in `website/` and confirming each `<url>` in `website/build/sitemap.xml` now contains a `<lastmod>` element. No breaking changes.

## Closes issue(s)
<!--
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)