### PR TITLE
chore: Bump go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thomaspoignant/go-feature-flag
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/bigquery v1.77.0


### PR DESCRIPTION
## Description

Bumps the Go directive in the root `go.mod` from `1.26.4` to `1.26.5` (patch-level bump within the same `1.26` minor). CI, goreleaser, and workflows all read `go-version-file: go.mod`, so they inherit this automatically. The other monorepo modules (`modules/core`, `cmd/wasm`, and the helper/test/example modules) are intentionally left at their current versions, since `modules/core` is published and its Go directive is a minimum floor for downstream OpenFeature providers. Verified locally with `go mod verify` (all modules verified) against `go1.26.5`.

## Closes issue(s)
Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)