### PR TITLE
refactor(website): remove outbound links from homepage company logos

### DIFF
--- a/website/src/components/home/using-it/index.js
+++ b/website/src/components/home/using-it/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Link from '@docusaurus/Link';
 import lyft from '@site/static/img/using-it/lyft.png';
 import tencent from '@site/static/img/using-it/tencent.png';
 import minder from '@site/static/img/using-it/minder.png';
@@ -110,15 +109,11 @@ function UsingItLogos({companies}) {
     <div className={'grid grid-cols-2 lg:grid-cols-6 mt-8 items-center mb-0'}>
       {companies.map(company => (
         <div key={company.name}>
-          <Link to={company.url}>
-            <img
-              src={company.logo}
-              alt={company.name}
-              className={
-                company.imgClassName ? company.imgClassName : 'max-w-28'
-              }
-            />
-          </Link>
+          <img
+            src={company.logo}
+            alt={company.name}
+            className={company.imgClassName ? company.imgClassName : 'max-w-28'}
+          />
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Description

The customer logos in the homepage "Trusted in production by engineering teams at" section were each wrapped in a `<Link>` pointing at the company's website. This PR removes that wrapper so the logos render as plain `<img>` elements and are no longer clickable outbound links. The now-unused `@docusaurus/Link` import is dropped as well, since `unused-imports/no-unused-imports` is an error in `website/.eslintrc`. To test, run `make watch-doc` and confirm the logo strip renders identically but the logos are no longer anchors. No breaking changes.

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)