### PR TITLE
fix: de-flake the Windows test suite (exporter + relay proxy api)

### DIFF
--- a/cmd/relayproxy/api/routes_monitoring_test.go
+++ b/cmd/relayproxy/api/routes_monitoring_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api"
@@ -77,10 +76,10 @@ func TestPprofEndpointsStarts(t *testing.T) {
 
 			go apiServer.StartWithContext(context.Background())
 			defer apiServer.Stop(context.Background())
-			time.Sleep(1 * time.Second) // waiting for the apiServer to start
+			waitForServer(t, fmt.Sprintf("http://localhost:%d", portToCheck))
 			resp, err := http.Get(fmt.Sprintf("http://localhost:%d/debug/pprof/heap", portToCheck))
-			defer func() { _ = resp.Body.Close() }()
 			require.NoError(t, err)
+			defer func() { _ = resp.Body.Close() }()
 			require.Equal(t, tt.expectedStatusCode, resp.StatusCode)
 		})
 	}

--- a/cmd/relayproxy/api/routes_stream_test.go
+++ b/cmd/relayproxy/api/routes_stream_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,7 +48,7 @@ func TestDeprecatedAliasHeaders(t *testing.T) {
 
 	go apiServer.StartWithContext(context.Background())
 	defer apiServer.Stop(context.Background())
-	time.Sleep(1 * time.Second)
+	waitForServer(t, fmt.Sprintf("http://localhost:%d", c.ServerPort(z)))
 
 	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/ws/v1/flag/change", c.ServerPort(z)))
 	require.NoError(t, err)

--- a/cmd/relayproxy/api/server_test.go
+++ b/cmd/relayproxy/api/server_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -26,11 +27,43 @@ import (
 	"github.com/thomaspoignant/go-feature-flag/cmdhelpers/log"
 	"github.com/thomaspoignant/go-feature-flag/cmdhelpers/retrieverconf"
 	"github.com/thomaspoignant/go-feature-flag/notifier"
+	"github.com/thomaspoignant/go-feature-flag/testutils"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/encoding/protodelim"
 )
 
+// newTestLogger returns a logger whose Fatal() terminates the calling goroutine instead of the
+// whole process. server.go reports a failed bind with zapLog.Fatal, and the default zap
+// behaviour is os.Exit(1): fired from the background goroutine that runs StartWithContext, it
+// takes the test binary down and every remaining test in the package is silently skipped.
+// With this hook the server goroutine dies, the Fatal is still logged, and the test fails on
+// its own readiness assertion with a message that points at the right place.
+func newTestLogger(t *testing.T) *log.Logger {
+	t.Helper()
+	l := log.InitLogger()
+	l.ZapLogger = l.ZapLogger.WithOptions(zap.WithFatalHook(zapcore.WriteThenGoexit))
+	t.Cleanup(func() { _ = l.ZapLogger.Sync() })
+	return l
+}
+
+// waitForServer blocks until the server accepts connections on baseURL. Binding a listener is
+// asynchronous, so a fixed sleep is a coin flip: 10ms is below the Windows timer granularity and
+// a loaded runner needs far more than that.
+func waitForServer(t *testing.T, baseURL string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(baseURL + "/health")
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return true
+	}, 10*time.Second, 20*time.Millisecond, "server never became reachable on %s", baseURL)
+}
+
 func Test_Starting_RelayProxy_with_monitoring_on_same_port(t *testing.T) {
+	port := testutils.GetFreePort(t)
 	proxyConf := &config.Config{
 		CommonFlagSet: config.CommonFlagSet{
 			Retrievers: &[]retrieverconf.RetrieverConf{
@@ -42,11 +75,10 @@ func Test_Starting_RelayProxy_with_monitoring_on_same_port(t *testing.T) {
 		},
 		Server: config.Server{
 			Mode: config.ServerModeHTTP,
-			Port: 11024,
+			Port: port,
 		},
 	}
-	log := log.InitLogger()
-	defer func() { _ = log.ZapLogger.Sync() }()
+	log := newTestLogger(t)
 
 	metricsV2, err := metric.NewMetrics()
 	if err != nil {
@@ -60,7 +92,7 @@ func Test_Starting_RelayProxy_with_monitoring_on_same_port(t *testing.T) {
 		prometheusNotifier,
 		proxyNotifier,
 	}, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	services := service.Services{
 		MonitoringService: service.NewMonitoring(flagsetManager),
@@ -73,25 +105,28 @@ func Test_Starting_RelayProxy_with_monitoring_on_same_port(t *testing.T) {
 	go func() { s.StartWithContext(context.Background()) }()
 	defer s.Stop(context.Background())
 
-	time.Sleep(10 * time.Millisecond)
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForServer(t, baseURL)
 
-	response, err := http.Get("http://localhost:11024/health")
-	assert.NoError(t, err)
+	response, err := http.Get(baseURL + "/health")
+	require.NoError(t, err)
 	defer func() { _ = response.Body.Close() }()
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 
-	responseM, err := http.Get("http://localhost:11024/metrics")
-	assert.NoError(t, err)
+	responseM, err := http.Get(baseURL + "/metrics")
+	require.NoError(t, err)
 	defer func() { _ = responseM.Body.Close() }()
 	assert.Equal(t, http.StatusOK, responseM.StatusCode)
 
-	responseI, err := http.Get("http://localhost:11024/info")
-	assert.NoError(t, err)
+	responseI, err := http.Get(baseURL + "/info")
+	require.NoError(t, err)
 	defer func() { _ = responseI.Body.Close() }()
 	assert.Equal(t, http.StatusOK, responseI.StatusCode)
 }
 
 func Test_Starting_RelayProxy_with_monitoring_on_different_port(t *testing.T) {
+	port := testutils.GetFreePort(t)
+	monitoringPort := testutils.GetFreePort(t)
 	proxyConf := &config.Config{
 		CommonFlagSet: config.CommonFlagSet{
 			Retrievers: &[]retrieverconf.RetrieverConf{
@@ -103,12 +138,11 @@ func Test_Starting_RelayProxy_with_monitoring_on_different_port(t *testing.T) {
 		},
 		Server: config.Server{
 			Mode:           config.ServerModeHTTP,
-			Port:           11024,
-			MonitoringPort: 11025,
+			Port:           port,
+			MonitoringPort: monitoringPort,
 		},
 	}
-	log := log.InitLogger()
-	defer func() { _ = log.ZapLogger.Sync() }()
+	log := newTestLogger(t)
 
 	metricsV2, err := metric.NewMetrics()
 	if err != nil {
@@ -122,7 +156,7 @@ func Test_Starting_RelayProxy_with_monitoring_on_different_port(t *testing.T) {
 		prometheusNotifier,
 		proxyNotifier,
 	}, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	services := service.Services{
 		MonitoringService: service.NewMonitoring(flagsetManager),
@@ -135,40 +169,44 @@ func Test_Starting_RelayProxy_with_monitoring_on_different_port(t *testing.T) {
 	go func() { s.StartWithContext(context.Background()) }()
 	defer s.Stop(context.Background())
 
-	time.Sleep(10 * time.Millisecond)
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	monitoringURL := fmt.Sprintf("http://localhost:%d", monitoringPort)
+	waitForServer(t, baseURL)
+	waitForServer(t, monitoringURL)
 
-	response, err := http.Get("http://localhost:11024/health")
-	assert.NoError(t, err)
+	response, err := http.Get(baseURL + "/health")
+	require.NoError(t, err)
 	defer func() { _ = response.Body.Close() }()
 	assert.Equal(t, http.StatusNotFound, response.StatusCode)
 
-	responseM, err := http.Get("http://localhost:11024/metrics")
-	assert.NoError(t, err)
+	responseM, err := http.Get(baseURL + "/metrics")
+	require.NoError(t, err)
 	defer func() { _ = responseM.Body.Close() }()
 	assert.Equal(t, http.StatusNotFound, responseM.StatusCode)
 
-	responseI, err := http.Get("http://localhost:11024/info")
-	assert.NoError(t, err)
+	responseI, err := http.Get(baseURL + "/info")
+	require.NoError(t, err)
 	defer func() { _ = responseI.Body.Close() }()
 	assert.Equal(t, http.StatusNotFound, responseI.StatusCode)
 
-	responseH1, err := http.Get("http://localhost:11025/health")
-	assert.NoError(t, err)
+	responseH1, err := http.Get(monitoringURL + "/health")
+	require.NoError(t, err)
 	defer func() { _ = responseH1.Body.Close() }()
 	assert.Equal(t, http.StatusOK, responseH1.StatusCode)
 
-	responseM1, err := http.Get("http://localhost:11025/metrics")
-	assert.NoError(t, err)
+	responseM1, err := http.Get(monitoringURL + "/metrics")
+	require.NoError(t, err)
 	defer func() { _ = responseM1.Body.Close() }()
 	assert.Equal(t, http.StatusOK, responseM1.StatusCode)
 
-	responseI1, err := http.Get("http://localhost:11025/info")
-	assert.NoError(t, err)
+	responseI1, err := http.Get(monitoringURL + "/info")
+	require.NoError(t, err)
 	defer func() { _ = responseI1.Body.Close() }()
 	assert.Equal(t, http.StatusOK, responseI1.StatusCode)
 }
 
 func Test_CheckOFREPAPIExists(t *testing.T) {
+	port := testutils.GetFreePort(t)
 	proxyConf := &config.Config{
 		CommonFlagSet: config.CommonFlagSet{
 			Retrievers: &[]retrieverconf.RetrieverConf{
@@ -180,15 +218,14 @@ func Test_CheckOFREPAPIExists(t *testing.T) {
 		},
 		Server: config.Server{
 			Mode: config.ServerModeHTTP,
-			Port: 11024,
+			Port: port,
 		},
 		AuthorizedKeys: config.APIKeys{
 			Admin:      nil,
 			Evaluation: []string{"test"},
 		},
 	}
-	log := log.InitLogger()
-	defer func() { _ = log.ZapLogger.Sync() }()
+	log := newTestLogger(t)
 
 	metricsV2, err := metric.NewMetrics()
 	if err != nil {
@@ -202,7 +239,7 @@ func Test_CheckOFREPAPIExists(t *testing.T) {
 		prometheusNotifier,
 		proxyNotifier,
 	}, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	services := service.Services{
 		MonitoringService: service.NewMonitoring(flagsetManager),
@@ -215,43 +252,45 @@ func Test_CheckOFREPAPIExists(t *testing.T) {
 	go func() { s.StartWithContext(context.Background()) }()
 	defer s.Stop(context.Background())
 
-	time.Sleep(10 * time.Millisecond)
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForServer(t, baseURL)
 
 	req, err := http.NewRequest("POST",
-		"http://localhost:11024/ofrep/v1/evaluate/flags",
+		baseURL+"/ofrep/v1/evaluate/flags",
 		strings.NewReader(`{ "context":{"targetingKey":"some-key"}}`))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	req.Header.Add("Authorization", "Bearer test")
 	req.Header.Add("Content-Type", "application/json")
 	response, err := http.DefaultClient.Do(req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { _ = response.Body.Close() }()
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 
 	req, err = http.NewRequest("POST",
-		"http://localhost:11024/ofrep/v1/evaluate/flags/some-key",
+		baseURL+"/ofrep/v1/evaluate/flags/some-key",
 		strings.NewReader(`{ "context":{"targetingKey":"some-key"}}`))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	req.Header.Add("Authorization", "Bearer test")
 	req.Header.Add("Content-Type", "application/json")
 	response, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { _ = response.Body.Close() }()
 	assert.Equal(t, http.StatusNotFound, response.StatusCode)
 
 	req, err = http.NewRequest("POST",
-		"http://localhost:11024/ofrep/v1/evaluate/flags/test-flag",
+		baseURL+"/ofrep/v1/evaluate/flags/test-flag",
 		strings.NewReader(`{ "context":{"targetingKey":"some-key"}}`))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	req.Header.Add("Authorization", "Bearer test")
 	req.Header.Add("Content-Type", "application/json")
 	response, err = http.DefaultClient.Do(req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { _ = response.Body.Close() }()
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 }
 
 func Test_Middleware_VersionHeader_Enabled_Default(t *testing.T) {
+	port := testutils.GetFreePort(t)
 	proxyConf := &config.Config{
 		CommonFlagSet: config.CommonFlagSet{
 			Retrievers: &[]retrieverconf.RetrieverConf{
@@ -263,11 +302,10 @@ func Test_Middleware_VersionHeader_Enabled_Default(t *testing.T) {
 		},
 		Server: config.Server{
 			Mode: config.ServerModeHTTP,
-			Port: 11024,
+			Port: port,
 		},
 	}
-	log := log.InitLogger()
-	defer func() { _ = log.ZapLogger.Sync() }()
+	log := newTestLogger(t)
 
 	metricsV2, err := metric.NewMetrics()
 	require.NoError(t, err)
@@ -287,16 +325,18 @@ func Test_Middleware_VersionHeader_Enabled_Default(t *testing.T) {
 	go func() { s.StartWithContext(context.Background()) }()
 	defer s.Stop(context.Background())
 
-	time.Sleep(10 * time.Millisecond)
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForServer(t, baseURL)
 
-	response, err := http.Get("http://localhost:11024/health")
-	assert.NoError(t, err)
+	response, err := http.Get(baseURL + "/health")
+	require.NoError(t, err)
 	defer func() { _ = response.Body.Close() }()
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 	assert.Equal(t, proxyConf.Version, response.Header.Get("X-GOFEATUREFLAG-VERSION"))
 }
 
 func Test_VersionHeader_Disabled(t *testing.T) {
+	port := testutils.GetFreePort(t)
 	proxyConf := &config.Config{
 		CommonFlagSet: config.CommonFlagSet{
 			Retrievers: &[]retrieverconf.RetrieverConf{
@@ -308,12 +348,11 @@ func Test_VersionHeader_Disabled(t *testing.T) {
 		},
 		Server: config.Server{
 			Mode: config.ServerModeHTTP,
-			Port: 11024,
+			Port: port,
 		},
 		DisableVersionHeader: true,
 	}
-	log := log.InitLogger()
-	defer func() { _ = log.ZapLogger.Sync() }()
+	log := newTestLogger(t)
 
 	metricsV2, err := metric.NewMetrics()
 	require.NoError(t, err)
@@ -333,10 +372,11 @@ func Test_VersionHeader_Disabled(t *testing.T) {
 	go func() { s.StartWithContext(context.Background()) }()
 	defer s.Stop(context.Background())
 
-	time.Sleep(10 * time.Millisecond)
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForServer(t, baseURL)
 
-	response, err := http.Get("http://localhost:11024/health")
-	assert.NoError(t, err)
+	response, err := http.Get(baseURL + "/health")
+	require.NoError(t, err)
 	defer func() { _ = response.Body.Close() }()
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 	assert.Empty(t, response.Header.Get("X-GOFEATUREFLAG-VERSION"))
@@ -367,11 +407,14 @@ func Test_AuthenticationMiddleware(t *testing.T) {
 			},
 		}
 
-		runAuthMiddlewareTests(t, tests, func(_ *testing.T, _ authMiddlewareTestCase) (*http.Response, error) {
-			return http.Post("http://localhost:11024/ofrep/v1/evaluate/flags/test-flag", "application/json",
-				strings.NewReader(`{"context":{"targetingKey":"some-key"}}`),
-			)
-		})
+		runAuthMiddlewareTests(
+			t,
+			tests,
+			func(_ *testing.T, _ authMiddlewareTestCase, baseURL string) (*http.Response, error) {
+				return http.Post(baseURL+"/ofrep/v1/evaluate/flags/test-flag", "application/json",
+					strings.NewReader(`{"context":{"targetingKey":"some-key"}}`),
+				)
+			})
 	})
 
 	t.Run("Admin Endpoint", func(t *testing.T) {
@@ -398,15 +441,18 @@ func Test_AuthenticationMiddleware(t *testing.T) {
 			},
 		}
 
-		runAuthMiddlewareTests(t, tests, func(t *testing.T, tt authMiddlewareTestCase) (*http.Response, error) {
-			request, err := http.NewRequest("POST", "http://localhost:11024/admin/v1/retriever/refresh", nil)
-			assert.NoError(t, err)
-			request.Header.Add("Content-Type", "application/json")
-			if tt.configAPIKeys != nil && len(tt.configAPIKeys.Admin) > 0 {
-				request.Header.Add("Authorization", "Bearer "+tt.configAPIKeys.Admin[0])
-			}
-			return http.DefaultClient.Do(request)
-		})
+		runAuthMiddlewareTests(
+			t,
+			tests,
+			func(t *testing.T, tt authMiddlewareTestCase, baseURL string) (*http.Response, error) {
+				request, err := http.NewRequest("POST", baseURL+"/admin/v1/retriever/refresh", nil)
+				require.NoError(t, err)
+				request.Header.Add("Content-Type", "application/json")
+				if tt.configAPIKeys != nil && len(tt.configAPIKeys.Admin) > 0 {
+					request.Header.Add("Authorization", "Bearer "+tt.configAPIKeys.Admin[0])
+				}
+				return http.DefaultClient.Do(request)
+			})
 	})
 }
 
@@ -422,11 +468,12 @@ type authMiddlewareTestCase struct {
 func runAuthMiddlewareTests(
 	t *testing.T,
 	tests []authMiddlewareTestCase,
-	doRequest func(t *testing.T, tt authMiddlewareTestCase) (*http.Response, error),
+	doRequest func(t *testing.T, tt authMiddlewareTestCase, baseURL string) (*http.Response, error),
 ) {
 	t.Helper()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			port := testutils.GetFreePort(t)
 			proxyConf := &config.Config{
 				CommonFlagSet: config.CommonFlagSet{
 					Retrievers: &[]retrieverconf.RetrieverConf{
@@ -438,7 +485,7 @@ func runAuthMiddlewareTests(
 				},
 				Server: config.Server{
 					Mode: config.ServerModeHTTP,
-					Port: 11024,
+					Port: port,
 				},
 				DisableVersionHeader: true,
 			}
@@ -447,8 +494,7 @@ func runAuthMiddlewareTests(
 			}
 			proxyConf.ForceReloadAPIKeys()
 
-			log := log.InitLogger()
-			defer func() { _ = log.ZapLogger.Sync() }()
+			log := newTestLogger(t)
 
 			metricsV2, err := metric.NewMetrics()
 			require.NoError(t, err)
@@ -467,13 +513,26 @@ func runAuthMiddlewareTests(
 			s := api.New(proxyConf, services, log.ZapLogger)
 			go func() { s.StartWithContext(context.Background()) }()
 			defer s.Stop(context.Background())
-			time.Sleep(10 * time.Millisecond)
 
-			response, err := doRequest(t, tt)
-			assert.NoError(t, err)
+			baseURL := fmt.Sprintf("http://localhost:%d", port)
+			waitForServer(t, baseURL)
+
+			response, err := doRequest(t, tt, baseURL)
+			require.NoError(t, err)
 			defer func() { _ = response.Body.Close() }()
 			assert.Equal(t, tt.want, response.StatusCode)
 		})
+	}
+}
+
+// skipUnixSocketOnWindows skips the unix socket tests on Windows. Binding an AF_UNIX listener
+// there intermittently fails on the CI runners with WSAENETDOWN ("a socket operation encountered
+// a dead network"), and unix socket mode is a Unix-only deployment target anyway.
+func skipUnixSocketOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("AF_UNIX listeners are unreliable on Windows CI (WSAENETDOWN); " +
+			"unix socket mode is a Unix-only deployment target")
 	}
 }
 
@@ -489,6 +548,7 @@ func newUnixSocketHTTPClient(socketPath string) *http.Client {
 }
 
 func Test_Starting_RelayProxy_UnixSocket(t *testing.T) {
+	skipUnixSocketOnWindows(t)
 	// Create a temporary directory for the socket
 	tempDir, err := os.MkdirTemp("", "goff-test-socket-*")
 	require.NoError(t, err)
@@ -510,8 +570,7 @@ func Test_Starting_RelayProxy_UnixSocket(t *testing.T) {
 			UnixSocketPath: socketPath,
 		},
 	}
-	log := log.InitLogger()
-	defer func() { _ = log.ZapLogger.Sync() }()
+	log := newTestLogger(t)
 
 	metricsV2, err := metric.NewMetrics()
 	if err != nil {
@@ -546,31 +605,33 @@ func Test_Starting_RelayProxy_UnixSocket(t *testing.T) {
 
 	// Verify socket file exists
 	_, err = os.Stat(socketPath)
-	assert.NoError(t, err, "Unix socket file should exist")
+	require.NoError(t, err, "Unix socket file should exist")
 
 	// Create a Unix socket HTTP client
 	client := newUnixSocketHTTPClient(socketPath)
 
 	// Test health endpoint
 	response, err := client.Get("http://unix/health")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { _ = response.Body.Close() }()
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 
 	// Test metrics endpoint
 	responseM, err := client.Get("http://unix/metrics")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { _ = responseM.Body.Close() }()
 	assert.Equal(t, http.StatusOK, responseM.StatusCode)
 
 	// Test info endpoint
 	responseI, err := client.Get("http://unix/info")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { _ = responseI.Body.Close() }()
 	assert.Equal(t, http.StatusOK, responseI.StatusCode)
 }
 
 func Test_Starting_RelayProxy_UnixSocket_MonitoringPort(t *testing.T) {
+	skipUnixSocketOnWindows(t)
+	monitoringPort := testutils.GetFreePort(t)
 	// Create a temporary directory for the socket
 	tempDir, err := os.MkdirTemp("", "goff-test-socket-*")
 	require.NoError(t, err)
@@ -590,11 +651,10 @@ func Test_Starting_RelayProxy_UnixSocket_MonitoringPort(t *testing.T) {
 		Server: config.Server{
 			Mode:           config.ServerModeUnixSocket,
 			UnixSocketPath: socketPath,
-			MonitoringPort: 11026,
+			MonitoringPort: monitoringPort,
 		},
 	}
-	log := log.InitLogger()
-	defer func() { _ = log.ZapLogger.Sync() }()
+	log := newTestLogger(t)
 
 	metricsV2, err := metric.NewMetrics()
 	if err != nil {
@@ -629,28 +689,32 @@ func Test_Starting_RelayProxy_UnixSocket_MonitoringPort(t *testing.T) {
 
 	// Verify socket file exists
 	_, err = os.Stat(socketPath)
-	assert.NoError(t, err, "Unix socket file should exist")
+	require.NoError(t, err, "Unix socket file should exist")
+
+	monitoringURL := fmt.Sprintf("http://localhost:%d", monitoringPort)
+	waitForServer(t, monitoringURL)
 
 	// Test health endpoint
-	responseH1, err := http.Get("http://localhost:11026/health")
-	assert.NoError(t, err)
+	responseH1, err := http.Get(monitoringURL + "/health")
+	require.NoError(t, err)
 	defer responseH1.Body.Close()
 	assert.Equal(t, http.StatusOK, responseH1.StatusCode)
 
 	// Test metrics endpoint
-	responseM1, err := http.Get("http://localhost:11026/metrics")
-	assert.NoError(t, err)
+	responseM1, err := http.Get(monitoringURL + "/metrics")
+	require.NoError(t, err)
 	defer responseM1.Body.Close()
 	assert.Equal(t, http.StatusOK, responseM1.StatusCode)
 
 	// Test info endpoint
-	responseI, err := http.Get("http://localhost:11026/info")
-	assert.NoError(t, err)
+	responseI, err := http.Get(monitoringURL + "/info")
+	require.NoError(t, err)
 	defer responseI.Body.Close()
 	assert.Equal(t, http.StatusOK, responseI.StatusCode)
 }
 
 func Test_Starting_RelayProxy_UnixSocket_OFREP_API(t *testing.T) {
+	skipUnixSocketOnWindows(t)
 	// Create a temporary directory for the socket
 	tempDir, err := os.MkdirTemp("", "goff-test-socket-*")
 	require.NoError(t, err)
@@ -676,8 +740,7 @@ func Test_Starting_RelayProxy_UnixSocket_OFREP_API(t *testing.T) {
 			Evaluation: []string{"test"},
 		},
 	}
-	log := log.InitLogger()
-	defer func() { _ = log.ZapLogger.Sync() }()
+	log := newTestLogger(t)
 
 	metricsV2, err := metric.NewMetrics()
 	if err != nil {
@@ -712,7 +775,7 @@ func Test_Starting_RelayProxy_UnixSocket_OFREP_API(t *testing.T) {
 
 	// Verify socket file exists
 	_, err = os.Stat(socketPath)
-	assert.NoError(t, err, "Unix socket file should exist")
+	require.NoError(t, err, "Unix socket file should exist")
 
 	// Create a Unix socket HTTP client
 	client := newUnixSocketHTTPClient(socketPath)
@@ -725,7 +788,7 @@ func Test_Starting_RelayProxy_UnixSocket_OFREP_API(t *testing.T) {
 	req.Header.Add("Authorization", "Bearer test")
 	req.Header.Add("Content-Type", "application/json")
 	response, err := client.Do(req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { _ = response.Body.Close() }()
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 
@@ -737,7 +800,7 @@ func Test_Starting_RelayProxy_UnixSocket_OFREP_API(t *testing.T) {
 	req.Header.Add("Authorization", "Bearer test")
 	req.Header.Add("Content-Type", "application/json")
 	response, err = client.Do(req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { _ = response.Body.Close() }()
 	assert.Equal(t, http.StatusNotFound, response.StatusCode)
 
@@ -749,12 +812,13 @@ func Test_Starting_RelayProxy_UnixSocket_OFREP_API(t *testing.T) {
 	req.Header.Add("Authorization", "Bearer test")
 	req.Header.Add("Content-Type", "application/json")
 	response, err = client.Do(req)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { _ = response.Body.Close() }()
 	assert.Equal(t, http.StatusOK, response.StatusCode)
 }
 
 func TestStartingRelayProxyUnixSocketAuthentication(t *testing.T) {
+	skipUnixSocketOnWindows(t)
 	tests := []struct {
 		name          string
 		configAPIKeys *config.APIKeys
@@ -835,8 +899,7 @@ func TestStartingRelayProxyUnixSocketAuthentication(t *testing.T) {
 			}
 			proxyConf.ForceReloadAPIKeys()
 
-			log := log.InitLogger()
-			defer func() { _ = log.ZapLogger.Sync() }()
+			log := newTestLogger(t)
 
 			metricsV2, err := metric.NewMetrics()
 			require.NoError(t, err)
@@ -882,7 +945,7 @@ func TestStartingRelayProxyUnixSocketAuthentication(t *testing.T) {
 			}
 
 			response, err := client.Do(req)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer func() { _ = response.Body.Close() }()
 			assert.Equal(t, tt.want, response.StatusCode)
 		})
@@ -890,6 +953,7 @@ func TestStartingRelayProxyUnixSocketAuthentication(t *testing.T) {
 }
 
 func TestStartingRelayProxyUnixSocketVersionHeader(t *testing.T) {
+	skipUnixSocketOnWindows(t)
 	tests := []struct {
 		name                 string
 		disableVersionHeader bool
@@ -933,8 +997,7 @@ func TestStartingRelayProxyUnixSocketVersionHeader(t *testing.T) {
 				Version:              "test-version-1.0.0",
 			}
 
-			log := log.InitLogger()
-			defer func() { _ = log.ZapLogger.Sync() }()
+			log := newTestLogger(t)
 
 			metricsV2, err := metric.NewMetrics()
 			require.NoError(t, err)
@@ -964,7 +1027,7 @@ func TestStartingRelayProxyUnixSocketVersionHeader(t *testing.T) {
 			client := newUnixSocketHTTPClient(socketPath)
 
 			response, err := client.Get("http://unix/health")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer func() { _ = response.Body.Close() }()
 			assert.Equal(t, http.StatusOK, response.StatusCode)
 
@@ -978,9 +1041,10 @@ func TestStartingRelayProxyUnixSocketVersionHeader(t *testing.T) {
 }
 
 func Test_NativeHistograms_Enabled(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
 
+	port := testutils.GetFreePort(t)
 	proxyConf := &config.Config{
 		CommonFlagSet: config.CommonFlagSet{
 			Retrievers: &[]retrieverconf.RetrieverConf{
@@ -992,12 +1056,11 @@ func Test_NativeHistograms_Enabled(t *testing.T) {
 		},
 		Server: config.Server{
 			Mode: config.ServerModeHTTP,
-			Port: 11024,
+			Port: port,
 		},
 	}
 
-	log := log.InitLogger()
-	defer func() { _ = log.ZapLogger.Sync() }()
+	log := newTestLogger(t)
 
 	metricsV2, err := metric.NewMetrics()
 	require.NoError(t, err)
@@ -1025,19 +1088,20 @@ func Test_NativeHistograms_Enabled(t *testing.T) {
 	go func() { s.StartWithContext(ctx) }()
 	defer s.Stop(ctx)
 
-	time.Sleep(10 * time.Millisecond)
+	baseURL := fmt.Sprintf("http://localhost:%d", port)
+	waitForServer(t, baseURL)
 
 	// Make some requests to generate histogram data
-	healthResp, err := http.Get("http://localhost:11024/health")
+	healthResp, err := http.Get(baseURL + "/health")
 	require.NoError(t, err)
 	_ = healthResp.Body.Close()
 
-	infoResp, err := http.Get("http://localhost:11024/info")
+	infoResp, err := http.Get(baseURL + "/info")
 	require.NoError(t, err)
 	_ = infoResp.Body.Close()
 
 	// Scrape /metrics with protobuf Accept header
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:11024/metrics", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/metrics", nil)
 	require.NoError(t, err)
 	req.Header.Set("Accept", "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited")
 
@@ -1110,8 +1174,7 @@ func Test_PortFreedAfterShutdown(t *testing.T) {
 		},
 	}
 
-	l := log.InitLogger()
-	defer func() { _ = l.ZapLogger.Sync() }()
+	l := newTestLogger(t)
 
 	wsService := stream.NewWebsocketService()
 

--- a/exporter/data_exporter.go
+++ b/exporter/data_exporter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/thomaspoignant/go-feature-flag/utils/fflog"
@@ -43,6 +44,9 @@ type dataExporterImpl[T ExportableEvent] struct {
 
 	daemonChan chan struct{}
 	ticker     *time.Ticker
+	// stopOnce guarantees that we stop the daemon only once: Close() can be called several times
+	// on a GO Feature Flag client, and closing an already closed channel panics.
+	stopOnce sync.Once
 }
 
 // NewDataExporter create a new DataExporter with the given exporter and his consumer information to consume the data
@@ -87,14 +91,17 @@ func (d *dataExporterImpl[T]) Start() {
 }
 
 // Stop is flushing the data and stopping the ticker
+// It is safe to call it several times.
 func (d *dataExporterImpl[T]) Stop() {
 	// we don't start the daemon if we are not in bulk mode
 	if !d.IsBulk() {
 		d.Flush()
 		return
 	}
-	d.ticker.Stop()
-	close(d.daemonChan)
+	d.stopOnce.Do(func() {
+		d.ticker.Stop()
+		close(d.daemonChan)
+	})
 	d.Flush()
 }
 

--- a/exporter/event_store.go
+++ b/exporter/event_store.go
@@ -21,6 +21,9 @@ type eventStoreImpl[T ExportableEvent] struct {
 	lastOffset int64
 	// stopPeriodicCleaning is a channel to stop the periodic cleaning goroutine
 	stopPeriodicCleaning chan struct{}
+	// stopOnce guarantees that we close stopPeriodicCleaning only once, Stop() is reachable
+	// from the exporter manager and directly from the tests.
+	stopOnce sync.Once
 	// cleanQueueInterval is the duration between each cleaning
 	cleanQueueInterval time.Duration
 }
@@ -230,6 +233,9 @@ func (e *eventStoreImpl[T]) periodicCleanQueue() {
 }
 
 // Stop is closing the Event store and stop the periodic cleaning.
+// It is safe to call it several times.
 func (e *eventStoreImpl[T]) Stop() {
-	close(e.stopPeriodicCleaning)
+	e.stopOnce.Do(func() {
+		close(e.stopPeriodicCleaning)
+	})
 }

--- a/exporter/event_store_test.go
+++ b/exporter/event_store_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
 	"github.com/thomaspoignant/go-feature-flag/testutils"
 )
@@ -59,9 +60,7 @@ func Test_SingleConsumer(t *testing.T) {
 	// start producer
 	ctx, cancel := context.WithCancel(context.Background())
 	go startEventProducer(ctx, eventStore, 100, false)
-	time.Sleep(50 * time.Millisecond)
-	got, _ = eventStore.GetPendingEventCount(consumerName)
-	assert.Equal(t, int64(100), got)
+	requireEventuallyPendingCount(t, eventStore, consumerName, 100)
 	cancel() // stop producing
 
 	// Consume
@@ -78,9 +77,7 @@ func Test_SingleConsumer(t *testing.T) {
 	ctx2, cancel2 := context.WithCancel(context.Background())
 	defer cancel2()
 	go startEventProducer(ctx2, eventStore, 91, false)
-	time.Sleep(50 * time.Millisecond)
-	got, _ = eventStore.GetPendingEventCount(consumerName)
-	assert.Equal(t, int64(91), got)
+	requireEventuallyPendingCount(t, eventStore, consumerName, 91)
 
 	err = eventStore.ProcessPendingEvents(consumerName,
 		func(ctx context.Context, events []testutils.ExportableMockEvent) error {
@@ -89,8 +86,7 @@ func Test_SingleConsumer(t *testing.T) {
 		})
 	assert.Nil(t, err)
 
-	time.Sleep(120 * time.Millisecond) // to wait until garbage collector remove the events
-	assert.Equal(t, int64(0), eventStore.GetTotalEventCount())
+	requireEventuallyEmptyStore(t, eventStore)
 }
 
 func Test_MultipleConsumersSingleThread(t *testing.T) {
@@ -151,8 +147,7 @@ func Test_MultipleConsumersSingleThread(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Check garbage collector
-	time.Sleep(120 * time.Millisecond)
-	assert.Equal(t, int64(0), eventStore.GetTotalEventCount())
+	requireEventuallyEmptyStore(t, eventStore)
 }
 
 func Test_MultipleConsumersMultipleGORoutines(t *testing.T) {
@@ -274,8 +269,7 @@ func Test_WaitForEmptyClean(t *testing.T) {
 	)
 	assert.Nil(t, err)
 	assert.True(t, eventStore.GetTotalEventCount() > 0)
-	time.Sleep(3 * defaultTestCleanQueueDuration)
-	assert.Equal(t, int64(0), eventStore.GetTotalEventCount())
+	requireEventuallyEmptyStore(t, eventStore)
 }
 
 func Test_ProcessPendingEvents_DoesNotBlockAdd(t *testing.T) {
@@ -464,6 +458,37 @@ func Test_ProcessPendingEvents_EmptyBatchSkipsCallback(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.False(t, callbackCalled)
+}
+
+// requireEventuallyPendingCount waits until the producer goroutine has pushed the expected
+// number of events. Sleeping for a fixed duration instead makes the test depend on the producer
+// being scheduled promptly, which is not guaranteed on a loaded CI runner.
+func requireEventuallyPendingCount(
+	t *testing.T,
+	eventStore exporter.EventStore[testutils.ExportableMockEvent],
+	consumerName string,
+	want int64,
+) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		got, err := eventStore.GetPendingEventCount(consumerName)
+		return err == nil && got == want
+	}, 10*time.Second, 10*time.Millisecond,
+		"consumer %q never reached %d pending events", consumerName, want)
+}
+
+// requireEventuallyEmptyStore waits for the periodic clean queue goroutine to drop the events
+// consumed by everybody. It runs on a ticker, so a fixed sleep of one or two intervals has no
+// margin left once the runner stalls.
+func requireEventuallyEmptyStore(
+	t *testing.T,
+	eventStore exporter.EventStore[testutils.ExportableMockEvent],
+) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return eventStore.GetTotalEventCount() == int64(0)
+	}, 10*time.Second, 10*time.Millisecond,
+		"the periodic clean queue never removed the consumed events")
 }
 
 func startEventProducer(

--- a/exporter/manager.go
+++ b/exporter/manager.go
@@ -74,4 +74,8 @@ func (m *managerImpl[T]) Stop() {
 	for _, consumer := range m.consumers {
 		consumer.Stop()
 	}
+	// The consumers have flushed everything they had, nobody will read from the store anymore,
+	// so we stop its periodic cleaning goroutine to avoid leaking it (and the events it retains)
+	// for the lifetime of the process.
+	(*m.eventStore).Stop()
 }

--- a/exporter/manager_test.go
+++ b/exporter/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/thejerf/slogassert"
 	ffclient "github.com/thomaspoignant/go-feature-flag"
 	"github.com/thomaspoignant/go-feature-flag/exporter"
@@ -313,13 +314,18 @@ func TestAddExporterMetadataFromContextToExporter(t *testing.T) {
 				},
 			}
 			goff, err := ffclient.New(config)
-			assert.NoError(t, err)
+			require.NoError(t, err)
+			defer goff.Close()
 
 			_, err = goff.BoolVariation("test-flag", tt.ctx, false)
 			assert.NoError(t, err)
 
-			time.Sleep(120 * time.Millisecond)
-			assert.Equal(t, 1, len(mockExporter.GetExportedEvents()))
+			// The event is collected in a goroutine and exported by the flush ticker, so we
+			// can't rely on a fixed sleep: a loaded CI runner can stall past the tick.
+			require.Eventually(t, func() bool {
+				return len(mockExporter.GetExportedEvents()) == 1
+			}, 10*time.Second, 10*time.Millisecond,
+				"the flush ticker never exported the evaluation event")
 
 			switch val := mockExporter.GetExportedEvents()[0].(type) {
 			case exporter.FeatureEvent:
@@ -445,7 +451,7 @@ func TestDataExporterManager_ValidateNumberOfEvents(t *testing.T) {
 					Exporter:         &mockExporter,
 				},
 			})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// create users
 			user1 := ffcontext.
@@ -462,14 +468,60 @@ func TestDataExporterManager_ValidateNumberOfEvents(t *testing.T) {
 				user1,
 				map[string]any{"test": "toto"},
 			)
-			time.Sleep(300 * time.Millisecond)
-			assert.Equal(t, 4, len(mockExporter.GetExportedEvents()))
+			// Events are collected in a goroutine (see notifyVariation) and exported by the
+			// flush ticker. A fixed sleep only gives us one or two ticks of margin, so a CI
+			// stall (very common on the Windows runner) makes every tick fire before the
+			// events reach the event store, and we export nothing.
+			require.Eventually(t, func() bool {
+				return len(mockExporter.GetExportedEvents()) == 4
+			}, 10*time.Second, 10*time.Millisecond,
+				"the flush ticker never exported the 4 evaluation events")
 
-			// Wait 2 seconds to have a second file
+			// Close() waits for the in-flight collect goroutines and then flushes, so the last
+			// 2 events are exported synchronously and this assertion needs no waiting.
 			_, _ = ffclient.BoolVariation("test-flag", user1, false)
 			_, _ = ffclient.BoolVariation("test-flag", user2, false)
 			ffclient.Close() // a flush is triggered here
 			assert.Equal(t, 6, len(mockExporter.GetExportedEvents()))
 		})
 	}
+}
+
+// TestDataExporterManager_StopReleasesEverything checks the two things Stop() has to guarantee:
+// it is safe to call several times, since callers are free to Close() a client twice, and it
+// releases every goroutine it started, including the event store cleaner. Forgetting the store
+// leaks one goroutine and the events it retains per client, which is unbounded for the relay
+// proxy since it builds a client per flagset on every hot reload.
+func TestDataExporterManager_StopReleasesEverything(t *testing.T) {
+	const nbManagers = 50
+	goroutinesBefore := runtime.NumGoroutine()
+
+	for range nbManagers {
+		dc := exporter.NewManager[exporter.FeatureEvent](
+			[]exporter.Config{
+				{
+					FlushInterval:    10 * time.Millisecond,
+					MaxEventInMemory: 100,
+					Exporter:         &mock.Exporter{Bulk: true},
+				},
+			},
+			10*time.Millisecond,
+			nil,
+		)
+		dc.Start()
+		dc.AddEvent(exporter.NewFeatureEvent(
+			ffcontext.NewEvaluationContextBuilder("ABCD").Build(),
+			"random-key", "YO", "defaultVar", false, "", "SERVER", nil))
+		dc.Stop()
+		// ffclient.Close() can legitimately be called twice, and Stop() used to panic with
+		// "close of closed channel" on the second call.
+		assert.NotPanics(t, dc.Stop)
+	}
+
+	require.Eventually(t, func() bool {
+		// A small tolerance, other tests in this package leak goroutines of their own.
+		return runtime.NumGoroutine() <= goroutinesBefore+5
+	}, 10*time.Second, 20*time.Millisecond,
+		"Stop() leaked goroutines: %d before creating %d managers, %d after stopping them all",
+		goroutinesBefore, nbManagers, runtime.NumGoroutine())
 }


### PR DESCRIPTION
## Description

`Test-Windows` was failing **~8% of runs** (5 of the last 60 `ci.yml` runs), a different test each time — most recently `TestDataExporterManager_ValidateNumberOfEvents` on the unrelated dependabot PR #5721. #5702 and #5710 swept the root package, leaving `exporter/` and `cmd/relayproxy/api` as the whole remaining surface. This PR fixes the four distinct mechanisms behind those failures, plus two lifecycle bugs the investigation surfaced.

- **One-tick margin against an async producer.** Evaluations record events from a fire-and-forget goroutine (`notifyVariation`) while export runs on a `time.Ticker`, and the tests slept only one or two flush intervals; a CI stall makes every tick fire before the events reach the store, so nothing is exported. Replaced with `require.Eventually` in `TestDataExporterManager_ValidateNumberOfEvents`, `TestAddExporterMetadataFromContextToExporter` and four event-store sites.
- **`zapLog.Fatal` killed the test binary.** `server.go` Fatals on a failed bind, which `os.Exit(1)`s the process from the background goroutine running `StartWithContext`, silently voiding every later test in the package. The api tests now use `zap.WithFatalHook(zapcore.WriteThenGoexit)`.
- **Windows AF_UNIX intermittently fails to bind** with `WSAENETDOWN`; unix-socket mode is a Unix-only deployment target, so those 5 tests now skip on Windows.
- **`assert.NoError` does not abort**, so a refused dial nil-panicked on the next `defer resp.Body.Close()`. Promoted every error check in `server_test.go` to `require.NoError`, replaced the 10ms readiness sleeps with a `waitForServer` helper, and replaced the hardcoded port `11024` (shared by 7 tests) with `testutils.GetFreePort`.

Two library bugs, both covered by the new `TestDataExporterManager_StopReleasesEverything` and each verified by reverting the fix and watching it fail: `exporter.Manager.Stop()` never stopped the `EventStore`, leaking a `periodicCleanQueue` goroutine and its retained events per client (3 → 56 goroutines over 50 managers; unbounded for the relay proxy, which builds a client per flagset on every hot reload); and `dataExporterImpl.Stop()` panicked with `close of closed channel` on a second `Close()`, now guarded with `sync.Once` like the retriever side.

**How to test:** `go test ./...` (the exact Windows CI command) and `make test` (`-race`) pass, `exporter/...` and `cmd/relayproxy/api` are green at `-count=8`, and `golangci-lint` reports 0 issues on the root module. Because the baseline flake rate is ~8%, please **re-run `Test-Windows` several times** rather than trusting one green run. No behaviour change for users; dropping the readiness sleeps also cuts the api package from ~3.5s to ~1.7s.

## Closes issue(s)

No issue — this was surfaced directly by the flaky `Test-Windows` job (most recently on #5721), and follows #5702 and #5710.

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`) — not applicable, no user-facing change
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
