### PR TITLE
fix(python-provider): WASM pool rebuild accounting and evaluation review findings

### DIFF
--- a/openfeature/providers/python-provider/README.md
+++ b/openfeature/providers/python-provider/README.md
@@ -114,19 +114,19 @@ else:
 | `endpoint` | `str` | _(required)_ | URL of the GO Feature Flag relay proxy |
 | `evaluation_type` | `EvaluationType` | `INPROCESS` | Evaluation mode: `INPROCESS` or `REMOTE` |
 | `data_collector_base_url` | `str` | `endpoint` | Base URL of the data collector only. Replaces the whole base — scheme, host, port and path prefix. Flag configuration and evaluation keep using `endpoint` |
-| `timeout` | `int` | `10000` | Timeout (ms) applied to every relay proxy request: flag configuration, remote evaluation and data collection |
+| `timeout` | `int` | `10000` | Timeout (ms) for flag configuration, remote evaluation and data collection requests. Carried by the HTTP client the provider builds, so a custom `urllib3_pool_manager` replaces it with its own |
 | `data_flush_interval` | `int` | `60000` | Interval (ms) to flush usage data to the relay proxy |
 | `disable_data_collection` | `bool` | `False` | Set to `True` to disable usage analytics |
 | `flag_config_poll_interval_seconds` | `int` | `120` | Polling interval (seconds) for flag configuration _(in-process mode)_ |
 | `api_key` | `str` | `None` | API key for authenticated relay proxy requests, sent as `Authorization: Bearer` |
-| `exporter_metadata` | `dict` | `{}` | Static metadata attached to evaluation events. Values must be `str`, `bool`, `int` or `float` |
-| `max_pending_events` | `int` | `10000` | Maximum buffered events before a forced flush |
+| `exporter_metadata` | `dict` | `{}` | Static metadata attached to evaluation events. Values must be `str`, `bool`, `int` or `float`. The reserved keys `provider` and `openfeature` are always added and win over your values |
+| `max_pending_events` | `int` | `10000` | Buffered events that trigger an immediate flush. The buffer holds up to twice this many, above which the oldest are dropped |
 | `wasm_file_path` | `str` | `None` | Path to a custom WASM/WASI evaluation binary _(in-process mode, uses bundled binary by default)_ |
 | `wasm_pool_size` | `int` | CPU core count | Pool size for concurrent WASM evaluation instances _(in-process mode)_ |
 | `evaluation_flag_list` | `list[str]` | `None` | Restrict the fetched flag configuration to these keys. Unset or empty means all flags _(in-process mode)_ |
 | `custom_headers` | `dict[str, str]` | `None` | Extra headers on every relay proxy request, for deployments behind a gateway with its own authentication. Applied before the provider's own headers, so a configured `api_key` wins over a custom `Authorization` |
 | `log_level` | `str\|int` | `"WARNING"` | Logging level (`"DEBUG"`, `"INFO"`, `"WARNING"`, `"ERROR"`) |
