### PR TITLE
docs(python-provider): remove stale cache options from the provider documentation

### DIFF
--- a/website/docs/sdk/server_providers/openfeature_python.mdx
+++ b/website/docs/sdk/server_providers/openfeature_python.mdx
@@ -127,16 +127,13 @@ You can configure the provider with several options to customize its behavior:
 | **`endpoint`** | `true` | — | URL of the GO Feature Flag relay proxy _(e.g. `http://localhost:1031`)_ |
 | **`evaluation_type`** | `false` | `INPROCESS` | Evaluation mode: `EvaluationType.INPROCESS` or `EvaluationType.REMOTE` |
 | **`api_key`** | `false` | `None` | API key for authenticated relay proxy requests |
-| **`flag_config_poll_interval_seconds`** | `false` | `10` | Polling interval (seconds) to refresh flag configuration _(in-process only)_ |
+| **`flag_config_poll_interval_seconds`** | `false` | `120` | Polling interval (seconds) to refresh flag configuration _(in-process only)_ |
 | **`wasm_file_path`** | `false` | `None` | Path to a custom WASM/WASI evaluation binary _(in-process only; uses bundled binary by default)_ |
-| **`wasm_pool_size`** | `false` | `10` | Pool size for concurrent WASM evaluation instances _(in-process only)_ |
+| **`wasm_pool_size`** | `false` | CPU core count | Pool size for concurrent WASM evaluation instances _(in-process only)_ |
 | **`data_flush_interval`** | `false` | `60000` | Interval (ms) to flush usage data to the relay proxy |
 | **`max_pending_events`** | `false` | `10000` | Maximum buffered events before a forced flush |
 | **`disable_data_collection`** | `false` | `False` | Set to `True` to disable usage analytics |
 | **`exporter_metadata`** | `false` | `{}` | Static metadata attached to evaluation events |
-| **`cache_size`** | `false` | `10000` | Maximum number of flag evaluations in the LRU cache _(remote only)_ |
-| **`disable_cache_invalidation`** | `false` | `False` | Disable WebSocket-based cache invalidation _(remote only)_ |
-| **`reconnect_interval`** | `false` | `60` | WebSocket reconnect interval (seconds) _(remote only)_ |
 | **`log_level`** | `false` | `"WARNING"` | Logging level: `"DEBUG"`, `"INFO"`, `"WARNING"`, or `"ERROR"` |
 | **`urllib3_pool_manager`** | `false` | `None` | Custom `urllib3.PoolManager` HTTP client |
 

--- a/website/versioned_docs/version-v1.55.1/sdk/server_providers/openfeature_python.mdx
+++ b/website/versioned_docs/version-v1.55.1/sdk/server_providers/openfeature_python.mdx
@@ -134,9 +134,9 @@ You can configure the provider with several options to customize its behavior:
 | **`max_pending_events`** | `false` | `10000` | Maximum buffered events before a forced flush |
 | **`disable_data_collection`** | `false` | `False` | Set to `True` to disable usage analytics |
 | **`exporter_metadata`** | `false` | `{}` | Static metadata attached to evaluation events |
-| **`cache_size`** | `false` | `10000` | Maximum number of flag evaluations in the LRU cache _(remote only)_ |
-| **`disable_cache_invalidation`** | `false` | `False` | Disable WebSocket-based cache invalidation _(remote only)_ |
-| **`reconnect_interval`** | `false` | `60` | WebSocket reconnect interval (seconds) _(remote only)_ |
+| **`cache_size`** | `false` | `10000` | **Deprecated — has no effect.** The evaluation cache was removed from the provider; the option is still accepted but ignored. |
+| **`disable_cache_invalidation`** | `false` | `False` | **Deprecated — has no effect.** WebSocket cache invalidation was removed from the provider. |
+| **`reconnect_interval`** | `false` | `60` | **Deprecated — has no effect.** WebSocket cache invalidation was removed from the provider. |
 | **`log_level`** | `false` | `"WARNING"` | Logging level: `"DEBUG"`, `"INFO"`, `"WARNING"`, or `"ERROR"` |
 | **`urllib3_pool_manager`** | `false` | `None` | Custom `urllib3.PoolManager` HTTP client |
 


### PR DESCRIPTION
## Description

This PR removes stale cache options from the Python provider documentation.

The provider no longer implements the remote-evaluation LRU cache, but `website/docs/sdk/server_providers/openfeature_python.mdx` still told users to set `cache_size`, `disable_cache_invalidation` and `reconnect_interval` — options the provider (after this stack) no longer accepts. It also corrects two documented defaults to match the code: `flag_config_poll_interval_seconds` (`120`) and `wasm_pool_size` (CPU core count).

The `v1.55.1` versioned snapshot keeps the three rows but marks them **deprecated — no effect**: at that release the options were still accepted (and silently ignored), and its documented defaults match the code that shipped, so they are left unchanged. Older snapshots (v1.52.1–v1.55.0) are untouched for the same reason.


## Closes issue(s)
No dedicated issue — documentation follow-up to the specification 1.0 alignment in this stack.

## Checklist
- [x] I have tested this code (Prettier check on the touched files; table-only markdown change)
- [ ] I have added unit test to cover this code — documentation only
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
