### PR TITLE
fix(website): stop Vignette underlining its whole card on hover

### DIFF
--- a/website/src/components/doc/vignette/index.js
+++ b/website/src/components/doc/vignette/index.js
@@ -4,14 +4,14 @@ import PropTypes from 'prop-types';
 export const Vignette = ({color, link, title, description, icon}) => {
   const colors = {
     cyan: {
-      href: 'block bg-gradient-to-br from-cyan-50 to-sky-100 dark:from-cyan-900/20 dark:to-sky-900/20 border border-cyan-200 dark:border-cyan-700 rounded-lg p-6 hover:shadow-lg transition-all duration-200 hover:scale-105 hover:border-cyan-300 dark:hover:border-cyan-600',
+      href: 'group block no-underline hover:no-underline bg-gradient-to-br from-cyan-50 to-sky-100 dark:from-cyan-900/20 dark:to-sky-900/20 border border-cyan-200 dark:border-cyan-700 rounded-lg p-6 hover:shadow-lg transition-all duration-200 hover:scale-105 hover:border-cyan-300 dark:hover:border-cyan-600',
       icon: 'bg-cyan-500 text-white p-3 rounded-lg mr-4',
-      link: 'inline-flex items-center mt-4 text-cyan-600 hover:text-cyan-800 dark:text-cyan-400 dark:hover:text-cyan-300 font-medium no-underline',
+      link: 'inline-flex items-center mt-4 text-cyan-600 group-hover:text-cyan-800 dark:text-cyan-400 dark:group-hover:text-cyan-300 font-medium',
     },
     blue: {
-      href: 'block bg-gradient-to-br from-blue-50 to-slate-100 dark:from-blue-900/20 dark:to-slate-800/20 border border-blue-200 dark:border-blue-700 rounded-lg p-6 hover:shadow-lg transition-all duration-200 hover:scale-105 hover:border-blue-300 dark:hover:border-blue-600',
+      href: 'group block no-underline hover:no-underline bg-gradient-to-br from-blue-50 to-slate-100 dark:from-blue-900/20 dark:to-slate-800/20 border border-blue-200 dark:border-blue-700 rounded-lg p-6 hover:shadow-lg transition-all duration-200 hover:scale-105 hover:border-blue-300 dark:hover:border-blue-600',
       icon: 'bg-blue-600 text-white p-3 rounded-lg mr-4',
-      link: 'inline-flex items-center mt-4 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 font-medium no-underline',
+      link: 'inline-flex items-center mt-4 text-blue-600 group-hover:text-blue-800 dark:text-blue-400 dark:group-hover:text-blue-300 font-medium',
     },
   };
 
@@ -21,7 +21,7 @@ export const Vignette = ({color, link, title, description, icon}) => {
         <div className={colors[color].icon}>
           <i className={`fa-solid ${icon} text-2xl`}></i>
         </div>
-        <h3 className="text-lg font-semibold no-underline text-gray-900 dark:text-gray-100">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
           {title}
         </h3>
       </div>
@@ -29,7 +29,9 @@ export const Vignette = ({color, link, title, description, icon}) => {
         {description}
       </p>
       <div className={colors[color].link}>
-        Get started <i className="fa-solid fa-circle-arrow-right ml-2"></i>
+        {/* Only the call to action underlines on hover, not the whole card. */}
+        <span className="group-hover:underline">Get started</span>
+        <i className="fa-solid fa-circle-arrow-right ml-2"></i>
       </div>
     </a>
   );


### PR DESCRIPTION
## Description

Hovering a `Vignette` card underlined every piece of text inside it — the title, the description and the call to action. The whole card is an `<a>`, so Docusaurus's `a:hover` underline propagates to all descendants; the `no-underline` classes already present on the `h3` and the CTA could not cancel it, because `text-decoration` propagates from the ancestor box and descendants are not allowed to remove it. The fix has to be applied on the anchor itself, which this PR does at the component level so it applies everywhere `Vignette` is used.

This PR changes the following:
- Adds `no-underline hover:no-underline` to the anchor, so the card no longer underlines on hover.
- Makes the anchor a `group` and underlines only the "Get started" text on `group-hover`, keeping a link affordance without the card-wide rule.
- Moves the CTA colour change from `hover:` to `group-hover:`, so hovering anywhere on the card lights it up instead of only when the pointer is directly over that line.
- Drops the two `no-underline` classes that never had any effect.

## Evaluation

`npm run build` passes and `eslint` is clean. Verified in the rendered production build on both pages that use the component — `/docs` and `/docs/relay-proxy/configure-relay-proxy` — by measuring `getComputedStyle(el).textDecorationLine` while the card is genuinely hovered:

```console
{"hovered":true,"anchor":"none","h3":"none","paragraph":"none","ctaSpan":"underline"}
```

Before, all four reported `underline`. The CTA colour also now shifts on card hover (`rgb(96,165,250)` → `rgb(147,197,253)` in dark mode).

## Closes issue(s)

No tracked issue — reported directly while reviewing #5934.

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code <!-- N/A: CSS-class-only change to a presentational component; the site has no component test suite -->
- [ ] I have updated the documentation (`README.md` and `/website/docs`) <!-- N/A: no user-facing documentation change -->
- [x] I have followed the [contributing guide](CONTRIBUTING.md)