### PR TITLE
fix: stabilize Test_ForceRefreshCache on Windows coarse clock

### DIFF
--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -585,6 +585,11 @@ func Test_ForceRefreshCache(t *testing.T) {
 	// checking that the cache has not been refreshed
 	assert.Equal(t, refreshTime, gffClient.GetCacheRefreshDate())
 
+	// Ensure the forced refresh lands on a strictly later timestamp even on
+	// platforms with a coarse monotonic clock (Windows timer granularity ~15ms),
+	// otherwise the initial load and the forced refresh can share the same instant.
+	time.Sleep(50 * time.Millisecond)
+
 	// checking that the cache has been refreshed
 	gffClient.ForceRefresh()
 	assert.NotEqual(t, refreshTime, gffClient.GetCacheRefreshDate())

--- a/feature_flag_test.go
+++ b/feature_flag_test.go
@@ -561,6 +561,9 @@ func Test_GetPollingInterval(t *testing.T) {
 func Test_ForceRefreshCache(t *testing.T) {
 	tempFile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
+	// close the handle before reusing/removing it: Windows cannot write to or
+	// delete a file that is still open by another handle
+	assert.NoError(t, tempFile.Close())
 	defer func() { _ = os.Remove(tempFile.Name()) }()
 	content, err := os.ReadFile("testdata/flag-config.yaml")
 	assert.NoError(t, err)


### PR DESCRIPTION
## Description

**What was the problem?**

The `Test-Windows` job fails on `Test_ForceRefreshCache`:

```
--- FAIL: Test_ForceRefreshCache (0.00s)
    feature_flag_test.go:590:
        Error Trace:  D:/a/go-feature-flag/go-feature-flag/feature_flag_test.go:590
        Error:        Should not be: time.Date(2026, time.July, 27, 12, 56, 0, 838698800, time.Local)
```

Windows-only, and not a product bug — the refresh genuinely happened (the log shows
`flag added key=foo-flag` / `bar-flag` from `flag-config-2nd-file.yaml` immediately before
the failure). The assertion is what is unsound.

On `windows/amd64`, `runtime/time_windows_amd64.s` reads **both** clocks out of
`KUSER_SHARED_DATA`:

```asm
TEXT time·now(SB),NOSPLIT,$0-24
    MOVQ  $_INTERRUPT_TIME, DI   // monotonic
    ...
    MOVQ  $_SYSTEM_TIME, DI      // wall
```

Neither is QPC-backed. Both only advance on the system clock interrupt (~0.5–15.6 ms), and
they advance together. `cacheManagerImpl.UpdateCache` stamps `c.latestUpdate = time.Now()`,
and the test does well under a millisecond of work between the initial load and
`ForceRefresh()` — so both stamps can land in the same tick and produce a **byte-identical**
`time.Time` (same wall *and* same monotonic reading). testify compares those with
`reflect.DeepEqual`, so `assert.NotEqual` fails.

Consistent with the observed value: the failing nanoseconds `838698800` are a multiple of
100, exactly what `_SYSTEM_TIME × 100` yields.

On Linux/macOS the clocks are nanosecond-resolution, which is why this only ever fires on
the Windows runner.

**How is it resolved?**

Same fix already applied to the identical pattern in
`cmd/relayproxy/handler/goff/retriever_refresh_test.go` in #5702 — that PR fixed one
instance of this and missed the other. Sleep past one clock tick before forcing the refresh,
reusing that comment verbatim so the two sites stay recognizable as the same fix.

I checked every other `GetCacheRefreshDate` / `GetLatestUpdateDate` assertion in the repo;
the rest are already safe (`TestStartWithNegativeIntervalToDisablePolling` and
`TestGoFeatureFlag_GetCacheRefreshDate` sleep for seconds, and
`Test_cacheManagerImpl_GetLatestUpdateDate` compares against the zero `time.Time`). This was
the last unfixed instance.

**How can we test the change?**

Locally on macOS: `go test -run Test_ForceRefreshCache -count=5 .` passes, and the full root
package (203 tests) is green. `golangci-lint run .` reports 0 issues. The real gate is the
`Test-Windows` job on this PR.

## Closes issue(s)

N/A — CI failure, no tracking issue.

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code <!-- this IS the test fix -->
- [ ] I have updated the documentation (`README.md` and `/website/docs`) <!-- test-only change -->
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
