### PR TITLE
refactor: use net/http method constants instead of echo aliases

### DIFF
--- a/cmd/relayproxy/handler/goff/all_flags_test.go
+++ b/cmd/relayproxy/handler/goff/all_flags_test.go
@@ -141,7 +141,7 @@ func Test_all_flag_Handler_DefaultMode(t *testing.T) {
 				bodyReq = strings.NewReader(string(bodyReqContent))
 			}
 
-			req := httptest.NewRequest(echo.POST, "/v1/allflags", bodyReq)
+			req := httptest.NewRequest(http.MethodPost, "/v1/allflags", bodyReq)
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			c := e.NewContext(req, rec)
 			c.SetPath("/v1/allflags")
@@ -276,7 +276,7 @@ func Test_all_flag_Handler_FlagsetMode(t *testing.T) {
 				bodyReq = strings.NewReader(string(bodyReqContent))
 			}
 
-			req := httptest.NewRequest(echo.POST, "/v1/allflags", bodyReq)
+			req := httptest.NewRequest(http.MethodPost, "/v1/allflags", bodyReq)
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			req.Header.Set(echo.HeaderAuthorization, "Bearer test-api-key")
 			c := e.NewContext(req, rec)

--- a/cmd/relayproxy/handler/goff/collect_eval_data_test.go
+++ b/cmd/relayproxy/handler/goff/collect_eval_data_test.go
@@ -263,7 +263,7 @@ func Test_collect_eval_data_Handler(t *testing.T) {
 				bodyReq = strings.NewReader(string(bodyReqContent))
 			}
 
