### PR TITLE
feat(website): don't publish blog posts dated in the future

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -28,6 +28,24 @@ const {
   generateDevelopersDropdownHTML,
 } = require('./src/components/navbar/developers');
 
+/**
+ * Blog posts dated in the future are drafts: they stay out of production builds
+ * until their date arrives. `npm run start` keeps them visible so they can be
+ * previewed, and SHOW_FUTURE_POSTS=true forces them into a build (deploy previews).
+ *
+ * @type {import('@docusaurus/plugin-content-blog').ProcessBlogPostsFn}
+ */
+const hideFuturePosts = async ({blogPosts}) => {
+  if (
+    process.env.NODE_ENV !== 'production' ||
+    process.env.SHOW_FUTURE_POSTS === 'true'
+  ) {
+    return undefined; // keep every post
+  }
+  const now = Date.now();
+  return blogPosts.filter(post => post.metadata.date.getTime() <= now);
+};
+
 /** @type {import("@docusaurus/types").Config} */
 const config = {
   title: 'GO Feature Flag',
@@ -316,6 +334,7 @@ const config = {
         },
         blog: {
           showReadingTime: true,
+          processBlogPosts: hideFuturePosts,
           // Not rendered on the page (the card grid opens straight on the
           // hero) — this is the /blog meta description and og:description.
           // Kept because the Docusaurus default is the bare word "Blog".


### PR DESCRIPTION
## Description

Posts written ahead of time went live the moment they landed on `main`, because the blog published every folder in `website/blog/` regardless of date. This adds a `processBlogPosts` hook to the blog plugin options that drops posts dated after build time from production builds; `npm run start` still shows them so drafts can be previewed, and `SHOW_FUTURE_POSTS=true npm run build` forces them in for deploy previews. The hook runs before routes, tags and feeds are generated, so a future-dated post is absent from the listing, its permalink, `rss.xml`/`atom.xml` and `sitemap.xml` in one place.

To test: drop a post folder dated a year out into `website/blog/`, run `npm run build` and confirm `grep -rl <slug> build/` finds nothing, then run `npm run start` and confirm the post is visible. No breaking changes.

## Closes issue(s)

N/A

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)