### PR TITLE
ci(website): fetch full git history for accurate sitemap lastmod

### DIFF
--- a/.github/workflows/doc-deploy.yml
+++ b/.github/workflows/doc-deploy.yml
@@ -15,6 +15,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # Full git history so the Docusaurus sitemap plugin can derive an
+          # accurate per-page <lastmod> from each file's last commit date.
+          # With the default shallow clone, every page's lastmod collapses to
+          # the build timestamp.
+          fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           package-manager-cache: false


### PR DESCRIPTION
## Description
Follow-up to #5584, which added `lastmod: 'datetime'` to the Docusaurus sitemap plugin.

**Problem:** The Docusaurus sitemap plugin derives each page's `<lastmod>` from its last git-commit date. The docs deploy workflow (`.github/workflows/doc-deploy.yml`) checks out the repo with `actions/checkout`'s default **shallow clone** (`fetch-depth: 1` — latest commit only), so no per-file git history is available at build time. As a result, every page's `lastmod` falls back to the build timestamp: all ~199 URLs get the same value and it changes on every deploy, which is a weaker (and potentially misleading) signal than intended.

**Resolution:** Set `fetch-depth: 0` on the checkout step so the full git history is available and the sitemap plugin can emit an accurate per-page `<lastmod>` derived from each file's last commit date.

**How to test:**
- `cd website && npm run build`, then inspect `website/build/sitemap.xml`: with full history, `<lastmod>` values differ per page (matching each page's last edit) rather than all being identical.
- On CI, confirm the deploy job checks out full history before the build step.

No breaking changes.

## Closes issue(s)
<!-- Follow-up to #5584 -->
Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)