### PR TITLE
fix(s3exporterv2): log through the logger passed to Export()

### DIFF
--- a/exporter/s3exporterv2/exporter.go
+++ b/exporter/s3exporterv2/exporter.go
@@ -62,7 +62,6 @@ type Exporter struct {
 
 	s3Uploader UploaderAPI
 	init       sync.Once
-	ffLogger   *fflog.FFLogger
 }
 
 func (f *Exporter) initializeUploader(ctx context.Context) error {
@@ -129,7 +128,7 @@ func (f *Exporter) Export(
 		// read file
 		of, err := os.Open(outputDir + "/" + file.Name())
 		if err != nil {
-			f.ffLogger.Error(
+			logger.Error(
 				"[S3Exporter] impossible to open the file",
 				slog.String("path", outputDir+"/"+file.Name()),
 			)
@@ -150,7 +149,7 @@ func (f *Exporter) Export(
 		if result.Location != nil {
 			location = *result.Location
 		}
-		f.ffLogger.Info("[S3Exporter] file uploaded.", slog.String("location", location))
+		logger.Info("[S3Exporter] file uploaded.", slog.String("location", location))
 	}
 	return nil
 }

--- a/exporter/s3exporterv2/exporter_test.go
+++ b/exporter/s3exporterv2/exporter_test.go
@@ -1,6 +1,7 @@
 package s3exporterv2
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 	"os"
@@ -273,6 +274,41 @@ func Test_errSDK(t *testing.T) {
 		[]exporter.ExportableEvent{},
 	)
 	assert.Error(t, err, "Empty AWS config should failed")
+}
+
+// TestS3_Export_LogsThroughParameterLogger ensures the exporter logs through the
+// logger passed to Export() and not through an always-nil internal field.
+// See https://github.com/thomaspoignant/go-feature-flag/issues/5637.
+func TestS3_Export_LogsThroughParameterLogger(t *testing.T) {
+	var buf bytes.Buffer
+	logger := &fflog.FFLogger{
+		LeveledLogger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	}
+
+	s3ManagerMock := testutils.S3ManagerV2Mock{}
+	f := &Exporter{
+		Bucket:     "test",
+		s3Uploader: &s3ManagerMock,
+	}
+
+	err := f.Export(
+		context.TODO(),
+		logger,
+		[]exporter.ExportableEvent{
+			exporter.FeatureEvent{
+				Kind: "feature", ContextKind: "anonymousUser", UserKey: "ABCD", CreationDate: 1617970547, Key: "random-key",
+				Variation: "Default", Value: "YO", Default: false, Source: "SERVER",
+			},
+		},
+	)
+
+	assert.NoError(t, err, "Export should not error")
+	assert.Contains(
+		t,
+		buf.String(),
+		"[S3Exporter] file uploaded.",
+		"the upload log line should be emitted through the logger passed to Export()",
+	)
 }
 
 func TestS3_IsBulk(t *testing.T) {


### PR DESCRIPTION
## Description

The `s3exporterv2` exporter logged through an unexported `ffLogger` field that was never assigned anywhere in the package, so it was always `nil` and both of its log calls were silently discarded — even a file that could not be opened during export was skipped with no log line and no returned error, making a partial export look successful. This PR routes both log calls through the `logger` parameter already passed into `Export()` (matching how the GCS exporter works), drops the dead `ffLogger` field, and adds a test asserting the upload log line is now emitted through the parameter logger. To test, run `go test ./exporter/s3exporterv2/...`; the new `TestS3_Export_LogsThroughParameterLogger` fails on the old nil-field code and passes with this fix. There are no breaking changes.

## Closes issue(s)
Resolve #5637

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
