### PR TITLE
refactor: use middleware.CORS() instead of DefaultCORSConfig

### DIFF
--- a/cmd/relayproxy/api/routes_monitoring.go
+++ b/cmd/relayproxy/api/routes_monitoring.go
@@ -18,7 +18,7 @@ func (s *Server) addMonitoringRoutes() {
 		s.monitoringEcho.HidePort = true
 		s.monitoringEcho.Debug = s.config.IsDebugEnabled()
 		s.monitoringEcho.Use(helpermiddleware.ZapLogger(s.zapLog, s.config.IsDebugEnabled()))
-		s.monitoringEcho.Use(middleware.CORSWithConfig(middleware.DefaultCORSConfig))
+		s.monitoringEcho.Use(middleware.CORS())
 		s.apiEcho.Use(custommiddleware.VersionHeader(custommiddleware.VersionHeaderConfig{
 			RelayProxyConfig: s.config,
 		}))

--- a/cmd/relayproxy/api/server.go
+++ b/cmd/relayproxy/api/server.go
@@ -91,7 +91,7 @@ func (s *Server) initRoutes() {
 			},
 		}))
 	}
-	s.apiEcho.Use(middleware.CORSWithConfig(middleware.DefaultCORSConfig))
+	s.apiEcho.Use(middleware.CORS())
 
 	s.apiEcho.Use(custommiddleware.VersionHeader(custommiddleware.VersionHeaderConfig{
 		Skipper: func(_ echo.Context) bool {


### PR DESCRIPTION
## Description

**What was the problem?**
Echo v5 removes `middleware.DefaultCORSConfig`, which this repo passes to `CORSWithConfig` in two places.

**How it is resolved?**
Switched both call sites to `middleware.CORS()`, which exists in v4 and v5. In v4 it is defined as literally `CORSWithConfig(DefaultCORSConfig)`, so this is behaviour-neutral on the current tree and drops a symbol v5 deleted.

> [!NOTE]
> In Echo **v5** the semantics differ: `CORS()` became variadic (`CORS(allowOrigins ...string)`) and no longer implies `"*"` — calling it with no origins panics. The migration PR at the top of this stack therefore passes `CORS("*")` to preserve v4 behaviour. That is deliberate and covered there.

**How can we test the change?**
`make test`, plus a CORS preflight against a running relay proxy — the `Access-Control-Allow-Origin: *` response is unchanged.

No breaking changes.

## Closes issue(s)
Preparation for #5294 (does not close it).

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code <!-- no behaviour change; existing tests cover it -->
- [ ] I have updated the documentation (`README.md` and `/website/docs`) <!-- no user-facing change -->
- [x] I have followed the [contributing guide](CONTRIBUTING.md)

---
*Part 2/5 of the Echo v5 migration stack.*