### PR TITLE
fix(python-provider): survive WASM traps and harden the WASM evaluation module

### DIFF
--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/evaluator/inprocess_evaluator.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/evaluator/inprocess_evaluator.py
@@ -21,7 +21,16 @@ from openfeature.flag_evaluation import FlagResolutionDetails, Reason
 from gofeatureflag_python_provider.evaluator.abstract_evaluator import AbstractEvaluator
 from gofeatureflag_python_provider.options import GoFeatureFlagOptions
 from gofeatureflag_python_provider.services.api import GoFeatureFlagApi
-from gofeatureflag_python_provider.wasm import EvaluateWasm, WasmFlagContext, WasmInput
+from gofeatureflag_python_provider.wasm import (
+    EvaluateWasm,
+    WasmEvaluationTrapError,
+    WasmFlagContext,
+    WasmInput,
+    WasmInputTooDeepError,
+    WasmInvalidResultError,
+    WasmNotLoadedError,
+    WasmPoolTimeoutError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +187,21 @@ class InProcessEvaluator(AbstractEvaluator):
             ),
         )
 
-        response = self._wasm.evaluate(wasm_input)
+        try:
+            response = self._wasm.evaluate(wasm_input)
+        except (
+            WasmEvaluationTrapError,
+            WasmInputTooDeepError,
+            WasmInvalidResultError,
+            WasmNotLoadedError,
+            WasmPoolTimeoutError,
+        ) as exc:
+            # Degrade per the OpenFeature spec: the SDK catches GeneralError
+            # and returns the default value with reason ERROR instead of
+            # surfacing a raw WASM runtime failure to the application.
+            raise GeneralError(
+                f"WASM evaluation failed for flag '{flag_key}': {exc}"
+            ) from exc
 
         if response.errorCode:
             self._raise_for_error_code(

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/wasm/__init__.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/wasm/__init__.py
@@ -1,6 +1,13 @@
 """WASM evaluator package for the GO Feature Flag Python provider."""
 
-from gofeatureflag_python_provider.wasm.evaluate_wasm import EvaluateWasm
+from gofeatureflag_python_provider.wasm.evaluate_wasm import (
+    EvaluateWasm,
+    WasmEvaluationTrapError,
+    WasmInputTooDeepError,
+    WasmInvalidResultError,
+    WasmNotLoadedError,
+    WasmPoolTimeoutError,
+)
 from gofeatureflag_python_provider.wasm.models import (
     WasmEvaluationResponse,
     WasmFlagContext,
@@ -12,4 +19,9 @@ __all__ = [
     "WasmInput",
     "WasmFlagContext",
     "WasmEvaluationResponse",
+    "WasmEvaluationTrapError",
+    "WasmInputTooDeepError",
+    "WasmInvalidResultError",
+    "WasmNotLoadedError",
+    "WasmPoolTimeoutError",
 ]

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/wasm/evaluate_wasm.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/wasm/evaluate_wasm.py
@@ -7,18 +7,29 @@ Memory protocol:
   2. malloc(len + 1) → input_ptr
   3. Write bytes + null terminator to WASM linear memory
   4. evaluate(input_ptr, len) → result (i64)
-  5. free(input_ptr)
-  6. output_ptr = result >> 32  (high 32 bits)
+  5. output_ptr = result >> 32  (high 32 bits)
      output_len = result & 0xFFFFFFFF  (low 32 bits)
-  7. Read output_len bytes from output_ptr, JSON-parse → WasmEvaluationResponse
+  6. Read output_len bytes from output_ptr, JSON-parse → WasmEvaluationResponse
+  7. free(input_ptr)
+
+The output buffer is owned by the module's garbage collector and is only
+guaranteed to stay valid until the next call into the instance, so it must be
+read before `free` (or anything else) runs on that store.
+
+Trap contract: a WASM trap does not unwind the module's shadow stack — the
+instance's `__stack_pointer` global keeps its mid-call value forever. A store
+that trapped once is therefore permanently poisoned (every later call faults
+inside `malloc` at a wrapped ~0xffffXXXX address) and must be discarded and
+replaced, never reused, and `free` must never be called on it.
 """
 
 import logging
 from pathlib import Path
-from queue import Queue
+from queue import Empty, Queue
 from typing import Any, Optional
 
 import wasmtime
+from pydantic import ValidationError
 
 from gofeatureflag_python_provider.wasm.models import WasmEvaluationResponse, WasmInput
 
@@ -53,6 +64,60 @@ class WasmFunctionNotFoundError(RuntimeError):
 
 class WasmInvalidResultError(RuntimeError):
     """Raised when the WASM module returns an unexpected result."""
+
+
+class WasmEvaluationTrapError(RuntimeError):
+    """
+    Raised when the WASM module traps during evaluation (stack overflow,
+    unrecoverable panic, out-of-memory...). The store that trapped has been
+    discarded and replaced with a fresh one; the evaluation itself failed.
+    """
+
+
+class WasmInputTooDeepError(RuntimeError):
+    """
+    Raised before calling the WASM module when the input payload is nested too
+    deeply. The module decodes JSON recursively on a small fixed-size stack, so
+    deeply nested evaluation contexts would overflow it and trap.
+    """
+
+
+class WasmPoolTimeoutError(RuntimeError):
+    """
+    Raised when no evaluation slot became available within the timeout and a
+    replacement slot could not be created. The pool can only stay empty that
+    long if slots were lost to irrecoverable store-creation failures or the
+    pool is badly undersized for the workload.
+    """
+
+
+# How long evaluate() waits for a free slot before assuming the pool has been
+# drained (e.g. every replacement after a trap failed) and trying to self-heal.
+_POOL_GET_TIMEOUT_SECONDS = 30.0
+
+
+# Maximum {}/[] nesting depth accepted for the JSON payload sent to the WASM
+# module. The module decodes JSON recursively on a fixed-size shadow stack
+# (64KB in binaries <= 0.2.3, where ~250 levels overflow it), so deep payloads
+# are rejected host-side before they can trap the module.
+_MAX_INPUT_NESTING_DEPTH = 128
+
+
+def _exceeds_depth(value: Any, limit: int) -> bool:
+    """Return True if `value` nests dicts/lists/tuples deeper than `limit` levels."""
+    stack = [(value, 1)]
+    while stack:
+        node, depth = stack.pop()
+        if isinstance(node, dict):
+            children: Any = node.values()
+        elif isinstance(node, (list, tuple)):
+            children = node
+        else:
+            continue
+        if depth > limit:
+            return True
+        stack.extend((child, depth + 1) for child in children)
+    return False
 
 
 def _create_slot(
@@ -168,16 +233,75 @@ class EvaluateWasm:
         """
         Evaluate a feature flag via the WASI module. Uses a slot from the pool
         (or the single store when pool_size=1) so evaluations are thread-safe.
+
+        If the module traps, the slot is discarded and replaced with a fresh
+        one (a trapped store is permanently poisoned, see module docstring) and
+        WasmEvaluationTrapError is raised.
         """
         if self._pool is None:
             raise WasmNotLoadedError(
                 "EvaluateWasm has not been initialized. Call initialize() first."
             )
-        slot = self._pool.get()
+        if _exceeds_depth(
+            [
+                wasm_input.flag,
+                wasm_input.evalContext,
+                wasm_input.flagContext.defaultSdkValue,
+                wasm_input.flagContext.evaluationContextEnrichment,
+            ],
+            _MAX_INPUT_NESTING_DEPTH,
+        ):
+            raise WasmInputTooDeepError(
+                "evaluation input exceeds the maximum supported nesting depth "
+                f"({_MAX_INPUT_NESTING_DEPTH})"
+            )
+        # Capture the queue: dispose() may null out self._pool while we hold a
+        # slot, and the finally below must return it to the queue it came from.
+        pool = self._pool
+        try:
+            slot = pool.get(timeout=_POOL_GET_TIMEOUT_SECONDS)
+        except Empty:
+            # The pool drained (replacement slots failed to build after traps)
+            # or is badly undersized. Try to heal it instead of blocking the
+            # caller forever; on failure degrade to a typed error so the
+            # evaluation falls back to the default value.
+            try:
+                slot = _create_slot(self._engine, self._module)
+                logger.warning(
+                    "no WASM slot became available within %.0fs; "
+                    "created a replacement slot",
+                    _POOL_GET_TIMEOUT_SECONDS,
+                )
+            except Exception as exc:
+                raise WasmPoolTimeoutError(
+                    "no WASM evaluation slot available after "
+                    f"{_POOL_GET_TIMEOUT_SECONDS:.0f}s and creating a "
+                    f"replacement slot failed: {exc}"
+                ) from exc
         try:
             return self._evaluate_with_slot(slot, wasm_input)
+        except wasmtime.Trap as exc:
+            slot = None  # poisoned: never reuse a store that trapped
+            raise WasmEvaluationTrapError(
+                f"WASM evaluation trapped; the store has been discarded: {exc}"
+            ) from exc
         finally:
-            self._pool.put(slot)
+            if slot is None:
+                try:
+                    slot = _create_slot(self._engine, self._module)
+                    logger.warning(
+                        "WASM store trapped during evaluation; "
+                        "replaced it with a fresh one"
+                    )
+                except Exception:
+                    # The pool shrinks by one slot; evaluations keep working
+                    # on the remaining slots.
+                    logger.exception(
+                        "failed to replace a trapped WASM store; "
+                        "the evaluation pool lost one slot"
+                    )
+            if slot is not None:
+                pool.put(slot)
 
     def _evaluate_with_slot(
         self,
@@ -188,24 +312,39 @@ class EvaluateWasm:
         store, memory, malloc_fn, free_fn, evaluate_fn = slot
         input_bytes = wasm_input.model_dump_json().encode("utf-8")
         ptr = malloc_fn(store, len(input_bytes) + 1)
-        if not isinstance(ptr, int):
-            raise WasmInvalidResultError(
-                f"malloc returned unexpected type {type(ptr).__name__!r}"
-            )
-        memory.write(store, input_bytes + b"\x00", ptr)
+        if not isinstance(ptr, int) or ptr == 0:
+            raise WasmInvalidResultError(f"malloc returned an invalid pointer: {ptr!r}")
+        trapped = False
         try:
-            result = evaluate_fn(store, ptr, len(input_bytes))
+            memory.write(store, input_bytes + b"\x00", ptr)
+            try:
+                result = evaluate_fn(store, ptr, len(input_bytes))
+            except wasmtime.Trap:
+                trapped = True
+                raise
+            if not isinstance(result, int):
+                raise WasmInvalidResultError(
+                    f"evaluate returned unexpected type {type(result).__name__!r}"
+                )
+            output_ptr = (result >> 32) & 0xFFFFFFFF
+            output_len = result & 0xFFFFFFFF
+            if output_ptr == 0 or output_len == 0:
+                raise WasmInvalidResultError(
+                    "evaluate returned a null or zero-length output pointer"
+                )
+            # Read the output before any further call into the module: the
+            # buffer belongs to the module's GC and is only guaranteed to
+            # survive until the next call into this instance.
+            output_bytes = memory.read(store, output_ptr, output_ptr + output_len)
+            try:
+                return WasmEvaluationResponse.model_validate_json(output_bytes)
+            except ValidationError as exc:
+                raise WasmInvalidResultError(
+                    f"module returned malformed output: {exc}"
+                ) from exc
         finally:
-            free_fn(store, ptr)
-        if not isinstance(result, int):
-            raise WasmInvalidResultError(
-                f"evaluate returned unexpected type {type(result).__name__!r}"
-            )
-        output_ptr = (result >> 32) & 0xFFFFFFFF
-        output_len = result & 0xFFFFFFFF
-        if output_ptr == 0 or output_len == 0:
-            raise WasmInvalidResultError(
-                "evaluate returned a null or zero-length output pointer"
-            )
-        output_bytes = memory.read(store, output_ptr, output_ptr + output_len)
-        return WasmEvaluationResponse.model_validate_json(output_bytes)
+            # Never call free on a trapped store: the trap left the shadow
+            # stack pointer unrestored, so the call would fault and mask the
+            # original error. The caller discards the store anyway.
+            if not trapped:
+                free_fn(store, ptr)

--- a/openfeature/providers/python-provider/tests/test_evaluate_wasm.py
+++ b/openfeature/providers/python-provider/tests/test_evaluate_wasm.py
@@ -8,22 +8,24 @@ from __future__ import annotations
 import threading
 
 import pytest
+import wasmtime
 
+import gofeatureflag_python_provider.wasm.evaluate_wasm as evaluate_wasm_module
 from gofeatureflag_python_provider.wasm import EvaluateWasm, WasmFlagContext, WasmInput
 from gofeatureflag_python_provider.wasm.evaluate_wasm import (
+    WasmEvaluationTrapError,
+    WasmInputTooDeepError,
     WasmInvalidResultError,
     WasmNotLoadedError,
+    WasmPoolTimeoutError,
+    _exceeds_depth,
 )
+from tests.wasm_helpers import BOOL_FLAG as _BOOL_FLAG
+from tests.wasm_helpers import nested_ctx as _nested_ctx
 
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
-
-_BOOL_FLAG = {
-    "variations": {"on": True, "off": False},
-    "defaultRule": {"variation": "on"},
-    "trackEvents": True,
-}
 
 _STR_FLAG = {
     "variations": {"v1": "hello", "v2": "world"},
@@ -322,6 +324,207 @@ def test_evaluate_concurrent_threads():
             assert all(results), f"Thread {tid}: expected all True, got {results}"
     finally:
         e.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Trap handling and buffer protocol (issue #5651)
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_slot(
+    output: bytes = b'{"value": true, "variationType": "on"}',
+    malloc_ret: int = 8,
+    trap_on_evaluate: bool = False,
+    evaluate_ret: object = None,
+):
+    """Duck-typed (store, memory, malloc, free, evaluate) slot recording calls."""
+    calls = {"free": 0, "writes": 0}
+    store = object()
+    out_ptr = 100
+
+    class FakeMemory:
+        def write(self, _store, data, ptr):
+            calls["writes"] += 1
+
+        def read(self, _store, start, end):
+            assert start == out_ptr
+            return output
+
+    def malloc_fn(_store, _size):
+        return malloc_ret
+
+    def free_fn(_store, _ptr):
+        calls["free"] += 1
+
+    def evaluate_fn(_store, _ptr, _length):
+        if trap_on_evaluate:
+            raise wasmtime.Trap("synthetic trap")
+        if evaluate_ret is not None:
+            return evaluate_ret
+        return (out_ptr << 32) | len(output)
+
+    return (store, FakeMemory(), malloc_fn, free_fn, evaluate_fn), calls
+
+
+def test_evaluate_with_slot_frees_input_after_reading_output():
+    """On success, the input buffer is freed exactly once (after the output read)."""
+    slot, calls = _make_fake_slot()
+    resp = EvaluateWasm()._evaluate_with_slot(slot, _make_input("f", _BOOL_FLAG))
+    assert resp.value is True
+    assert calls["writes"] == 1
+    assert calls["free"] == 1
+
+
+def test_evaluate_with_slot_skips_free_after_trap():
+    """free must never run on a trapped store (it would fault and mask the trap)."""
+    slot, calls = _make_fake_slot(trap_on_evaluate=True)
+    with pytest.raises(wasmtime.Trap):
+        EvaluateWasm()._evaluate_with_slot(slot, _make_input("f", _BOOL_FLAG))
+    assert calls["free"] == 0
+
+
+def test_evaluate_with_slot_rejects_null_malloc():
+    """A NULL malloc result raises instead of writing to address 0."""
+    slot, calls = _make_fake_slot(malloc_ret=0)
+    with pytest.raises(WasmInvalidResultError, match="invalid pointer"):
+        EvaluateWasm()._evaluate_with_slot(slot, _make_input("f", _BOOL_FLAG))
+    assert calls["writes"] == 0
+    assert calls["free"] == 0
+
+
+def test_evaluate_with_slot_rejects_non_int_result():
+    """A non-integer evaluate return raises instead of being unpacked."""
+    slot, calls = _make_fake_slot(evaluate_ret="nope")
+    with pytest.raises(WasmInvalidResultError, match="unexpected type"):
+        EvaluateWasm()._evaluate_with_slot(slot, _make_input("f", _BOOL_FLAG))
+    assert calls["free"] == 1  # not a trap: the input buffer is still freed
+
+
+def test_evaluate_with_slot_rejects_zero_output_pointer():
+    """A 0 result (no output produced) raises instead of reading address 0."""
+    slot, calls = _make_fake_slot(evaluate_ret=1)  # ptr=0, len=1
+    with pytest.raises(WasmInvalidResultError, match="null or zero-length"):
+        EvaluateWasm()._evaluate_with_slot(slot, _make_input("f", _BOOL_FLAG))
+    assert calls["free"] == 1
+
+
+def test_evaluate_with_slot_wraps_malformed_output():
+    """Malformed module output raises the typed error, not a raw pydantic one."""
+    slot, calls = _make_fake_slot(output=b"definitely not json")
+    with pytest.raises(WasmInvalidResultError, match="malformed output"):
+        EvaluateWasm()._evaluate_with_slot(slot, _make_input("f", _BOOL_FLAG))
+    assert calls["free"] == 1
+
+
+def test_trap_recycles_slot_and_next_evaluation_succeeds():
+    """A trapped store is discarded and replaced; the pool keeps working."""
+    e = EvaluateWasm(pool_size=1)
+    e.initialize()
+    try:
+        original_store = e._pool.queue[0][0]
+        real_evaluate_with_slot = e._evaluate_with_slot
+        raised = []
+
+        def trap_once(slot, wasm_input):
+            if not raised:
+                raised.append(True)
+                raise wasmtime.Trap("synthetic trap")
+            return real_evaluate_with_slot(slot, wasm_input)
+
+        e._evaluate_with_slot = trap_once
+        with pytest.raises(WasmEvaluationTrapError):
+            e.evaluate(_make_input("f", _BOOL_FLAG, default=False))
+        assert e._pool.qsize() == 1
+        assert e._pool.queue[0][0] is not original_store
+
+        resp = e.evaluate(_make_input("f", _BOOL_FLAG, default=False))
+        assert resp.value is True
+    finally:
+        e.dispose()
+
+
+def test_pool_size_preserved_after_trap_storm():
+    """Repeated traps never shrink the pool nor break later evaluations."""
+    pool_size = 3
+    e = EvaluateWasm(pool_size=pool_size)
+    e.initialize()
+    try:
+        real_evaluate_with_slot = e._evaluate_with_slot
+
+        def always_trap(slot, wasm_input):
+            raise wasmtime.Trap("synthetic trap")
+
+        e._evaluate_with_slot = always_trap
+        for _ in range(10):
+            with pytest.raises(WasmEvaluationTrapError):
+                e.evaluate(_make_input("f", _BOOL_FLAG, default=False))
+
+        e._evaluate_with_slot = real_evaluate_with_slot
+        assert e._pool.qsize() == pool_size
+        for _ in range(10):
+            assert e.evaluate(_make_input("f", _BOOL_FLAG, default=False)).value is True
+    finally:
+        e.dispose()
+
+
+def test_empty_pool_self_heals_on_timeout(monkeypatch):
+    """A drained pool creates a replacement slot instead of blocking forever."""
+    monkeypatch.setattr(evaluate_wasm_module, "_POOL_GET_TIMEOUT_SECONDS", 0.05)
+    e = EvaluateWasm(pool_size=1)
+    e.initialize()
+    try:
+        _hostage = e._pool.get()  # simulate a slot lost to a rebuild failure
+        resp = e.evaluate(_make_input("f", _BOOL_FLAG, default=False))
+        assert resp.value is True
+        assert e._pool.qsize() == 1  # the healed slot went back to the pool
+    finally:
+        e.dispose()
+
+
+def test_empty_pool_raises_typed_error_when_heal_fails(monkeypatch):
+    """If healing fails too, a typed error surfaces instead of a hang."""
+    monkeypatch.setattr(evaluate_wasm_module, "_POOL_GET_TIMEOUT_SECONDS", 0.05)
+    e = EvaluateWasm(pool_size=1)
+    e.initialize()
+    try:
+        _hostage = e._pool.get()
+
+        def failing_create_slot(*_args):
+            raise RuntimeError("instantiation failed")
+
+        monkeypatch.setattr(evaluate_wasm_module, "_create_slot", failing_create_slot)
+        with pytest.raises(WasmPoolTimeoutError, match="no WASM evaluation slot"):
+            e.evaluate(_make_input("f", _BOOL_FLAG, default=False))
+    finally:
+        e.dispose()
+
+
+def test_input_too_deep_raises_before_reaching_wasm():
+    """Nesting beyond the depth limit is rejected host-side; the pool is untouched."""
+    e = EvaluateWasm(pool_size=1)
+    e.initialize()
+    try:
+        with pytest.raises(WasmInputTooDeepError, match="nesting depth"):
+            e.evaluate(_make_input("deep", _BOOL_FLAG, ctx=_nested_ctx(200)))
+        assert e._pool.qsize() == 1
+        assert e.evaluate(_make_input("f", _BOOL_FLAG, default=False)).value is True
+    finally:
+        e.dispose()
+
+
+def test_exceeds_depth_boundary():
+    """_exceeds_depth flags containers nested strictly deeper than the limit."""
+
+    def nest(n: int):
+        value = 1
+        for _ in range(n):
+            value = {"a": value}
+        return value
+
+    assert not _exceeds_depth(nest(5), 5)
+    assert _exceeds_depth(nest(6), 5)
+    assert not _exceeds_depth({"a": [1, 2, {"b": "c"}]}, 5)
+    assert not _exceeds_depth("scalar", 1)
 
 
 # ---------------------------------------------------------------------------

--- a/openfeature/providers/python-provider/tests/test_inprocess_evaluator.py
+++ b/openfeature/providers/python-provider/tests/test_inprocess_evaluator.py
@@ -566,3 +566,47 @@ def test_is_flag_trackable_returns_true_for_unknown_flag():
     evaluator, _ = _setup_evaluator_with_flag(_BOOL_FLAG_DICT)
     assert evaluator.is_flag_trackable("unknown-flag") is True
     evaluator.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# WASM runtime failures degrade to GeneralError (issue #5651)
+# ---------------------------------------------------------------------------
+
+
+def test_wasm_trap_degrades_to_general_error():
+    """
+    A WASM trap surfaces as GeneralError so the OpenFeature SDK returns the
+    default value with reason ERROR instead of a raw wasmtime exception.
+    """
+    from gofeatureflag_python_provider.wasm import WasmEvaluationTrapError
+
+    evaluator, mock_wasm = _setup_evaluator_with_flag(_BOOL_FLAG_DICT)
+    mock_wasm.evaluate.side_effect = WasmEvaluationTrapError("stack overflow trap")
+
+    with pytest.raises(GeneralError, match="WASM evaluation failed"):
+        evaluator.resolve_boolean_details(_FLAG_KEY, False, _DEFAULT_CTX)
+    evaluator.shutdown()
+
+
+def test_wasm_input_too_deep_degrades_to_general_error():
+    """A rejected too-deep payload surfaces as GeneralError, not a raw error."""
+    from gofeatureflag_python_provider.wasm import WasmInputTooDeepError
+
+    evaluator, mock_wasm = _setup_evaluator_with_flag(_BOOL_FLAG_DICT)
+    mock_wasm.evaluate.side_effect = WasmInputTooDeepError("too deep")
+
+    with pytest.raises(GeneralError, match="WASM evaluation failed"):
+        evaluator.resolve_boolean_details(_FLAG_KEY, False, _DEFAULT_CTX)
+    evaluator.shutdown()
+
+
+def test_wasm_pool_timeout_degrades_to_general_error():
+    """An exhausted, unhealable pool surfaces as GeneralError, not a hang/raw error."""
+    from gofeatureflag_python_provider.wasm import WasmPoolTimeoutError
+
+    evaluator, mock_wasm = _setup_evaluator_with_flag(_BOOL_FLAG_DICT)
+    mock_wasm.evaluate.side_effect = WasmPoolTimeoutError("no slot available")
+
+    with pytest.raises(GeneralError, match="WASM evaluation failed"):
+        evaluator.resolve_boolean_details(_FLAG_KEY, False, _DEFAULT_CTX)
+    evaluator.shutdown()

--- a/openfeature/providers/python-provider/tests/test_wasm_trap_diagnosis.py
+++ b/openfeature/providers/python-provider/tests/test_wasm_trap_diagnosis.py
@@ -1,0 +1,462 @@
+"""
+Diagnosis and regression tests for issue #5651: WASM stack-overflow traps and
+poisoned-store reuse.
+
+Binaries up to 0.2.3 have a 64KB shadow stack placed at the bottom of linear
+memory (wasm-ld --stack-first, TinyGo default stack size). Deeply nested JSON
+overflows it during decoding: the stack pointer wraps below address 0 and the
+call traps out-of-bounds at a ~0xffffXXXX address. Because a trap never unwinds
+the module's __stack_pointer global, a store that trapped once is permanently
+poisoned — every later call faults inside `malloc` — which is the production
+signature reported in the issue.
+
+These tests document that failure mode against the vulnerable bundled binary
+and pin the invariant that the host can never be poisoned, whatever binary is
+in use.
+
+Environment switches:
+  GOFF_TEST_WASI_PATH  path to a candidate .wasi binary to test instead of the
+                       bundled one (used to validate new wasm releases).
+  GOFF_SOAK=1          enable the long-running soak test.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+import pytest
+import wasmtime
+
+from gofeatureflag_python_provider.wasm import (
+    EvaluateWasm,
+    WasmEvaluationTrapError,
+    WasmFlagContext,
+    WasmInput,
+    WasmInputTooDeepError,
+)
+from gofeatureflag_python_provider.wasm.evaluate_wasm import (
+    _create_slot,
+    _default_wasi_path,
+)
+from tests.wasm_helpers import BOOL_FLAG as _BOOL_FLAG
+from tests.wasm_helpers import int_in_list_query as _int_in_list_query
+from tests.wasm_helpers import nested_ctx as _nested_ctx
+from tests.wasm_helpers import or_chain_query as _or_chain_query
+from tests.wasm_helpers import query_flag as _query_flag
+from tests.wasm_helpers import split_int_in_list_query as _split_int_in_list_query
+
+_WASI_OVERRIDE = os.environ.get("GOFF_TEST_WASI_PATH")
+
+_FAULT_RE = re.compile(r"memory fault at wasm address (0x[0-9a-f]+)")
+
+
+def _wasi_path() -> Path:
+    return Path(_WASI_OVERRIDE) if _WASI_OVERRIDE else _default_wasi_path()
+
+
+def _is_known_vulnerable_binary() -> bool:
+    """True when testing a bundled binary <= 0.2.3 (64KB stack, no guards)."""
+    if _WASI_OVERRIDE:
+        return False
+    match = re.search(r"_(\d+)\.(\d+)\.(\d+)\.wasi$", _wasi_path().name)
+    if match is None:
+        return False
+    return tuple(int(part) for part in match.groups()) <= (0, 2, 3)
+
+
+requires_vulnerable_binary = pytest.mark.skipif(
+    not _is_known_vulnerable_binary(),
+    reason="documents the failure mode of bundled binaries <= 0.2.3",
+)
+
+
+def _payload(ctx: dict) -> bytes:
+    return json.dumps(
+        {
+            "flagKey": "diag-flag",
+            "flag": _BOOL_FLAG,
+            "evalContext": ctx,
+            "flagContext": {"defaultSdkValue": False},
+        }
+    ).encode("utf-8")
+
+
+def _wasm_input(ctx: dict) -> WasmInput:
+    return WasmInput(
+        flagKey="diag-flag",
+        flag=_BOOL_FLAG,
+        evalContext=ctx,
+        flagContext=WasmFlagContext(defaultSdkValue=False),
+    )
+
+
+@pytest.fixture(scope="module")
+def wasm_module() -> tuple[wasmtime.Engine, wasmtime.Module]:
+    engine = wasmtime.Engine()
+    return engine, wasmtime.Module.from_file(engine, str(_wasi_path()))
+
+
+def _new_slot(wasm_module: tuple) -> tuple:
+    engine, module = wasm_module
+    return _create_slot(engine, module)
+
+
+def _raw_evaluate(slot: tuple, payload: bytes) -> bytes:
+    """Bare host protocol with no trap protection (deliberately unhardened)."""
+    store, memory, malloc_fn, free_fn, evaluate_fn = slot
+    ptr = malloc_fn(store, len(payload) + 1)
+    memory.write(store, payload + b"\x00", ptr)
+    result = evaluate_fn(store, ptr, len(payload))
+    output_ptr = (result >> 32) & 0xFFFFFFFF
+    output_len = result & 0xFFFFFFFF
+    output = bytes(memory.read(store, output_ptr, output_ptr + output_len))
+    free_fn(store, ptr)
+    return output
+
+
+def _fault_address(exc: BaseException) -> int | None:
+    match = _FAULT_RE.search(str(exc))
+    return int(match.group(1), 16) if match else None
+
+
+def _query_payload(query: str, ctx: dict) -> bytes:
+    return json.dumps(
+        {
+            "flagKey": "diag-flag",
+            "flag": _query_flag(query),
+            "evalContext": ctx,
+            "flagContext": {"defaultSdkValue": False},
+        }
+    ).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Failure-mode documentation (vulnerable binaries only)
+# ---------------------------------------------------------------------------
+
+
+@requires_vulnerable_binary
+def test_deep_nested_context_overflows_the_shadow_stack(wasm_module):
+    """A ~3KB payload with a 400-deep context traps the module (stack overflow)."""
+    slot = _new_slot(wasm_module)
+    payload = _payload(_nested_ctx(400))
+    assert len(payload) < 5_000
+    with pytest.raises(wasmtime.Trap):
+        _raw_evaluate(slot, payload)
+
+
+@requires_vulnerable_binary
+def test_moderate_nesting_evaluates_fine(wasm_module):
+    """Depth 200 fits in the 64KB stack: the trap threshold sits above it."""
+    slot = _new_slot(wasm_module)
+    output = _raw_evaluate(slot, _payload(_nested_ctx(200)))
+    assert b"variationType" in output
+
+
+@requires_vulnerable_binary
+def test_trapped_store_is_poisoned_and_faults_ratchet_downward(wasm_module):
+    """
+    After one trap, every valid evaluation on the same store faults inside
+    malloc at a wrapped ~0xffffXXXX address that decreases call after call —
+    the exact signature reported in issue #5651.
+    """
+    slot = _new_slot(wasm_module)
+    baseline = _raw_evaluate(slot, _payload({"targetingKey": "user-1"}))
+    assert b"variationType" in baseline
+
+    with pytest.raises(wasmtime.Trap):
+        _raw_evaluate(slot, _payload(_nested_ctx(400)))
+
+    addresses = []
+    for _ in range(5):
+        with pytest.raises(wasmtime.Trap) as excinfo:
+            _raw_evaluate(slot, _payload({"targetingKey": "user-1"}))
+        assert "malloc" in str(excinfo.value)
+        address = _fault_address(excinfo.value)
+        assert address is not None and address >= 0xFFFF0000
+        addresses.append(address)
+    assert addresses == sorted(addresses, reverse=True)
+    assert len(set(addresses)) == len(addresses)
+
+
+# ---------------------------------------------------------------------------
+# Host invariant: no payload may poison the evaluator (any binary version)
+# ---------------------------------------------------------------------------
+
+
+def test_hostile_payload_never_poisons_the_evaluator():
+    """
+    The invariant under hostile inputs is recovery, not any particular
+    outcome of the hostile call itself: depending on the binary it may trap
+    (converted to a typed error, store recycled), be rejected by a guard
+    (host-side typed error or a structured error result), or even evaluate
+    cleanly (a future binary with a bigger stack). Whatever happens, later
+    evaluations must succeed and the pool must keep its size.
+
+    The inputs cover every known recursion driver: deeply nested query
+    parentheses (~30 levels trap 0.2.3), huge flat `in` lists (breadth, the
+    issue #5651 production shape), flat `and`/`or` chains (condition count),
+    and a deeply nested evaluation context (input JSON depth).
+    """
+    deep_parens = "(" * 300 + 'targetingKey eq "u"' + ")" * 300
+    huge_in_list = "targetingKey in [" + ",".join(f'"u{i}"' for i in range(2500)) + "]"
+    huge_int_list = _int_in_list_query(20_000)
+    huge_or_chain = _or_chain_query(2_000)
+    hostile_inputs = [
+        *(
+            WasmInput(
+                flagKey="hostile-flag",
+                flag=_query_flag(query),
+                evalContext={"targetingKey": "user-1"},
+                flagContext=WasmFlagContext(defaultSdkValue=False),
+            )
+            for query in (deep_parens, huge_in_list, huge_int_list, huge_or_chain)
+        ),
+        WasmInput(
+            flagKey="hostile-flag",
+            flag=_BOOL_FLAG,
+            evalContext=_nested_ctx(400),
+            flagContext=WasmFlagContext(defaultSdkValue=False),
+        ),
+    ]
+    pool_size = 2
+    e = EvaluateWasm(wasm_path=_WASI_OVERRIDE, pool_size=pool_size)
+    e.initialize()
+    try:
+        for hostile in hostile_inputs:
+            for _ in range(2 * pool_size):  # hit every pool slot at least twice
+                try:
+                    e.evaluate(hostile)
+                except (WasmEvaluationTrapError, WasmInputTooDeepError):
+                    pass  # typed error; a trapped store has been recycled
+
+        for _ in range(20):
+            response = e.evaluate(_wasm_input({"targetingKey": "user-1"}))
+            assert response.value is True
+        assert e._pool.qsize() == pool_size
+    finally:
+        e.dispose()
+
+
+def test_invalid_json_input_returns_structured_error(wasm_module):
+    """
+    Literally invalid JSON must come back as a structured PARSE_ERROR from the
+    built binary, not a trap. encoding/json (and the module's own recovery
+    path) rely on Go's panic/recover machinery internally, so this doubles as
+    proof that TinyGo's recover works in the shipped binary — if it did not,
+    this input would trap and poison the store.
+    """
+    slot = _new_slot(wasm_module)
+    output = _raw_evaluate(slot, b'{"flagKey": not-valid-json')
+    result = json.loads(output)
+    assert result["errorCode"] == "PARSE_ERROR"
+
+    # The store must still be healthy afterwards.
+    ok = _raw_evaluate(slot, _payload({"targetingKey": "user-1"}))
+    assert b"variationType" in ok
+
+
+def test_moderate_paren_query_needs_more_than_64kb_stack():
+    """
+    A 45-paren nikunjy query passes the nesting guard (limit 64) and must
+    evaluate cleanly on hardened binaries — it needs more than a 64KB stack,
+    so this test fails functionally if the stack-size linker flag is ever
+    lost (see .github/ci-scripts/verify-wasm-stack.py for the build-time
+    check). On the vulnerable bundled 0.2.3 it traps instead, which the
+    evaluator must survive via the recycle path.
+    """
+    query = "(" * 45 + 'targetingKey eq "user-1"' + ")" * 45
+    e = EvaluateWasm(wasm_path=_WASI_OVERRIDE, pool_size=1)
+    e.initialize()
+    try:
+        wasm_input = WasmInput(
+            flagKey="paren-flag",
+            flag=_query_flag(query),
+            evalContext={"targetingKey": "user-1"},
+            flagContext=WasmFlagContext(defaultSdkValue=False),
+        )
+        if _is_known_vulnerable_binary():
+            with pytest.raises(WasmEvaluationTrapError):
+                e.evaluate(wasm_input)
+        else:
+            response = e.evaluate(wasm_input)
+            assert response.errorCode in (None, "")
+            assert response.value is True
+        # Either way the evaluator keeps working.
+        follow_up = e.evaluate(_wasm_input({"targetingKey": "user-1"}))
+        assert follow_up.value is True
+    finally:
+        e.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Issue #5651 reporter shape: flat `in` lists (breadth, not nesting)
+# ---------------------------------------------------------------------------
+
+
+@requires_vulnerable_binary
+def test_reporter_int_list_traps_on_vulnerable_binary(wasm_module):
+    """
+    The reporters' production trigger: a flat `in` list of ~200 integers.
+    Bracket depth is 1, so no nesting guard can see it — the right-recursive
+    list parser (one SubListOfInts frame per item) overflows the 64KB stack
+    at 154 items.
+    """
+    slot = _new_slot(wasm_module)
+    with pytest.raises(wasmtime.Trap):
+        _raw_evaluate(
+            slot,
+            _query_payload(
+                _int_in_list_query(200), {"targetingKey": "user-1", "age": 150}
+            ),
+        )
+
+
+def test_reporter_int_list_evaluates_cleanly_on_hardened_binary():
+    """
+    Acceptance test for the production case of issue #5651: the exact flag
+    shape that trapped (flat 200-integer `in` list) must evaluate cleanly on
+    hardened binaries (1MB stack: first trap moves to 2,947 items, and the
+    breadth guard rejects lists above 1,000 with a structured error first).
+    """
+    e = EvaluateWasm(wasm_path=_WASI_OVERRIDE, pool_size=1)
+    e.initialize()
+    try:
+        wasm_input = WasmInput(
+            flagKey="reporter-flag",
+            flag=_query_flag(_int_in_list_query(200)),
+            evalContext={"targetingKey": "user-1", "age": 150},
+            flagContext=WasmFlagContext(defaultSdkValue=False),
+        )
+        if _is_known_vulnerable_binary():
+            with pytest.raises(WasmEvaluationTrapError):
+                e.evaluate(wasm_input)
+        else:
+            response = e.evaluate(wasm_input)
+            assert response.errorCode in (None, "")
+            assert response.value is True
+        # Either way the evaluator keeps working.
+        follow_up = e.evaluate(_wasm_input({"targetingKey": "user-1"}))
+        assert follow_up.value is True
+    finally:
+        e.dispose()
+
+
+@requires_vulnerable_binary
+def test_workaround_split_in_list_avoids_trap_on_vulnerable_binary(wasm_module):
+    """
+    The flag-config workaround recommended on the issue: splitting the same
+    200-integer allow-list into or-joined `in` chunks of 50 keeps the parser
+    recursion at 50 frames per list and evaluates fine even on the shipped
+    0.2.3 binary (64KB stack).
+    """
+    slot = _new_slot(wasm_module)
+    output = _raw_evaluate(
+        slot,
+        _query_payload(
+            _split_int_in_list_query(200, chunk=50),
+            {"targetingKey": "user-1", "age": 150},
+        ),
+    )
+    assert b"variationType" in output
+    result = json.loads(output)
+    assert result["value"] is True
+
+
+@pytest.mark.skipif(
+    _is_known_vulnerable_binary(),
+    reason="the breadth guard only exists in binaries > 0.2.3",
+)
+def test_over_breadth_list_returns_structured_error(wasm_module):
+    """
+    A list too large for any stack must be rejected by the breadth guard as a
+    structured PARSE_ERROR before the parser recurses — the store stays
+    healthy (5,000 items would trap even the 1MB stack at ~2,947).
+    """
+    slot = _new_slot(wasm_module)
+    output = _raw_evaluate(
+        slot,
+        _query_payload(_int_in_list_query(5_000), {"targetingKey": "user-1"}),
+    )
+    result = json.loads(output)
+    assert result["errorCode"] == "PARSE_ERROR"
+    assert "maximum item count" in result["errorDetails"]
+
+    # The guard fired before any recursion: the same store keeps working.
+    ok = _raw_evaluate(slot, _payload({"targetingKey": "user-1"}))
+    assert b"variationType" in ok
+
+
+@pytest.mark.skipif(
+    _is_known_vulnerable_binary(),
+    reason="the input nesting guard only exists in binaries > 0.2.3",
+)
+def test_over_deep_input_returns_structured_error(wasm_module):
+    """
+    Input JSON nested beyond the module's depth budget must be rejected by
+    the module itself as a structured PARSE_ERROR before the recursive JSON
+    decode — hosts need no pre-flight depth guard of their own.
+    """
+    slot = _new_slot(wasm_module)
+    output = _raw_evaluate(slot, _payload(_nested_ctx(400)))
+    result = json.loads(output)
+    assert result["errorCode"] == "PARSE_ERROR"
+    assert "maximum nesting depth" in result["errorDetails"]
+
+    # The guard fired before any recursion: the same store keeps working.
+    ok = _raw_evaluate(slot, _payload({"targetingKey": "user-1"}))
+    assert b"variationType" in ok
+
+
+@pytest.mark.skipif(
+    _is_known_vulnerable_binary(),
+    reason="the condition-count guard only exists in binaries > 0.2.3",
+)
+def test_over_condition_chain_returns_structured_error(wasm_module):
+    """
+    A flat and/or chain too long for any stack must be rejected by the
+    condition-count guard as a structured PARSE_ERROR before the parser
+    recurses (5,000 conditions would trap even the 1MB stack at ~3,266).
+    """
+    slot = _new_slot(wasm_module)
+    output = _raw_evaluate(
+        slot,
+        _query_payload(_or_chain_query(5_000), {"targetingKey": "user-1", "age": 1}),
+    )
+    result = json.loads(output)
+    assert result["errorCode"] == "PARSE_ERROR"
+    assert "maximum condition count" in result["errorDetails"]
+
+    # The guard fired before any recursion: the same store keeps working.
+    ok = _raw_evaluate(slot, _payload({"targetingKey": "user-1"}))
+    assert b"variationType" in ok
+
+
+# ---------------------------------------------------------------------------
+# Soak test (opt-in): linear memory must plateau, not grow unbounded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    os.environ.get("GOFF_SOAK") != "1",
+    reason="long-running soak test; set GOFF_SOAK=1 to enable",
+)
+def test_soak_linear_memory_plateaus(wasm_module):
+    """50k evaluations on one store: memory may grow early but must plateau."""
+    slot = _new_slot(wasm_module)
+    store, memory = slot[0], slot[1]
+    samples = []
+    for i in range(50_000):
+        output = _raw_evaluate(
+            slot,
+            _payload({"targetingKey": f"user-{i}", "email": f"user-{i}@example.com"}),
+        )
+        assert b"variationType" in output
+        if i % 5_000 == 0:
+            samples.append(memory.data_len(store))
+    samples.append(memory.data_len(store))
+    midpoint = samples[len(samples) // 2]
+    assert samples[-1] == midpoint, f"linear memory still growing: {samples}"

--- a/openfeature/providers/python-provider/tests/wasm_helpers.py
+++ b/openfeature/providers/python-provider/tests/wasm_helpers.py
@@ -1,0 +1,63 @@
+"""Shared fixtures and builders for the WASM evaluation test suites."""
+
+BOOL_FLAG = {
+    "variations": {"on": True, "off": False},
+    "defaultRule": {"variation": "on"},
+    "trackEvents": True,
+}
+
+
+def nested_ctx(depth: int) -> dict:
+    """Evaluation context whose attributes nest `depth` dict levels deep."""
+    ctx: dict = {"targetingKey": "user-1"}
+    cur = ctx
+    for _ in range(depth):
+        cur["a"] = {}
+        cur = cur["a"]
+    cur["x"] = 1
+    return ctx
+
+
+def deep_paren_query(depth: int) -> str:
+    """nikunjy query wrapped in `depth` nested parentheses."""
+    return "(" * depth + 'targetingKey eq "user-1"' + ")" * depth
+
+
+def int_in_list_query(count: int, attr: str = "age") -> str:
+    """
+    nikunjy `in` list of `count` integers. List parsing is right-recursive,
+    so each item costs one parser stack frame — the production trigger of
+    issue #5651 was a flat allow-list of ~200 integers.
+    """
+    return f"{attr} in [" + ",".join(str(i + 1) for i in range(count)) + "]"
+
+
+def or_chain_query(count: int, attr: str = "age") -> str:
+    """
+    Flat bracket-less or-chain of `count` conditions. Logical expressions are
+    binary and recursive in the nikunjy parser, so each operator costs stack
+    frames while showing none of the bracket nesting or list commas the other
+    recursion drivers do.
+    """
+    return " or ".join(f"{attr} eq {i + 1}" for i in range(count))
+
+
+def split_int_in_list_query(count: int, chunk: int, attr: str = "age") -> str:
+    """
+    The same allow-list split into or-joined `in` chunks of at most `chunk`
+    items, so the parser recursion never exceeds `chunk` frames per list.
+    """
+    parts = []
+    for start in range(0, count, chunk):
+        items = ",".join(str(i + 1) for i in range(start, min(start + chunk, count)))
+        parts.append(f"({attr} in [{items}])")
+    return " or ".join(parts)
+
+
+def query_flag(query: str) -> dict:
+    """Boolean flag whose single targeting rule uses `query`."""
+    return {
+        "variations": {"on": True, "off": False},
+        "targeting": [{"query": query, "variation": "on"}],
+        "defaultRule": {"variation": "off"},
+    }


### PR DESCRIPTION
## Description

This PR fixes the in-process WASM evaluation path so a single hostile or pathological flag evaluation can no longer poison the shared instance pool.

The root cause is that a `wasmtime` instance that traps is left in an unusable state; returning it to the pool made every subsequent evaluation on that slot fail.

This PR contains several changes:
- Treat a WASM trap as a poisoned instance: convert it to a typed error, discard and recycle the store/memory instead of returning it to the pool, and skip the `free()` cleanup call that would fault on a trapped instance.
- Harden pool draining and malformed module output handling, and add host-side query/input guards with typed errors.
- Add a trap-diagnosis test suite (trap recovery, pool poisoning, workaround shapes). Guard-specific assertions skip against the pinned published binary and only run against a locally built candidate via `GOFF_TEST_WASI_PATH`.

How to test: `uv run pytest` in `openfeature/providers/python-provider` — 171 passed, 4 skipped at this commit.


## Closes issue(s)
Resolve #5651

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`) — documentation for the whole stack lands in the last PR
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