-| `urllib3_pool_manager` | `urllib3.PoolManager` | `None` | Custom HTTP client |
+| `urllib3_pool_manager` | `urllib3.PoolManager` | `None` | Custom HTTP client for flag configuration and data collection. Remote evaluation uses the OFREP client, which builds its own |
 
 ## Conformance
 

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/evaluator/inprocess_evaluator.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/evaluator/inprocess_evaluator.py
@@ -14,6 +14,7 @@ from openfeature.exception import (
     FlagNotFoundError,
     GeneralError,
     InvalidContextError,
+    ParseError,
     ProviderFatalError,
     ProviderNotReadyError,
     TargetingKeyMissingError,
@@ -52,9 +53,14 @@ _ERROR_CODE_GENERAL = "GENERAL"
 # fault. The relay proxy is authoritative and reachable, so re-evaluating there
 # turns a local failure into a correct answer.
 #
-# FLAG_CONFIG is deliberately absent: it is a deterministic misconfiguration
-# that the relay proxy would reproduce identically, so a fallback would only add
-# latency to the same wrong answer.
+# PARSE_ERROR means the module could not read the payload this provider built
+# for it, and GENERAL is the engine's catch-all — which the bundled engine also
+# returns for anything a newer relay proxy understands and it does not. Both can
+# therefore succeed remotely.
+#
+# FLAG_CONFIG is deliberately absent: it names the flag itself as invalid, a
+# verdict the relay proxy reaches from the same configuration, so a fallback
+# would only add latency to the same wrong answer.
 _FALLBACK_ERROR_CODES = frozenset({_ERROR_CODE_PARSE_ERROR, _ERROR_CODE_GENERAL})
 
 # Flag metadata marking a result that came from the relay proxy rather than the
@@ -245,15 +251,11 @@ class InProcessEvaluator(AbstractEvaluator):
             # answered, so this is a successful refresh, not a failure.
             self._record_refresh_success(changed_flags=[])
             return
-        if not response.flags:
-            # A flag map that is null, absent or empty is a failed refresh, not
-            # an instruction to drop every flag.
-            logger.warning("Ignoring flag configuration refresh with an empty flag map")
-            self._record_refresh_failure(
-                "flag configuration refresh returned an empty flag map"
-            )
-            return
-
+        # A missing flag map never reaches here: the API rejects that response as
+        # malformed, which is a failed fetch above. An empty one is a relay proxy
+        # that legitimately serves no flags, and is applied as-is — treating it
+        # as a failure would drive a correctly-configured provider to STALE and
+        # answer PROVIDER_NOT_READY instead of FLAG_NOT_FOUND, forever.
         enrichment = response.evaluation_context_enrichment or {}
         with self._lock:
             changed_flags = _changed_flag_keys(self._flags or {}, response.flags)
@@ -340,15 +342,11 @@ class InProcessEvaluator(AbstractEvaluator):
             return TargetingKeyMissingError(details or "Targeting key missing")
         if error_code == _ERROR_CODE_INVALID_CONTEXT:
             return InvalidContextError(details or "Invalid context")
+        if error_code == _ERROR_CODE_PARSE_ERROR:
+            return ParseError(details or f"Error parsing flag '{flag_key}'")
         return GeneralError(
             details or f"Error evaluating flag '{flag_key}': {error_code}"
         )
-
-    def _raise_for_error_code(
-        self, flag_key: str, error_code: str, details: Optional[str]
-    ) -> None:
-        """Translate a WASM error code into the appropriate OpenFeature exception."""
-        raise self._error_for_code(flag_key, error_code, details)
 
     def _fallback_provider(self):
         """The OFREP client used for remote fallback, built on first use.
@@ -484,7 +482,7 @@ class InProcessEvaluator(AbstractEvaluator):
                         flag_key, response.errorCode, response.errorDetails
                     ),
                 )
-            self._raise_for_error_code(
+            raise self._error_for_code(
                 flag_key, response.errorCode, response.errorDetails
             )
 

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/hooks/data_collector.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/hooks/data_collector.py
@@ -1,5 +1,7 @@
 import datetime
 import logging
+from typing import Optional
+
 from gofeatureflag_python_provider.evaluator import AbstractEvaluator
 from gofeatureflag_python_provider.options import GoFeatureFlagOptions
 from gofeatureflag_python_provider.request_data_collector import FeatureEvent
@@ -19,6 +21,20 @@ VERSION_KEY = "version"
 # Every event this hook emits is a local evaluation: remote mode produces no
 # trackable flags, and fallback results are skipped above.
 SOURCE_INPROCESS = "INPROCESS"
+
+
+def _version_from(flag_metadata: Optional[dict]) -> Optional[str]:
+    """Read the flag version out of flag metadata as a string.
+
+    Flag metadata is authored by whoever wrote the flag, so `version` can hold
+    any JSON type. FeatureEvent types it as a string, and an unconvertible value
+    would raise inside this hook — which the SDK turns into an error result, so
+    a perfectly good evaluation would start returning the default value.
+    """
+    version = (flag_metadata or {}).get(VERSION_KEY)
+    if version is None or isinstance(version, str):
+        return version
+    return str(version)
 
 
 class DataCollectorHook(Hook):
@@ -63,7 +79,7 @@ class DataCollectorHook(Hook):
             key=hook_context.flag_key,
             value=details.value,
             variation=details.variant or "SdkDefault",
-            version=(details.flag_metadata or {}).get(VERSION_KEY),
+            version=_version_from(details.flag_metadata),
             source=SOURCE_INPROCESS,
             userKey=hook_context.evaluation_context.targeting_key
             or default_targeting_key,

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/options.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/options.py
@@ -128,8 +128,6 @@ class GoFeatureFlagOptions(BaseModel):
 
     def get_log_level_int(self) -> int:
         """Resolve log_level to a logging module level constant."""
-        if self.log_level is None:
-            return logging.WARNING
         if isinstance(self.log_level, int):
             return self.log_level
         return getattr(logging, str(self.log_level).upper(), logging.WARNING)

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/options.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/options.py
@@ -32,18 +32,20 @@ class GoFeatureFlagOptions(BaseModel):
     # default: endpoint
     data_collector_base_url: typing.Optional[AnyHttpUrl] = None
 
-    # timeout (optional) in milliseconds, applied to every request to the relay proxy:
-    # flag configuration, remote evaluation and data collection.
+    # timeout (optional) in milliseconds, applied to flag configuration, remote evaluation
+    # and data collection requests. It is carried by the HTTP client the provider builds, so
+    # supplying urllib3_pool_manager replaces it with that client's own timeout.
     # default: 10000
     timeout: typing.Optional[int] = 10_000
 
-    # dataFlushInterval (optional) interval time (in millisecond) we use to call the relay proxy to collect data.
-    # The parameter is used only if the cache is enabled, otherwise the collection of the data is done directly
-    # when calling the evaluation API.
+    # data_flush_interval (optional) interval in milliseconds between two flushes of the
+    # collected evaluation data to the relay proxy. A buffer that reaches max_pending_events
+    # flushes before the interval elapses.
     # default: 1 minute
     data_flush_interval: typing.Optional[int] = 60000
 
-    # disableDataCollection set to true if you don't want to collect the usage of flags retrieved in the cache.
+    # disable_data_collection (optional) set to true to stop reporting flag evaluations to
+    # the relay proxy's data collector.
     # default: false
     disable_data_collection: typing.Optional[bool] = False
 
@@ -65,13 +67,13 @@ class GoFeatureFlagOptions(BaseModel):
     # default: none
     custom_headers: typing.Optional[dict[str, str]] = None
 
-    # ADVANCED OPTIONS --- be careful when changing these options
-
     # log_level (optional) logging level: "DEBUG", "INFO", "WARNING", "ERROR" or int (e.g. logging.DEBUG).
     # default: "WARNING"
     log_level: typing.Union[int, str] = "WARNING"
 
-    # http_client (optional) is the http client used to call the relay proxy.
+    # urllib3_pool_manager (optional) Advanced: HTTP client used for flag configuration and
+    # data collection. Remote evaluation goes through the OFREP client, which builds its own.
+    # Supplying one also replaces the configured timeout with that client's own.
     urllib3_pool_manager: typing.Optional[urllib3.PoolManager] = None
 
     # api_key (optional) If the relay proxy is configured to authenticate the requests, you should provide
@@ -79,30 +81,32 @@ class GoFeatureFlagOptions(BaseModel):
     # Default: None
     api_key: typing.Optional[str] = None
 
-    # ExporterMetadata (optional) is the metadata we send to the GO Feature Flag relay proxy when we report the
-    # evaluation data usage. Values are restricted to string, boolean, integer or
+    # exporter_metadata (optional) is the metadata we send to the GO Feature Flag relay proxy when we
+    # report the evaluation data usage. Values are restricted to string, boolean, integer or
     # float; anything else is rejected here rather than failing later inside the
     # publisher, where the batch would be re-queued and retried forever.
     #
-    # ‼️Important: If you are using a GO Feature Flag relay proxy before version v1.41.0, the information of this
-    # field will not be added to your feature events.
+    # The reserved keys `provider` and `openfeature` are always added and win over a value
+    # set here.
     exporter_metadata: typing.Optional[
         dict[str, typing.Union[str, bool, int, float]]
     ] = {}
 
-    # max_pending_events (optional) is the maximum number of events buffered in memory before an immediate
-    # flush is triggered (fire-and-forget). Used by EventPublisher.
+    # max_pending_events (optional) number of buffered events that triggers an immediate
+    # flush (fire-and-forget). A threshold, not the ceiling: the buffer holds up to twice
+    # this many, above which the oldest events are dropped. Used by EventPublisher.
     # default: 10000
     max_pending_events: typing.Optional[int] = 10_000
 
-    # wasm_file_path (optional) is the path to the GO Feature Flag evaluation WASI binary.
+    # wasm_file_path (optional) Advanced: path to the GO Feature Flag evaluation WASI binary.
     # Used only when evaluation_type is INPROCESS.
     # If not set, the bundled WASI binary is used (version pinned in wasm/_wasi_version.txt).
     wasm_file_path: typing.Optional[str] = None
 
-    # wasm_pool_size (optional) number of WASM Store instances for concurrent in-process evaluation.
-    # Used only when evaluation_type is INPROCESS. wasmtime.Store is not thread-safe; a pool
-    # allows multiple evaluations to run in parallel.
+    # wasm_pool_size (optional) Advanced: number of WASM Store instances for concurrent
+    # in-process evaluation. Used only when evaluation_type is INPROCESS. wasmtime.Store is
+    # not thread-safe; a pool allows multiple evaluations to run in parallel.
+    # Zero or negative is treated as unset.
     # default: the host's CPU core count
     wasm_pool_size: typing.Optional[int] = Field(
         default_factory=lambda: os.cpu_count() or 1

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/services/api.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/services/api.py
@@ -138,7 +138,16 @@ class GoFeatureFlagApi:
                 f"Failed to parse flag configuration response: {e}"
             ) from e
 
-        result.flags = data.get("flags") or {}
+        flags = data.get("flags")
+        if not isinstance(flags, dict):
+            # A response without a flag map is malformed, and is rejected here so
+            # callers never have to guess. An *empty* map is a different thing
+            # entirely — a relay proxy that legitimately serves no flags — and is
+            # accepted as the valid configuration it is.
+            raise FlagConfigurationUnavailableError(
+                "flag configuration response does not contain a flag map"
+            )
+        result.flags = flags
         result.evaluation_context_enrichment = (
             data.get("evaluationContextEnrichment") or {}
         )

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/services/event_publisher.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/services/event_publisher.py
@@ -13,7 +13,8 @@ from gofeatureflag_python_provider.services.api import GoFeatureFlagApi
 
 DEFAULT_FLUSH_INTERVAL_MS: int = 60_000
 DEFAULT_MAX_PENDING_EVENTS: int = 10_000
-# Upper bound on how long shutdown waits for background work.
+# Upper bound on how long a caller waits for background work: shutdown waiting
+# for the runner thread, and any flush that queues behind an in-flight publish.
 DEFAULT_SHUTDOWN_TIMEOUT_SECONDS: float = 5.0
 
 logger = logging.getLogger(__name__)
@@ -55,6 +56,10 @@ class EventPublisher:
         # deliberately never taken by add_event: enqueuing runs inside an
         # evaluation hook and must not block on collector availability.
         self._flush_lock = threading.Lock()
+        # One event per runner rather than one shared by every runner: a runner
+        # that outlived its stop() keeps its own set event and exits, where a
+        # shared event would be cleared by the next start() and revive it,
+        # leaving two runners publishing in parallel.
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
         self._running = False
@@ -71,8 +76,10 @@ class EventPublisher:
         if self._running:
             return
         self._running = True
-        self._stop_event.clear()
-        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run, args=(self._stop_event,), daemon=True
+        )
         self._thread.start()
 
     def stop(self, timeout: float = DEFAULT_SHUTDOWN_TIMEOUT_SECONDS) -> None:
@@ -85,9 +92,19 @@ class EventPublisher:
             return
         self._running = False
         self._stop_event.set()
-        if self._thread is not None:
-            self._thread.join(timeout=timeout)
-            self._thread = None
+        thread = self._thread
+        self._thread = None
+        if thread is not None:
+            thread.join(timeout=timeout)
+            if thread.is_alive():
+                # Its stop event is set and is its own, so it exits as soon as
+                # the publish it is stuck in returns. Reported because until
+                # then a request to the collector is still outstanding.
+                self._logger.warning(
+                    "EventPublisher: flush thread still finishing a publish after "
+                    "%.1fs; it will exit on its own",
+                    timeout,
+                )
         self._publish_events(wait=True, timeout=timeout)
 
     def add_event(self, event: FeatureEvent) -> None:
@@ -122,19 +139,25 @@ class EventPublisher:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _run(self) -> None:
-        """Background thread: flush periodically until stopped."""
+    def _run(self, stopper: threading.Event) -> None:
+        """Background thread: flush periodically until its own stopper is set."""
         flush_interval_ms = (
             self._options.data_flush_interval or DEFAULT_FLUSH_INTERVAL_MS
         )
         flush_interval_sec = flush_interval_ms / 1000.0
-        while not self._stop_event.wait(timeout=flush_interval_sec):
+        while not stopper.wait(timeout=flush_interval_sec):
             self._publish_events()
 
     def _immediate_flush(self) -> None:
-        """Target of the fire-and-forget flush spawned by add_event."""
+        """Target of the fire-and-forget flush spawned by add_event.
+
+        Waits for an in-flight publish instead of skipping: this flush was
+        triggered by a full buffer, and the running publish drained the buffer
+        before those events arrived, so skipping would leave them queued until
+        the next periodic tick — a whole flush interval of growth past the cap.
+        """
         try:
-            self._publish_events()
+            self._publish_events(wait=True)
         finally:
             with self._lock:
                 self._immediate_flush_scheduled = False
@@ -148,9 +171,11 @@ class EventPublisher:
         Atomically drain the buffer and send events to the collector.
 
         At most one publish is in flight at a time. A periodic flush that finds
-        one already running simply returns — the running publish drains whatever
-        was queued in the meantime. Shutdown passes wait=True so it flushes
-        after the in-flight publish instead of skipping its own final drain.
+        one already running simply returns — the next tick comes soon enough.
+        Callers whose drain cannot wait for a tick (shutdown, and the
+        overflow-triggered flush) pass wait=True and queue behind the in-flight
+        publish instead, bounded by *timeout* so an unreachable collector never
+        blocks them indefinitely.
 
         On failure the drained batch is re-queued at the front of the buffer so
         no events are lost and chronological order is preserved.

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/wasm/evaluate_wasm.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/wasm/evaluate_wasm.py
@@ -24,6 +24,7 @@ replaced, never reused, and `free` must never be called on it.
 """
 
 import logging
+import threading
 from pathlib import Path
 from queue import Empty, Queue
 from typing import Any, Optional
@@ -76,15 +77,14 @@ class WasmEvaluationTrapError(RuntimeError):
 
 class WasmPoolTimeoutError(RuntimeError):
     """
-    Raised when no evaluation slot became available within the timeout and a
-    replacement slot could not be created. The pool can only stay empty that
-    long if slots were lost to irrecoverable store-creation failures or the
-    pool is badly undersized for the workload.
+    Raised when no evaluation slot became available within the timeout, either
+    because every slot is still busy (the pool is undersized for the workload)
+    or because slots were lost to irrecoverable store-creation failures and
+    rebuilding one failed again.
     """
 
 
-# How long evaluate() waits for a free slot before assuming the pool has been
-# drained (e.g. every replacement after a trap failed) and trying to self-heal.
+# How long evaluate() waits for a free slot before giving up on it.
 _POOL_GET_TIMEOUT_SECONDS = 30.0
 
 
@@ -161,6 +161,11 @@ class EvaluateWasm:
         self._engine: Optional[wasmtime.Engine] = None
         self._module: Optional[wasmtime.Module] = None
         self._pool: Optional[Queue[tuple[Any, ...]]] = None
+        # How many slots exist right now, queued or checked out. Only this
+        # tells a lost slot apart from a busy one, so rebuilding can be limited
+        # to capacity actually lost and never grows the pool past _pool_size.
+        self._live_slots = 0
+        self._live_slots_lock = threading.Lock()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -180,6 +185,8 @@ class EvaluateWasm:
         for _ in range(self._pool_size):
             slot = _create_slot(self._engine, self._module)
             self._pool.put(slot)
+        with self._live_slots_lock:
+            self._live_slots = self._pool_size
         logger.debug(
             "WASI module initialized from %s (pool_size=%d)",
             self._wasm_path,
@@ -191,6 +198,8 @@ class EvaluateWasm:
         self._pool = None
         self._module = None
         self._engine = None
+        with self._live_slots_lock:
+            self._live_slots = 0
         logger.debug("WASI module disposed")
 
     # ------------------------------------------------------------------
@@ -216,18 +225,34 @@ class EvaluateWasm:
         try:
             slot = pool.get(timeout=_POOL_GET_TIMEOUT_SECONDS)
         except Empty:
-            # The pool drained (replacement slots failed to build after traps)
-            # or is badly undersized. Try to heal it instead of blocking the
-            # caller forever; on failure degrade to a typed error so the
+            # A timeout on its own does not mean a slot was lost: every slot may
+            # simply still be busy. Rebuild only the capacity known to be gone
+            # (slots whose post-trap replacement failed), otherwise sustained
+            # saturation would add a store per waiting caller and grow the pool
+            # without bound. Plain saturation degrades to a typed error so the
             # evaluation falls back to the default value.
+            with self._live_slots_lock:
+                lost_capacity = self._live_slots < self._pool_size
+                if lost_capacity:
+                    # Reserved before the slot exists, so concurrent callers
+                    # cannot each rebuild the same missing slot.
+                    self._live_slots += 1
+            if not lost_capacity:
+                raise WasmPoolTimeoutError(
+                    "no WASM evaluation slot available after "
+                    f"{_POOL_GET_TIMEOUT_SECONDS:.0f}s; all {self._pool_size} "
+                    "slot(s) are in use. Consider increasing wasm_pool_size."
+                )
             try:
                 slot = _create_slot(self._engine, self._module)
                 logger.warning(
                     "no WASM slot became available within %.0fs; "
-                    "created a replacement slot",
+                    "rebuilt a slot the pool had lost",
                     _POOL_GET_TIMEOUT_SECONDS,
                 )
             except Exception as exc:
+                with self._live_slots_lock:
+                    self._live_slots -= 1
                 raise WasmPoolTimeoutError(
                     "no WASM evaluation slot available after "
                     f"{_POOL_GET_TIMEOUT_SECONDS:.0f}s and creating a "
@@ -249,8 +274,11 @@ class EvaluateWasm:
                         "replaced it with a fresh one"
                     )
                 except Exception:
-                    # The pool shrinks by one slot; evaluations keep working
-                    # on the remaining slots.
+                    # The pool shrinks by one slot; evaluations keep working on
+                    # the remaining slots, and the lost capacity is recorded so
+                    # a later timeout can rebuild exactly this slot.
+                    with self._live_slots_lock:
+                        self._live_slots -= 1
                     logger.exception(
                         "failed to replace a trapped WASM store; "
                         "the evaluation pool lost one slot"

--- a/openfeature/providers/python-provider/gofeatureflag_python_provider/wasm/evaluate_wasm.py
+++ b/openfeature/providers/python-provider/gofeatureflag_python_provider/wasm/evaluate_wasm.py
@@ -69,9 +69,10 @@ class WasmInvalidResultError(RuntimeError):
 
 class WasmEvaluationTrapError(RuntimeError):
     """
-    Raised when the WASM module traps during evaluation (stack overflow,
-    unrecoverable panic, out-of-memory...). The store that trapped has been
-    discarded and replaced with a fresh one; the evaluation itself failed.
+    Raised when the WASM module died mid-call (stack overflow, unrecoverable
+    panic, out-of-memory, or an abort that exits through WASI proc_exit). The
+    store has been discarded and replaced with a fresh one; the evaluation
+    itself failed.
     """
 
 
@@ -86,6 +87,13 @@ class WasmPoolTimeoutError(RuntimeError):
 
 # How long evaluate() waits for a free slot before giving up on it.
 _POOL_GET_TIMEOUT_SECONDS = 30.0
+
+# Errors that mean the call into the module died mid-flight, leaving the store
+# poisoned. wasmtime raises Trap for a genuine trap, and ExitTrap — which is a
+# WasmtimeError, *not* a Trap subclass — when the module calls proc_exit, as
+# TinyGo's abort() does. Catching only Trap would let an abort escape with the
+# store still in the pool.
+_STORE_POISONING_ERRORS = (wasmtime.Trap, wasmtime.WasmtimeError)
 
 
 def _create_slot(
@@ -260,7 +268,7 @@ class EvaluateWasm:
                 ) from exc
         try:
             return self._evaluate_with_slot(slot, wasm_input)
-        except wasmtime.Trap as exc:
+        except _STORE_POISONING_ERRORS as exc:
             slot = None  # poisoned: never reuse a store that trapped
             raise WasmEvaluationTrapError(
                 f"WASM evaluation trapped; the store has been discarded: {exc}"
@@ -302,7 +310,7 @@ class EvaluateWasm:
             memory.write(store, input_bytes + b"\x00", ptr)
             try:
                 result = evaluate_fn(store, ptr, len(input_bytes))
-            except wasmtime.Trap:
+            except _STORE_POISONING_ERRORS:
                 trapped = True
                 raise
             if not isinstance(result, int):

--- a/openfeature/providers/python-provider/tests/test_data_collector_hook.py
+++ b/openfeature/providers/python-provider/tests/test_data_collector_hook.py
@@ -441,3 +441,35 @@ def test_event_version_is_unset_when_the_flag_has_none(mock_evaluator):
     hook.after(_make_hook_context(), _make_details(), {})
 
     assert publisher.add_event.call_args[0][0].version is None
+
+
+@pytest.mark.parametrize(
+    "raw_version,expected",
+    [(2, "2"), (1.7, "1.7"), (True, "True")],
+)
+def test_a_non_string_flag_version_does_not_break_the_evaluation(
+    mock_evaluator, raw_version, expected
+):
+    """Flag metadata is user-authored, so `version` can be any JSON type.
+
+    An event model that rejects it would raise inside this hook, and the SDK
+    turns a hook failure into an error result — so a flag carrying
+    `metadata: {version: 2}` would never resolve to its real value again.
+    """
+    publisher = MagicMock()
+    hook = DataCollectorHook(
+        options=_make_options(),
+        event_publisher=publisher,
+        evaluator=mock_evaluator,
+    )
+    details = FlagEvaluationDetails(
+        flag_key="test-flag",
+        value=True,
+        variant="on",
+        reason="TARGETING_MATCH",
+        flag_metadata={"version": raw_version},
+    )
+
+    hook.after(_make_hook_context(), details, {})
+
+    assert publisher.add_event.call_args[0][0].version == expected

--- a/openfeature/providers/python-provider/tests/test_evaluate_wasm.py
+++ b/openfeature/providers/python-provider/tests/test_evaluate_wasm.py
@@ -464,34 +464,95 @@ def test_pool_size_preserved_after_trap_storm():
         e.dispose()
 
 
-def test_empty_pool_self_heals_on_timeout(monkeypatch):
-    """A drained pool creates a replacement slot instead of blocking forever."""
+def _drain_pool_by_losing_slots(evaluator, creation_fails, count=1):
+    """
+    Make the pool genuinely lose `count` slots: trap the evaluation while slot
+    creation is broken, so the post-trap replacement fails too. This is the only
+    way capacity is really lost, as opposed to merely being checked out.
+    """
+    real_evaluate_with_slot = evaluator._evaluate_with_slot
+
+    def always_trap(_slot, _wasm_input):
+        raise wasmtime.Trap("synthetic trap")
+
+    evaluator._evaluate_with_slot = always_trap
+    creation_fails["value"] = True
+    try:
+        for _ in range(count):
+            with pytest.raises(WasmEvaluationTrapError):
+                evaluator.evaluate(_make_input("f", _BOOL_FLAG, default=False))
+    finally:
+        creation_fails["value"] = False
+        evaluator._evaluate_with_slot = real_evaluate_with_slot
+
+
+def _patch_fallible_create_slot(monkeypatch):
+    """Patch _create_slot so tests can switch creation failures on and off."""
+    creation_fails = {"value": False}
+    real_create_slot = evaluate_wasm_module._create_slot
+
+    def maybe_failing_create_slot(*args):
+        if creation_fails["value"]:
+            raise RuntimeError("instantiation failed")
+        return real_create_slot(*args)
+
+    monkeypatch.setattr(evaluate_wasm_module, "_create_slot", maybe_failing_create_slot)
+    return creation_fails
+
+
+def test_lost_slot_is_rebuilt_on_next_evaluation(monkeypatch):
+    """Capacity lost to a failed post-trap rebuild is restored, not left missing."""
     monkeypatch.setattr(evaluate_wasm_module, "_POOL_GET_TIMEOUT_SECONDS", 0.05)
+    creation_fails = _patch_fallible_create_slot(monkeypatch)
     e = EvaluateWasm(pool_size=1)
     e.initialize()
     try:
-        _hostage = e._pool.get()  # simulate a slot lost to a rebuild failure
+        _drain_pool_by_losing_slots(e, creation_fails)
+        assert e._pool.qsize() == 0
+        assert e._live_slots == 0
+
         resp = e.evaluate(_make_input("f", _BOOL_FLAG, default=False))
         assert resp.value is True
-        assert e._pool.qsize() == 1  # the healed slot went back to the pool
+        assert e._pool.qsize() == 1  # the rebuilt slot went back to the pool
+        assert e._live_slots == 1
     finally:
         e.dispose()
 
 
-def test_empty_pool_raises_typed_error_when_heal_fails(monkeypatch):
-    """If healing fails too, a typed error surfaces instead of a hang."""
+def test_empty_pool_raises_typed_error_when_rebuild_fails(monkeypatch):
+    """If rebuilding fails too, a typed error surfaces instead of a hang."""
+    monkeypatch.setattr(evaluate_wasm_module, "_POOL_GET_TIMEOUT_SECONDS", 0.05)
+    creation_fails = _patch_fallible_create_slot(monkeypatch)
+    e = EvaluateWasm(pool_size=1)
+    e.initialize()
+    try:
+        _drain_pool_by_losing_slots(e, creation_fails)
+
+        creation_fails["value"] = True
+        with pytest.raises(WasmPoolTimeoutError, match="no WASM evaluation slot"):
+            e.evaluate(_make_input("f", _BOOL_FLAG, default=False))
+        # A failed rebuild must not leave phantom capacity behind, or the pool
+        # would never rebuild that slot again.
+        assert e._live_slots == 0
+    finally:
+        e.dispose()
+
+
+def test_saturated_pool_does_not_grow(monkeypatch):
+    """Busy slots are not lost slots: saturation errors instead of adding stores."""
     monkeypatch.setattr(evaluate_wasm_module, "_POOL_GET_TIMEOUT_SECONDS", 0.05)
     e = EvaluateWasm(pool_size=1)
     e.initialize()
     try:
-        _hostage = e._pool.get()
+        busy_slot = e._pool.get()  # checked out by another (slow) evaluation
+        for _ in range(3):
+            with pytest.raises(WasmPoolTimeoutError, match="all 1 slot"):
+                e.evaluate(_make_input("f", _BOOL_FLAG, default=False))
 
-        def failing_create_slot(*_args):
-            raise RuntimeError("instantiation failed")
-
-        monkeypatch.setattr(evaluate_wasm_module, "_create_slot", failing_create_slot)
-        with pytest.raises(WasmPoolTimeoutError, match="no WASM evaluation slot"):
-            e.evaluate(_make_input("f", _BOOL_FLAG, default=False))
+        e._pool.put(busy_slot)
+        assert e._pool.qsize() == 1  # never grew past pool_size
+        assert e._live_slots == 1
+        assert e.evaluate(_make_input("f", _BOOL_FLAG, default=False)).value is True
     finally:
         e.dispose()
 

--- a/openfeature/providers/python-provider/tests/test_evaluate_wasm.py
+++ b/openfeature/providers/python-provider/tests/test_evaluate_wasm.py
@@ -6,6 +6,7 @@ initialization, disposal, and flag evaluation for all supported types and scenar
 from __future__ import annotations
 
 import threading
+from typing import Optional
 
 import pytest
 import wasmtime
@@ -333,6 +334,7 @@ def _make_fake_slot(
     malloc_ret: int = 8,
     trap_on_evaluate: bool = False,
     evaluate_ret: object = None,
+    evaluate_error: Optional[BaseException] = None,
 ):
     """Duck-typed (store, memory, malloc, free, evaluate) slot recording calls."""
     calls = {"free": 0, "writes": 0}
@@ -354,6 +356,8 @@ def _make_fake_slot(
         calls["free"] += 1
 
     def evaluate_fn(_store, _ptr, _length):
+        if evaluate_error is not None:
+            raise evaluate_error
         if trap_on_evaluate:
             raise wasmtime.Trap("synthetic trap")
         if evaluate_ret is not None:
@@ -378,6 +382,44 @@ def test_evaluate_with_slot_skips_free_after_trap():
     with pytest.raises(wasmtime.Trap):
         EvaluateWasm()._evaluate_with_slot(slot, _make_input("f", _BOOL_FLAG))
     assert calls["free"] == 0
+
+
+def test_evaluate_with_slot_skips_free_after_a_wasi_abort():
+    """An abort exits through proc_exit, which wasmtime reports as ExitTrap.
+
+    ExitTrap is a WasmtimeError and *not* a Trap subclass, so a handler that
+    only names Trap would run free() on a store that is just as poisoned.
+    """
+    slot, calls = _make_fake_slot(evaluate_error=wasmtime.ExitTrap("wasi proc_exit(1)"))
+    with pytest.raises(wasmtime.ExitTrap):
+        EvaluateWasm()._evaluate_with_slot(slot, _make_input("f", _BOOL_FLAG))
+    assert calls["free"] == 0
+
+
+def test_wasi_abort_discards_the_store_like_a_trap():
+    """The store is poisoned either way, so it must never go back to the pool."""
+    e = EvaluateWasm(pool_size=1)
+    e.initialize()
+    try:
+        original_store = e._pool.queue[0][0]
+        real_evaluate_with_slot = e._evaluate_with_slot
+        raised = []
+
+        def abort_once(slot, wasm_input):
+            if not raised:
+                raised.append(True)
+                raise wasmtime.ExitTrap("wasi proc_exit(1)")
+            return real_evaluate_with_slot(slot, wasm_input)
+
+        e._evaluate_with_slot = abort_once
+        with pytest.raises(WasmEvaluationTrapError):
+            e.evaluate(_make_input("f", _BOOL_FLAG, default=False))
+
+        assert e._pool.qsize() == 1
+        assert e._pool.queue[0][0] is not original_store
+        assert e.evaluate(_make_input("f", _BOOL_FLAG, default=False)).value is True
+    finally:
+        e.dispose()
 
 
 def test_evaluate_with_slot_rejects_null_malloc():

--- a/openfeature/providers/python-provider/tests/test_event_publisher.py
+++ b/openfeature/providers/python-provider/tests/test_event_publisher.py
@@ -242,6 +242,88 @@ def test_stop_is_bounded_when_the_collector_hangs():
         release.set()
 
 
+def test_overflow_flush_waits_for_an_in_flight_publish():
+    """The flush a full buffer triggers must not be skipped.
+
+    The publish already running drained the buffer before these events arrived,
+    so skipping would leave them queued past the cap until the next periodic
+    tick — a whole flush interval away.
+    """
+    in_flight = threading.Event()
+    release = threading.Event()
+    sent_batches = []
+
+    def _send(events, meta):
+        sent_batches.append(list(events))
+        if len(sent_batches) == 1:
+            in_flight.set()
+            release.wait(timeout=5.0)
+
+    mock_api = Mock()
+    mock_api.send_event_to_data_collector.side_effect = _send
+    publisher = EventPublisher(api=mock_api, options=_make_options(2))
+
+    # Occupy the publish lock with a slow, already-running flush.
+    publisher.add_event(_make_event(user_key="u0"))
+    threading.Thread(target=publisher._publish_events, daemon=True).start()
+    assert in_flight.wait(timeout=2.0)
+
+    # These arrive after that publish took its snapshot, and reaching the
+    # threshold spawns the overflow flush.
+    publisher.add_event(_make_event(user_key="u1"))
+    publisher.add_event(_make_event(user_key="u2"))
+    release.set()
+
+    deadline = time.monotonic() + 3.0
+    while len(sent_batches) < 2 and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert len(sent_batches) == 2
+    assert [event.userKey for event in sent_batches[1]] == ["u1", "u2"]
+
+
+def test_start_after_a_timed_out_stop_leaves_a_single_runner():
+    """A stop() that timed out must not leave a second runner behind.
+
+    The old runner is still alive; giving each runner its own stop event means
+    the next start() cannot revive it into publishing alongside the new one.
+    """
+    release = threading.Event()
+    in_flight = threading.Event()
+
+    def _hanging_send(events, meta):
+        in_flight.set()
+        release.wait(timeout=10.0)
+
+    mock_api = Mock()
+    mock_api.send_event_to_data_collector.side_effect = _hanging_send
+    # Tick fast enough that the runner thread itself is the one stuck in the
+    # publish when stop() gives up waiting for it.
+    publisher = EventPublisher(api=mock_api, options=_make_options(2, 50))
+    publisher.add_event(_make_event())
+    publisher.start()
+    old_thread = publisher._thread
+    old_stopper = publisher._stop_event
+    assert in_flight.wait(timeout=2.0)
+
+    try:
+        publisher.stop(timeout=0.2)
+        assert old_thread.is_alive()  # still stuck in the hanging publish
+        assert old_stopper.is_set()
+
+        publisher.start()
+
+        assert publisher._thread is not old_thread
+        # The old runner is still waiting on the event it was started with, so
+        # it stays stopped. Sharing one event would clear it here and put that
+        # thread back to work alongside the new one.
+        assert old_stopper.is_set()
+        assert publisher._stop_event is not old_stopper
+    finally:
+        release.set()
+        publisher.stop(timeout=1.0)
+
+
 def test_exporter_metadata_always_carries_the_reserved_keys():
     """Without them, events cannot be attributed to an SDK."""
     mock_api = Mock()

--- a/openfeature/providers/python-provider/tests/test_inprocess_evaluator.py
+++ b/openfeature/providers/python-provider/tests/test_inprocess_evaluator.py
@@ -12,8 +12,10 @@ import pytest
 
 from openfeature.evaluation_context import EvaluationContext
 from openfeature.exception import (
+    ErrorCode,
     FlagNotFoundError,
     GeneralError,
+    ParseError,
     ProviderFatalError,
     ProviderNotReadyError,
     TypeMismatchError,
@@ -144,7 +146,7 @@ def test_shutdown_stops_polling_and_disposes_wasm():
 
 
 def test_304_keeps_existing_flags():
-    """When refresh returns a response with empty flags (304-style), stored flags are unchanged."""
+    """A 'not modified' answer leaves the stored configuration untouched."""
     mock_api = Mock()
     mock_api.retrieve_flag_configuration.side_effect = [
         FlagConfigResponse(
@@ -152,7 +154,7 @@ def test_304_keeps_existing_flags():
             flags={"my_flag": {"defaultValue": False}},
             evaluation_context_enrichment={},
         ),
-        FlagConfigResponse(etag="v1", flags={}, evaluation_context_enrichment={}),
+        None,  # 304 Not Modified
     ]
     evaluator, _ = _make_evaluator_with_mock_wasm(mock_api=mock_api)
     evaluator.initialize()
@@ -161,6 +163,31 @@ def test_304_keeps_existing_flags():
     evaluator._refresh_flag_configuration()
     with evaluator._lock:
         assert evaluator._flags == {"my_flag": {"defaultValue": False}}
+    evaluator.shutdown()
+
+
+def test_an_emptied_flag_map_is_applied_and_flags_report_as_not_found():
+    """Every flag being removed is a configuration change like any other.
+
+    The provider is ready and its configuration is current, so the answer to a
+    lookup is FLAG_NOT_FOUND — not PROVIDER_NOT_READY, which would blame the
+    infrastructure for an empty config.
+    """
+    mock_api = Mock()
+    mock_api.retrieve_flag_configuration.side_effect = [
+        FlagConfigResponse(etag='"v1"', flags={_FLAG_KEY: _BOOL_FLAG_DICT}),
+        FlagConfigResponse(etag='"v2"', flags={}),
+    ]
+    evaluator, _ = _make_evaluator_with_mock_wasm(mock_api=mock_api)
+    evaluator.initialize()
+
+    evaluator._refresh_flag_configuration()
+
+    with evaluator._lock:
+        assert evaluator._flags == {}
+        assert evaluator._etag == '"v2"'
+    with pytest.raises(FlagNotFoundError):
+        evaluator.resolve_boolean_details(_FLAG_KEY, False, _DEFAULT_CTX)
     evaluator.shutdown()
 
 
@@ -715,17 +742,23 @@ def test_304_does_not_advance_the_stored_etag():
     evaluator.shutdown()
 
 
-def test_null_flag_map_does_not_advance_the_stored_etag():
-    """A 200 with a null/absent flag map is a failed refresh.
+def test_a_rejected_response_does_not_advance_the_stored_etag():
+    """A refresh the API rejected (e.g. a body with no flag map) changes nothing.
 
     Advancing the ETag here pins the provider to a configuration it never
     received, after which the server answers 304 forever and the stale
     configuration becomes permanent.
     """
+    from gofeatureflag_python_provider.exceptions import (
+        FlagConfigurationUnavailableError,
+    )
+
     mock_api = Mock()
     mock_api.retrieve_flag_configuration.side_effect = [
         FlagConfigResponse(etag='"v1"', flags={"f": {"defaultValue": True}}),
-        FlagConfigResponse(etag='"v2"', flags={}),
+        FlagConfigurationUnavailableError(
+            "flag configuration response does not contain a flag map"
+        ),
     ]
     evaluator, _ = _make_evaluator_with_mock_wasm(mock_api=mock_api)
     evaluator.initialize()
@@ -951,7 +984,12 @@ def test_stale_after_three_consecutive_failures_then_ready_on_recovery():
     evaluator.shutdown()
 
 
-def test_an_empty_flag_map_counts_as_a_failed_refresh_for_staleness():
+def test_an_empty_flag_map_is_a_successful_refresh():
+    """A relay proxy serving no flags is a valid configuration, not a failure.
+
+    Counting it as one would drive a correctly-configured provider to STALE and
+    keep it there: the ETag never advances, so no later poll can clear it.
+    """
     mock_api = Mock()
     mock_api.retrieve_flag_configuration.side_effect = [
         FlagConfigResponse(etag='"v1"', flags={"f": {}}),
@@ -965,7 +1003,10 @@ def test_an_empty_flag_map_counts_as_a_failed_refresh_for_staleness():
     for _ in range(3):
         evaluator._refresh_flag_configuration()
 
-    assert len(events["stale"]) == 1
+    assert events["stale"] == []
+    with evaluator._lock:
+        assert evaluator._flags == {}
+        assert evaluator._etag == '"v4"'
     evaluator.shutdown()
 
 
@@ -1108,8 +1149,25 @@ def test_remote_failure_surfaces_the_original_in_process_error():
         value=None, errorCode="PARSE_ERROR", errorDetails="malformed flag"
     )
 
-    with pytest.raises(GeneralError, match="malformed flag"):
+    with pytest.raises(ParseError, match="malformed flag"):
         evaluator.resolve_boolean_details(_FLAG_KEY, False, _DEFAULT_CTX)
+    evaluator.shutdown()
+
+
+def test_engine_parse_error_maps_to_parse_error():
+    """PARSE_ERROR has its own SDK exception; collapsing it into GeneralError
+    would report the wrong error code to the caller."""
+    evaluator, mock_wasm, _ = _evaluator_with_fallback(
+        remote_error=RuntimeError("relay proxy unreachable")
+    )
+    mock_wasm.evaluate.return_value = _wasm_ok_response(
+        value=None, errorCode="PARSE_ERROR", errorDetails="boom"
+    )
+
+    with pytest.raises(ParseError) as raised:
+        evaluator.resolve_boolean_details(_FLAG_KEY, False, _DEFAULT_CTX)
+
+    assert raised.value.error_code == ErrorCode.PARSE_ERROR
     evaluator.shutdown()
 
 

--- a/openfeature/providers/python-provider/tests/test_services_api.py
+++ b/openfeature/providers/python-provider/tests/test_services_api.py
@@ -320,7 +320,7 @@ def test_retrieve_flag_configuration_invalid_last_modified_returns_none(
     mock_pool_manager_class.return_value = mock_http
     mock_http.request.return_value = _mock_response(
         HTTPStatus.OK,
-        "{}",
+        json.dumps({"flags": {}}),
         {"ETag": '"123456789"', "Last-Modified": "invalid-date"},
     )
     options = _make_options()
@@ -330,6 +330,43 @@ def test_retrieve_flag_configuration_invalid_last_modified_returns_none(
 
     # Parsing invalid date leaves last_updated as None (JS: lastUpdated?.getTime() is NaN)
     assert result.last_updated is None
+
+
+@patch("gofeatureflag_python_provider.services.api.urllib3.PoolManager")
+def test_retrieve_flag_configuration_accepts_an_empty_flag_map(
+    mock_pool_manager_class,
+):
+    """A relay proxy serving no flags returns a valid, empty configuration."""
+    mock_http = Mock()
+    mock_pool_manager_class.return_value = mock_http
+    mock_http.request.return_value = _mock_response(
+        HTTPStatus.OK, json.dumps({"flags": {}}), {"ETag": '"v1"'}
+    )
+    api = GoFeatureFlagApi(_make_options())
+
+    result = api.retrieve_flag_configuration()
+
+    assert result.flags == {}
+    assert result.etag == '"v1"'
+
+
+@patch("gofeatureflag_python_provider.services.api.urllib3.PoolManager")
+@pytest.mark.parametrize("body", ["{}", json.dumps({"flags": None})])
+def test_retrieve_flag_configuration_rejects_a_response_without_a_flag_map(
+    mock_pool_manager_class, body
+):
+    """A body with no flag map is malformed, and must not read as 'no flags'.
+
+    Silently turning it into an empty configuration would drop every flag the
+    provider is serving.
+    """
+    mock_http = Mock()
+    mock_pool_manager_class.return_value = mock_http
+    mock_http.request.return_value = _mock_response(HTTPStatus.OK, body, {})
+    api = GoFeatureFlagApi(_make_options())
+
+    with pytest.raises(FlagConfigurationUnavailableError, match="flag map"):
+        api.retrieve_flag_configuration()
 
 
 @patch("gofeatureflag_python_provider.services.api.urllib3.PoolManager")


### PR DESCRIPTION
## Description

This PR fixes a WASM pool growth bug and a batch of review findings on the hooks, WASM and refresh paths.

Pool rebuild accounting: a `pool.get()` timeout does not prove a slot was lost — every slot may simply be busy. Rebuilding on every timeout meant sustained saturation added one `wasmtime` Store per waiting caller, growing the pool past `wasm_pool_size` without any ceiling. The pool now tracks how many slots exist (queued or checked out) and rebuilds only when that count is below `pool_size`. Ordinary saturation returns `WasmPoolTimeoutError`, which the evaluator already maps to `GeneralError` and the default value.

Review findings:
- Coerce a non-string flag version before building the data collection event — user-authored `metadata: {version: 2}` raised a `ValidationError` inside the after hook, turning a good evaluation into an error result.
- Treat a WASI abort (`ExitTrap`, which is not a `Trap` subclass) like a trap, so the poisoned store is not returned to the pool.
- Accept an empty flag map as a valid configuration — a relay proxy serving zero flags no longer drives the provider into a permanent `STALE` state.
- Map the engine's `PARSE_ERROR` onto `ParseError` instead of `GeneralError`.
- Make the overflow-triggered flush wait for an in-flight publish instead of silently no-opping.
- Give each `EventPublisher` runner its own stop event, so a `start()` after a timed-out `stop()` cannot revive the previous runner.
- Correct stale option comments (`data_flush_interval`/`disable_data_collection` still referred to the removed cache) and align the README rows.

How to test: `uv run pytest` — 259 passed, 6 skipped at this commit.


## Closes issue(s)
No dedicated issue — follow-up fixes found while reviewing the evaluation and data-collection paths.

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` option rows)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