-			req := httptest.NewRequest(echo.POST, "/v1/data/collector", bodyReq)
+			req := httptest.NewRequest(http.MethodPost, "/v1/data/collector", bodyReq)
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			if tt.apiKey != "" {
 				req.Header.Set("Authorization", "Bearer "+tt.apiKey)
@@ -474,7 +474,7 @@ func Test_collect_tracking_and_evaluation_events(t *testing.T) {
 			e := echo.New()
 			rec := httptest.NewRecorder()
 
-			req := httptest.NewRequest(echo.POST, "/v1/data/collector", strings.NewReader(string(bodyReq)))
+			req := httptest.NewRequest(http.MethodPost, "/v1/data/collector", strings.NewReader(string(bodyReq)))
 			if tt.apiKey != "" {
 				req.Header.Set("Authorization", "Bearer "+tt.apiKey)
 			}

--- a/cmd/relayproxy/handler/goff/flag_change_test.go
+++ b/cmd/relayproxy/handler/goff/flag_change_test.go
@@ -98,7 +98,7 @@ func TestPIFlagChange_WithConfigChange(t *testing.T) {
 
 			e := echo.New()
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(echo.GET, "/v1/flag/change", nil)
+			req := httptest.NewRequest(http.MethodGet, "/v1/flag/change", nil)
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			if tt.apiKey != "" {
 				req.Header.Set("Authorization", "Bearer "+tt.apiKey)
@@ -210,7 +210,7 @@ func TestPIFlagChange_WithoutConfigChange(t *testing.T) {
 
 			e := echo.New()
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(echo.GET, "/v1/flag/change", nil)
+			req := httptest.NewRequest(http.MethodGet, "/v1/flag/change", nil)
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			if tt.apiKey != "" {
 				req.Header.Set("Authorization", "Bearer "+tt.apiKey)

--- a/cmd/relayproxy/handler/goff/flag_configuration_test.go
+++ b/cmd/relayproxy/handler/goff/flag_configuration_test.go
@@ -89,7 +89,7 @@ func TestFlagConfigurationAPICtrl_Handler_DefaultMode(t *testing.T) {
 			requestBody, err := os.ReadFile(tt.requestBody)
 			assert.NoError(t, err)
 
-			req := httptest.NewRequest(echo.POST, "/v1/flag/configuration", strings.NewReader(string(requestBody)))
+			req := httptest.NewRequest(http.MethodPost, "/v1/flag/configuration", strings.NewReader(string(requestBody)))
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			c := e.NewContext(req, rec)
 			c.SetPath("/v1/flag/configuration")
@@ -212,7 +212,7 @@ func TestFlagConfigurationAPICtrl_Handler_FlagsetMode(t *testing.T) {
 			requestBody, err := os.ReadFile(tt.requestBody)
 			assert.NoError(t, err)
 
-			req := httptest.NewRequest(echo.POST, "/v1/flag/configuration", strings.NewReader(string(requestBody)))
+			req := httptest.NewRequest(http.MethodPost, "/v1/flag/configuration", strings.NewReader(string(requestBody)))
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 			// Add API key to header if provided

--- a/cmd/relayproxy/handler/goff/flag_eval_test.go
+++ b/cmd/relayproxy/handler/goff/flag_eval_test.go
@@ -173,7 +173,7 @@ func Test_flag_eval_Handler(t *testing.T) {
 				bodyReq = strings.NewReader(string(bodyReqContent))
 			}
 
-			req := httptest.NewRequest(echo.POST, "/v1/feature/"+tt.args.flagKey+"/eval", bodyReq)
+			req := httptest.NewRequest(http.MethodPost, "/v1/feature/"+tt.args.flagKey+"/eval", bodyReq)
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			c := e.NewContext(req, rec)
 			c.SetPath("/v1/feature/:flagKey/eval")

--- a/cmd/relayproxy/handler/goff/health_test.go
+++ b/cmd/relayproxy/handler/goff/health_test.go
@@ -55,7 +55,7 @@ func Test_health_Handler(t *testing.T) {
 
 			e := echo.New()
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(echo.GET, "/health", nil)
+			req := httptest.NewRequest(http.MethodGet, "/health", nil)
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			c := e.NewContext(req, rec)
 			res := healthCtrl.Handler(c)

--- a/cmd/relayproxy/handler/goff/info_test.go
+++ b/cmd/relayproxy/handler/goff/info_test.go
@@ -87,7 +87,7 @@ func Test_info_Handler(t *testing.T) {
 
 			e := echo.New()
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(echo.GET, "/info", nil)
+			req := httptest.NewRequest(http.MethodGet, "/info", nil)
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			c := e.NewContext(req, rec)
 			res := infoCtrl.Handler(c)
@@ -145,7 +145,7 @@ func Test_info_Handler_Error(t *testing.T) {
 
 		e := echo.New()
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(echo.GET, "/info", nil)
+		req := httptest.NewRequest(http.MethodGet, "/info", nil)
 		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 		c := e.NewContext(req, rec)
 		res := infoCtrl.Handler(c)
@@ -172,7 +172,7 @@ func Test_info_Handler_Error(t *testing.T) {
 
 		e := echo.New()
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(echo.GET, "/info", nil)
+		req := httptest.NewRequest(http.MethodGet, "/info", nil)
 		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 		c := e.NewContext(req, rec)
 		res := infoCtrl.Handler(c)

--- a/cmd/relayproxy/handler/goff/retriever_refresh_test.go
+++ b/cmd/relayproxy/handler/goff/retriever_refresh_test.go
@@ -1,6 +1,7 @@
 package controller_test
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -21,7 +22,7 @@ func Test_retriever_refresh_Handler_no_goff(t *testing.T) {
 	e := echo.New()
 	rec := httptest.NewRecorder()
 
-	req := httptest.NewRequest(echo.POST, "/admin/v1/retriever/refresh", nil)
+	req := httptest.NewRequest(http.MethodPost, "/admin/v1/retriever/refresh", nil)
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	c := e.NewContext(req, rec)
 	handlerErr := ctrl.Handler(c)
@@ -59,7 +60,7 @@ func Test_retriever_refresh_Handler_valid(t *testing.T) {
 	ctrl := controller.NewForceFlagsRefresh(flagsetManager, metric.Metrics{})
 	e := echo.New()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(echo.POST, "/admin/v1/retriever/refresh", nil)
+	req := httptest.NewRequest(http.MethodPost, "/admin/v1/retriever/refresh", nil)
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 	c := e.NewContext(req, rec)
 	handlerErr := ctrl.Handler(c)

--- a/cmd/relayproxy/handler/manifest/handlers_test.go
+++ b/cmd/relayproxy/handler/manifest/handlers_test.go
@@ -52,7 +52,7 @@ func TestManifestCtrl_GetManifest_DefaultMode(t *testing.T) {
 	ctrl := manifest.NewManifest(flagsetManager, metric.Metrics{}, zap.NewNop())
 	e := echo.New()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(echo.GET, manifestEndpoint, nil)
+	req := httptest.NewRequest(http.MethodGet, manifestEndpoint, nil)
 	c := e.NewContext(req, rec)
 	c.SetPath(manifestEndpoint)
 
@@ -159,7 +159,7 @@ func TestManifestCtrl_GetManifest_FlagsetMode(t *testing.T) {
 			ctrl := manifest.NewManifest(flagsetManager, metric.Metrics{}, zap.NewNop())
 			e := echo.New()
 			rec := httptest.NewRecorder()
-			req := httptest.NewRequest(echo.GET, manifestEndpoint, nil)
+			req := httptest.NewRequest(http.MethodGet, manifestEndpoint, nil)
 			if tt.apiKey != "" {
 				req.Header.Set(helper.AuthorizationHeader, helper.BearerPrefix+tt.apiKey)
 			}
@@ -197,7 +197,7 @@ func TestManifestCtrl_GetManifest_NilFlagsetManager(t *testing.T) {
 	ctrl := manifest.NewManifest(nil, metric.Metrics{}, zap.NewNop())
 	e := echo.New()
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(echo.GET, manifestEndpoint, nil)
+	req := httptest.NewRequest(http.MethodGet, manifestEndpoint, nil)
 	c := e.NewContext(req, rec)
 	c.SetPath(manifestEndpoint)
 

--- a/cmd/relayproxy/handler/ofrep/evaluate_test.go
+++ b/cmd/relayproxy/handler/ofrep/evaluate_test.go
@@ -141,7 +141,7 @@ func Test_Bulk_Evaluation(t *testing.T) {
 				bodyReq = strings.NewReader(string(bodyReqContent))
 			}
 
-			req := httptest.NewRequest(echo.POST, "/ofrep/v1/evaluate/flags", bodyReq)
+			req := httptest.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags", bodyReq)
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			c := e.NewContext(req, rec)
 
@@ -317,7 +317,7 @@ func Test_Evaluate(t *testing.T) {
 				assert.NoError(t, err, "request wantBody file missing %s", tt.args.bodyFile)
 				bodyReq = strings.NewReader(string(bodyReqContent))
 			}
-			req := httptest.NewRequest(echo.POST, "/ofrep/v1/evaluate/flags/"+flagKey, bodyReq)
+			req := httptest.NewRequest(http.MethodPost, "/ofrep/v1/evaluate/flags/"+flagKey, bodyReq)
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 
 			e.ServeHTTP(rec, req)


### PR DESCRIPTION
## Description

**What was the problem?**
Echo v5 removes the HTTP method constants that v4 exposed (`echo.GET`, `echo.POST`, ...). They were plain aliases for the `net/http` ones, so 20 call sites in this repo would break on the version bump for no good reason.

**How it is resolved?**
Replaced every `echo.GET` / `echo.POST` with `http.MethodGet` / `http.MethodPost`. In Echo v4 these are defined as exactly those `net/http` constants, so this is behaviour-neutral today and removes 20 sites from the upcoming migration diff.

**How can we test the change?**
`make test` — all touched files are tests and the assertions are unchanged.

No breaking changes.

## Closes issue(s)
Preparation for #5294 (does not close it).

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code <!-- no new behaviour; existing tests cover it -->
- [ ] I have updated the documentation (`README.md` and `/website/docs`) <!-- no user-facing change -->
- [x] I have followed the [contributing guide](CONTRIBUTING.md)

---
*Part 1/5 of the Echo v5 migration stack.*