### PR TITLE
ci: add Windows test runner job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,27 @@ jobs:
           cache: false
       - run: make test
 
+  Test-Windows:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Setup go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: false
+      # `make test` is not portable to Windows (bash loops, tput, -race/CGO,
+      # and -tags=docker testcontainers), so run the root module unit tests
+      # directly. This surfaces Windows-specific failures in CI.
+      - run: go test ./...
+
   Coverage:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Description

**What was the problem?**
A contributor on Windows reported the test suite failing with ~48 failures that never surface in our current CI, which only runs on `ubuntu-latest`. We have no Windows coverage, so these regressions are invisible until someone tries to build on Windows.

**How it is resolved?**
This PR adds a `Test-Windows` job (`windows-latest`) to `.github/workflows/ci.yml` so Windows test failures are visible in CI going forward.

`make test` is not portable to Windows (bash `for` loops, `tput`, `-race`/CGO, and `-tags=docker` testcontainers that don't run on `windows-latest`), so the job runs the root-module unit tests directly with `go test ./...`. Since `go.work` is gitignored, a fresh checkout runs in plain root-module mode — the same way the contributor reproduced the failures.

> ⚠️ **This job is expected to be RED for now** — it is intentionally added *before* the fixes so the Windows failures are visible. Two root causes were diagnosed from the contributor's log:
> 1. **CRLF line endings on checkout** — there is no `.gitattributes` enforcing LF, so Git for Windows (`core.autocrlf=true`) rewrites `testdata/*.json`, `testdata/*.yaml` and golden files to CRLF. This breaks golden-file string comparisons (`expected "...\r\n..."` vs `actual "...\n..."`), byte-offset assertions (`offset 322` vs `335` = +13 `\r`), and YAML flow-style parsing of `testdata/flag-config.json` (`yaml: line 43: did not find expected ',' or '}'`).
> 2. **Windows temp-file locking** — a few tests (`TestInitializableRetriever*`, `Test_PersistFlagConfigurationOnDisk`, `TestLoadConfigFile/...default_location`) leave an `os.CreateTemp` handle open before `os.Remove`/`os.Rename`, which Windows forbids ("The process cannot access the file because it is being used by another process").
>
> Follow-up PR(s) will add a root `.gitattributes` (`* text=auto eol=lf`) and close the leaked temp-file handles, turning this job green.
>
> If you'd prefer this job to not block merges until the fixes land, add `continue-on-error: true` to the job.

**How can we test the change?**
The new job runs automatically on this PR — check the `Test-Windows` check.

## Closes issue(s)
Resolve #

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
