### PR TITLE
ci: remove manual trigger from Sonar autofix workflow

### DIFF
--- a/.github/workflows/sonar-autofix.yml
+++ b/.github/workflows/sonar-autofix.yml
@@ -1,7 +1,6 @@
 name: Sonar Autofix
 
 on:
-  workflow_dispatch:
   schedule:
     # every morning at 06:00 UTC
     - cron: 0 6 * * *


### PR DESCRIPTION
## Summary
- Remove `workflow_dispatch` from the Sonar Autofix workflow so it only runs on the daily schedule (06:00 UTC).

## Test plan
- [ ] Confirm the Actions UI no longer shows a "Run workflow" button for Sonar Autofix
- [ ] Confirm the cron schedule is still present in the workflow file


Made with [Cursor](https://cursor.com)