### PR TITLE
fix(ffcontext): ToMap() no longer mutates the evaluation context

### DIFF
--- a/modules/core/ffcontext/context.go
+++ b/modules/core/ffcontext/context.go
@@ -1,6 +1,9 @@
 package ffcontext
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"maps"
+)
 
 var _ Context = (*EvaluationContext)(nil)
 
@@ -92,7 +95,8 @@ func (u EvaluationContext) AddCustomAttribute(name string, value any) {
 }
 
 func (u EvaluationContext) ToMap() map[string]any {
-	resMap := u.attributes
+	resMap := make(map[string]any, len(u.attributes)+1)
+	maps.Copy(resMap, u.attributes)
 	resMap["targetingKey"] = u.targetingKey
 	return resMap
 }

--- a/modules/core/ffcontext/context.go
+++ b/modules/core/ffcontext/context.go
@@ -94,6 +94,10 @@ func (u EvaluationContext) AddCustomAttribute(name string, value any) {
 	}
 }
 
+// ToMap returns a new map containing the context attributes plus the targetingKey.
+// The returned map is a shallow copy: the top-level map is independent from the context,
+// so adding or removing keys does not affect it, but nested reference values (maps, slices,
+// pointers) are shared and mutating them will also mutate the context.
 func (u EvaluationContext) ToMap() map[string]any {
 	resMap := make(map[string]any, len(u.attributes)+1)
 	maps.Copy(resMap, u.attributes)

--- a/modules/core/ffcontext/context_test.go
+++ b/modules/core/ffcontext/context_test.go
@@ -339,3 +339,38 @@ func TestEvaluationContextToMap(t *testing.T) {
 		})
 	}
 }
+
+func TestEvaluationContextToMap_DoesNotMutateContext(t *testing.T) {
+	t.Run("targetingKey is not leaked into the context attributes", func(t *testing.T) {
+		ctx := ffcontext.NewEvaluationContext("user-123")
+		ctx.AddCustomAttribute("company", "acme")
+
+		_ = ctx.ToMap()
+
+		assert.Equal(t, map[string]any{"company": "acme"}, ctx.GetCustom(),
+			"ToMap() must not add targetingKey to the context's attributes")
+	})
+
+	t.Run("mutating the returned map does not leak back into the context", func(t *testing.T) {
+		ctx := ffcontext.NewEvaluationContext("user-123")
+		ctx.AddCustomAttribute("company", "acme")
+
+		m := ctx.ToMap()
+		m["injected"] = true
+
+		assert.NotContains(t, ctx.GetCustom(), "injected",
+			"mutating the map returned by ToMap() must not reach back into the context")
+		assert.Equal(t, map[string]any{"company": "acme"}, ctx.GetCustom())
+	})
+
+	t.Run("multiple calls are stable and leave the context untouched", func(t *testing.T) {
+		ctx := ffcontext.NewEvaluationContext("user-123")
+		ctx.AddCustomAttribute("company", "acme")
+
+		first := ctx.ToMap()
+		second := ctx.ToMap()
+
+		assert.Equal(t, first, second, "successive ToMap() calls must return equal maps")
+		assert.Equal(t, map[string]any{"company": "acme"}, ctx.GetCustom())
+	})
+}


### PR DESCRIPTION
## Description

`EvaluationContext.ToMap()` in `modules/core/ffcontext/context.go` aliased the receiver's `attributes` map (`resMap := u.attributes`) instead of copying it, so writing `targetingKey` mutated the context's own attributes — leaking `targetingKey` into `GetCustom()`/`MarshalJSON()` and letting callers mutate the context through the returned map, which violates the type's documented immutability contract. This PR builds a fresh map (matching the existing `utils.ContextToMap` pattern) so `ToMap()` returns a true snapshot and leaves the context untouched. Test it via `go test ./modules/core/ffcontext/...`, including the new `TestEvaluationContextToMap_DoesNotMutateContext` regression test; no breaking changes.

## Closes issue(s)
Resolve #5635

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)