### PR TITLE
ci: install Python provider deps from the committed uv.lock

### DIFF
--- a/.github/release-please/release-please-config.json
+++ b/.github/release-please/release-please-config.json
@@ -83,7 +83,12 @@
             "changelog-path": "CHANGELOG.md",
             "extra-files": [
                 "pyproject.toml",
-                "README.md"
+                "README.md",
+                {
+                    "path": "uv.lock",
+                    "type": "toml",
+                    "jsonpath": "$.package[?(@.name.value=='gofeatureflag-python-provider')].version"
+                }
             ]
         }
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,15 +249,15 @@ jobs:
       - name: uv sync
         if: steps.changed-files-specific.outputs.changed == 'true'
         working-directory: ./openfeature/providers/python-provider
-        run: uv sync
+        run: uv sync --locked
       - name: lint black
         if: steps.changed-files-specific.outputs.changed == 'true'
         working-directory: ./openfeature/providers/python-provider
-        run: uv run black . --check
+        run: uv run --no-sync black . --check
       - name: Pytest
         if: steps.changed-files-specific.outputs.changed == 'true'
         working-directory: ./openfeature/providers/python-provider
-        run: uv run pytest
+        run: uv run --no-sync pytest
   GraddleWrapperValidation:
     runs-on: ubuntu-latest
     permissions:

--- a/openfeature/providers/python-provider/uv.lock
+++ b/openfeature/providers/python-provider/uv.lock
@@ -213,7 +213,7 @@ wheels = [
 
 [[package]]
 name = "gofeatureflag-python-provider"
-version = "1.0.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "openfeature-provider-ofrep" },
@@ -235,7 +235,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "openfeature-provider-ofrep", specifier = ">=0.2.0" },
-    { name = "openfeature-sdk", specifier = ">=0.8.4,<0.9.0" },
+    { name = "openfeature-sdk", specifier = ">=0.8.4,<0.11.0" },
     { name = "pydantic", specifier = ">=2.5.2" },
     { name = "urllib3", specifier = ">=2.1.0" },
     { name = "wasmtime", specifier = ">=41.0.0" },


### PR DESCRIPTION
## Description

Fixes 3 open SonarCloud issues (`githubactions:S8544`, MAJOR) on the `Python-provider`
job in `.github/workflows/ci.yml` — *"Using dependencies without locking resolved versions
is security-sensitive"*.

**What was the problem?**

CI ran a bare `uv sync`. That re-resolves the dependency tree against the ranges in
`pyproject.toml` and silently rewrites `uv.lock` rather than installing from it. The
committed lockfile had therefore drifted from `pyproject.toml` in two ways, undetected:

- `version = "1.0.0"` in the lock vs `1.2.0` in `pyproject.toml` — release-please bumps
  `pyproject.toml` only (#5062, #5299, #5334).
- `openfeature-sdk >=0.8.4,<0.9.0` in the lock vs `>=0.8.4,<0.11.0` in `pyproject.toml` —
  widened in #5427 without re-locking.

So the provider's test suite had never run against the lockfile the project ships.
`uv lock --check` fails on `main` today.

**How is it resolved?**

- Regenerated `uv.lock`. The resolved `openfeature-sdk` stays at `0.8.4` (still valid under
  the widened range), so this is a 2-line metadata diff, not a dependency upgrade.
- `uv sync` → `uv sync --locked`, so drift fails the build loudly instead of being papered over.
- `uv run` → `uv run --no-sync` for black and pytest, so the lint/test steps use the
  environment built by the sync step without mutating it.
- Added `uv.lock` to the python-provider `extra-files` in `release-please-config.json`.
  Without this, `--locked` would turn every `chore(main): release` PR red, since the project
  version alone invalidates the lock. Uses the documented TOML/jsonpath workaround from
  googleapis/release-please#2561 (note `@.name.value`, not `@.name`).

One intended behaviour change: Dependabot PRs that edit `pyproject.toml` dependencies will
now fail CI with `uv.lock needs to be updated` instead of passing while testing a different
dependency set. The fix is a one-line `uv lock` + push.

**How can we test the change?**

Ran the exact new commands locally:

```
cd openfeature/providers/python-provider
uv lock --check                        # clean (fails on main)
uv sync --locked                       # OK
uv run --no-sync black . --check       # 37 files unchanged
uv run --no-sync pytest                # 147 passed
```

The `Python-provider` job on this PR exercises it on CI, since the diff touches
`openfeature/providers/python-provider/`.

**Not fixed here:** the 3 companion `githubactions:S8541` issues (*"Omitting `--no-build`"*)
on the same lines are not actionable — the provider is a hatchling package that must be built
to be importable, so `uv sync --locked --no-build` errors with *"`gofeatureflag-python-provider
==1.2.0 @ editable+.` can't be installed because it is marked as `--no-build` but has no binary
distribution"*, and uv has no "no-build except the workspace root" option. All 31 third-party
deps resolve to prebuilt wheels, so the real exposure is nil. I'll mark those as *Won't fix*
in SonarCloud.

## Closes issue(s)

N/A — reported by SonarCloud, no tracking issue.

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code <!-- CI/lockfile change, not unit-testable -->
- [ ] I have updated the documentation (`README.md` and `/website/docs`) <!-- no user-facing change -->
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
