### PR TITLE
chore: bump go directive to latest patch in side modules

### DIFF
--- a/.github/ci-scripts/bump-wasm-contrib/go.mod
+++ b/.github/ci-scripts/bump-wasm-contrib/go.mod
@@ -1,3 +1,3 @@
 module github.com/thomaspoignant/go-feature-flag/.github/ci-scripts/bump-wasm-contrib
 
-go 1.25.0
+go 1.25.12

--- a/examples/lint_flag_programmatically/go.mod
+++ b/examples/lint_flag_programmatically/go.mod
@@ -1,6 +1,6 @@
 module github.com/thomaspoignant/go-feature-flag/examples/lint_flag_programmatically
 
-go 1.24.8
+go 1.24.13
 
 require (
 	github.com/thomaspoignant/go-feature-flag/modules/core v0.1.4

--- a/openfeature/provider_tests/go-integration-tests/go.mod
+++ b/openfeature/provider_tests/go-integration-tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/thomaspoignant/go-feature-flag/openfeature/provider_tests/go-integration-tests
 
-go 1.25.9
+go 1.25.12
 
 require (
 	github.com/open-feature/go-sdk v1.17.2

--- a/website/.ci/go.mod
+++ b/website/.ci/go.mod
@@ -1,3 +1,3 @@
 module github.com/thomaspoignant/go-feature-flag/website/.ci
 
-go 1.25.0
+go 1.25.12


### PR DESCRIPTION
## Description

Four `go.mod` files were sitting on stale patch releases, and since every workflow resolves its Go version through `setup-go`'s `go-version-file`, CI was building them on an older toolchain than intended. This PR bumps each one to the latest patch of the minor line it already targets — `website/.ci` and `.github/ci-scripts/bump-wasm-contrib` `1.25.0 -> 1.25.12`, `openfeature/provider_tests/go-integration-tests` `1.25.9 -> 1.25.12`, and `examples/lint_flag_programmatically` `1.24.8 -> 1.24.13`. The root module, `modules/core` and `cmd/wasm` are deliberately untouched: they are already on their line's latest patch, and raising `modules/core` to a newer minor would force every downstream consumer to upgrade, which belongs in the modules release train rather than here. No `require` lines changed and no `toolchain` directives were added, so there are no breaking changes. To test: `GOWORK=off go build ./...` in the two script modules, `go vet ./...` in the integration-tests module, and `go vet sdkVersions.go versions.go` in `website/.ci` (that directory has two `main` packages by design — CI runs `go run ./website/.ci/sdkVersions.go` — so a package-wide build there fails both before and after this change).

## Closes issue(s)

N/A — routine maintenance, no issue filed.

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code — not applicable, no behaviour change
- [ ] I have updated the documentation (`README.md` and `/website/docs`) — not applicable
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
