### PR TITLE
refactor: vendor the etag middleware into cmdhelpers/api/middleware

### DIFF
--- a/cmd/relayproxy/api/routes_goff.go
+++ b/cmd/relayproxy/api/routes_goff.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"github.com/labstack/echo/v4"
-	etag "github.com/pablor21/echo-etag/v4"
 	echoSwagger "github.com/swaggo/echo-swagger"
 	controller "github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/handler/goff"
+	helpermiddleware "github.com/thomaspoignant/go-feature-flag/cmdhelpers/api/middleware"
 )
 
 func (s *Server) addGOFFRoutes(
@@ -18,7 +18,7 @@ func (s *Server) addGOFFRoutes(
 	// Grouping the routes
 	v1 := s.apiEcho.Group("/v1")
 	v1.Use(authMiddleware)
-	v1.Use(etag.WithConfig(etag.Config{
+	v1.Use(helpermiddleware.EtagWithConfig(helpermiddleware.EtagConfig{
 		Skipper: func(c echo.Context) bool {
 			switch c.Path() {
 			case

--- a/cmd/relayproxy/api/routes_ofrep.go
+++ b/cmd/relayproxy/api/routes_ofrep.go
@@ -2,13 +2,13 @@ package api
 
 import (
 	"github.com/labstack/echo/v4"
-	etag "github.com/pablor21/echo-etag/v4"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/handler/ofrep"
+	helpermiddleware "github.com/thomaspoignant/go-feature-flag/cmdhelpers/api/middleware"
 )
 
 func (s *Server) addOFREPRoutes(cFlagEvalOFREP ofrep.EvaluateCtrl, authMiddleware echo.MiddlewareFunc) {
 	ofrepGroup := s.apiEcho.Group("/ofrep/v1")
-	ofrepGroup.Use(etag.WithConfig(etag.Config{
+	ofrepGroup.Use(helpermiddleware.EtagWithConfig(helpermiddleware.EtagConfig{
 		Skipper: func(c echo.Context) bool {
 			switch c.Path() {
 			case "/ofrep/v1/evaluate/flags":

--- a/cmdhelpers/api/middleware/etag.go
+++ b/cmdhelpers/api/middleware/etag.go
@@ -1,0 +1,207 @@
+// This file is a temporary in-repo copy of github.com/pablor21/echo-etag.
+//
+// Upstream has no Echo v5 release yet, which blocks the relay proxy migration
+// tracked in thomaspoignant/go-feature-flag#5294. The port is already open
+// upstream:
+//
+//	https://github.com/pablor21/echo-etag/issues/13
+//	https://github.com/pablor21/echo-etag/pull/14
+//
+// Once upstream tags a v5 release, DELETE this file and etag_test.go and go
+// back to depending on github.com/pablor21/echo-etag/v5. The code below is kept
+// deliberately faithful to upstream (only the exported names are prefixed, to
+// avoid over-generic identifiers in this shared package) so that swap stays a
+// clean removal rather than a re-port.
+//
+// Known upstream sharp edge, intentionally NOT fixed here so the copy stays
+// faithful: writeRaw calls WriteHeader(hw.status), which panics if a handler
+// returns nil having written neither a status nor a body (hw.status == 0). All
+// three endpoints this middleware is mounted on always write a body, so it is
+// not reachable in this repo.
+//
+// MIT License
+//
+// Copyright (c) 2023 Pablo Ramirez <pablo@pramirez.dev>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package middleware
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"hash/crc32"
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+// EtagConfig defines the config for the Etag middleware.
+// Upstream name: etag.Config
+type EtagConfig struct {
+	// Skipper defines a function to skip middleware.
+	Skipper middleware.Skipper
+	// Weak defines if the Etag is weak or strong.
+	Weak bool
+	// HashFn defines the hash function to use. Default is crc32q.
+	HashFn func(config EtagConfig) hash.Hash
+}
+
+var (
+	// DefaultEtagConfig is the default Etag middleware config.
+	DefaultEtagConfig = EtagConfig{
+		Skipper: middleware.DefaultSkipper,
+		Weak:    true,
+		HashFn: func(config EtagConfig) hash.Hash {
+			if config.Weak {
+				const crcPol = 0xD5828281
+				crc32qTable := crc32.MakeTable(crcPol)
+				return crc32.New(crc32qTable)
+			}
+			return sha1.New()
+		},
+	}
+	normalizedETagName        = http.CanonicalHeaderKey("Etag")
+	normalizedIfNoneMatchName = http.CanonicalHeaderKey("If-None-Match")
+	weakPrefix                = "W/"
+)
+
+// Etag returns an Etag middleware using the default config.
+func Etag() echo.MiddlewareFunc {
+	c := DefaultEtagConfig
+	return EtagWithConfig(c)
+}
+
+// EtagWithConfig returns an Etag middleware with config.
+// Upstream name: etag.WithConfig
+func EtagWithConfig(config EtagConfig) echo.MiddlewareFunc {
+	if config.Skipper == nil {
+		config.Skipper = DefaultEtagConfig.Skipper
+	}
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) (err error) {
+			skipper := config.Skipper
+			if skipper == nil {
+				skipper = DefaultEtagConfig.Skipper
+			}
+
+			if skipper(c) {
+				return next(c)
+			}
+
+			// get the hash function
+			hashFn := config.HashFn
+			if hashFn == nil {
+				hashFn = DefaultEtagConfig.HashFn
+			}
+
+			originalWriter := c.Response().Writer
+			res := c.Response()
+			req := c.Request()
+			// ResponseWriter
+			hw := bufferedWriter{rw: res.Writer, hash: hashFn(config), buf: bytes.NewBuffer(nil)}
+			res.Writer = &hw
+			err = next(c)
+			// restore the original writer
+			res.Writer = originalWriter
+			if err != nil {
+				return err
+			}
+
+			resHeader := res.Header()
+
+			if hw.hash == nil ||
+				resHeader.Get(normalizedETagName) != "" ||
+				strconv.Itoa(hw.status)[0] != '2' ||
+				hw.status == http.StatusNoContent ||
+				hw.buf.Len() == 0 {
+				writeRaw(originalWriter, hw)
+				return
+			}
+
+			etag := fmt.Sprintf("\"%v-%v\"", strconv.Itoa(hw.len),
+				hex.EncodeToString(hw.hash.Sum(nil)))
+
+			if config.Weak {
+				etag = weakPrefix + etag
+			}
+
+			resHeader.Set(normalizedETagName, etag)
+
+			ifNoneMatch := req.Header.Get(normalizedIfNoneMatchName) // get the If-None-Match header
+			headerFresh := ifNoneMatch == etag || ifNoneMatch == weakPrefix+etag
+
+			if headerFresh {
+				originalWriter.WriteHeader(http.StatusNotModified)
+				_, _ = originalWriter.Write(nil)
+			} else {
+				writeRaw(originalWriter, hw)
+			}
+			return
+		}
+	}
+}
+
+// bufferedWriter is a wrapper around http.ResponseWriter that
+// buffers the response and calculates the hash of the response.
+type bufferedWriter struct {
+	rw     http.ResponseWriter
+	hash   hash.Hash
+	buf    *bytes.Buffer
+	len    int
+	status int
+}
+
+// Header returns the header map that will be sent by the underlying writer.
+func (hw bufferedWriter) Header() http.Header {
+	return hw.rw.Header()
+}
+
+// WriteHeader sends an HTTP response header with the provided status code.
+func (hw *bufferedWriter) WriteHeader(status int) {
+	hw.status = status
+}
+
+// Write writes the data to the buffer to be sent as part of an HTTP reply.
+func (hw *bufferedWriter) Write(b []byte) (int, error) {
+	if hw.status == 0 {
+		hw.status = http.StatusOK
+	}
+	// write to the buffer
+	l, err := hw.buf.Write(b)
+	if err != nil {
+		return l, err
+	}
+	// write to the hash
+	l, err = hw.hash.Write(b)
+	hw.len += l
+	return l, err
+}
+
+// writeRaw writes the buffered data to the underlying http.ResponseWriter.
+func writeRaw(res http.ResponseWriter, hw bufferedWriter) {
+	res.WriteHeader(hw.status)
+	_, _ = res.Write(hw.buf.Bytes())
+}

--- a/cmdhelpers/api/middleware/etag.go
+++ b/cmdhelpers/api/middleware/etag.go
@@ -45,7 +45,7 @@ package middleware
 
 import (
 	"bytes"
-	"crypto/sha1"
+	"crypto/sha1" //nolint:gosec // SHA-1 is used for ETag hashing, not security.
 	"encoding/hex"
 	"fmt"
 	"hash"
@@ -79,7 +79,7 @@ var (
 				crc32qTable := crc32.MakeTable(crcPol)
 				return crc32.New(crc32qTable)
 			}
-			return sha1.New()
+			return sha1.New() //nolint:gosec // SHA-1 is used for ETag hashing, not security.
 		},
 	}
 	normalizedETagName        = http.CanonicalHeaderKey("Etag")
@@ -138,7 +138,7 @@ func EtagWithConfig(config EtagConfig) echo.MiddlewareFunc {
 				hw.status == http.StatusNoContent ||
 				hw.buf.Len() == 0 {
 				writeRaw(originalWriter, hw)
-				return
+				return //nolint:nakedret // kept faithful to upstream
 			}
 
 			etag := fmt.Sprintf("\"%v-%v\"", strconv.Itoa(hw.len),
@@ -159,14 +159,14 @@ func EtagWithConfig(config EtagConfig) echo.MiddlewareFunc {
 			} else {
 				writeRaw(originalWriter, hw)
 			}
-			return
+			return //nolint:nakedret // kept faithful to upstream
 		}
 	}
 }
 
 // bufferedWriter is a wrapper around http.ResponseWriter that
 // buffers the response and calculates the hash of the response.
-type bufferedWriter struct {
+type bufferedWriter struct { //nolint:recvcheck // mixed receivers kept faithful to upstream
 	rw     http.ResponseWriter
 	hash   hash.Hash
 	buf    *bytes.Buffer

--- a/cmdhelpers/api/middleware/etag_test.go
+++ b/cmdhelpers/api/middleware/etag_test.go
@@ -11,10 +11,10 @@ import (
 )
 
 const (
-	etagBody     = "Hello World"
-	weakEtag     = "W/\"11-8dcfee46\""
-	strongEtag   = "\"11-0a4d55a8d778e5022fab701977c5d840bbc486d0\""
-	invalidEtag  = "invalid"
+	etagBody    = "Hello World"
+	weakEtag    = "W/\"11-8dcfee46\""
+	strongEtag  = "\"11-0a4d55a8d778e5022fab701977c5d840bbc486d0\""
+	invalidEtag = "invalid"
 )
 
 // newEtagServer builds an echo instance exposing the routes used by the Etag tests.

--- a/cmdhelpers/api/middleware/etag_test.go
+++ b/cmdhelpers/api/middleware/etag_test.go
@@ -1,0 +1,137 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/thomaspoignant/go-feature-flag/cmdhelpers/api/middleware"
+)
+
+const (
+	etagBody     = "Hello World"
+	weakEtag     = "W/\"11-8dcfee46\""
+	strongEtag   = "\"11-0a4d55a8d778e5022fab701977c5d840bbc486d0\""
+	invalidEtag  = "invalid"
+)
+
+// newEtagServer builds an echo instance exposing the routes used by the Etag tests.
+func newEtagServer() *echo.Echo {
+	e := echo.New()
+
+	e.GET("/etag", func(c echo.Context) error {
+		return c.String(http.StatusOK, etagBody)
+	}, middleware.EtagWithConfig(middleware.EtagConfig{Weak: false}))
+
+	e.GET("/etag/weak", func(c echo.Context) error {
+		return c.String(http.StatusOK, etagBody)
+	}, middleware.Etag())
+
+	e.GET("/etag/nocontent", func(c echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	}, middleware.Etag())
+
+	e.GET("/etag/skipped", func(c echo.Context) error {
+		return c.String(http.StatusOK, etagBody)
+	}, middleware.EtagWithConfig(middleware.EtagConfig{
+		Skipper: func(_ echo.Context) bool { return true },
+	}))
+
+	return e
+}
+
+func TestEtag(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		ifNoneMatch  string
+		wantStatus   int
+		wantEtag     string
+		wantBody     string
+		wantNoEtagHd bool
+	}{
+		{
+			name:       "strong etag is set on first request",
+			path:       "/etag",
+			wantStatus: http.StatusOK,
+			wantEtag:   strongEtag,
+			wantBody:   etagBody,
+		},
+		{
+			name:        "strong etag returns 304 when If-None-Match matches",
+			path:        "/etag",
+			ifNoneMatch: strongEtag,
+			wantStatus:  http.StatusNotModified,
+			wantEtag:    strongEtag,
+			wantBody:    "",
+		},
+		{
+			name:        "strong etag returns 200 when If-None-Match does not match",
+			path:        "/etag",
+			ifNoneMatch: invalidEtag,
+			wantStatus:  http.StatusOK,
+			wantEtag:    strongEtag,
+			wantBody:    etagBody,
+		},
+		{
+			name:       "weak etag is set on first request",
+			path:       "/etag/weak",
+			wantStatus: http.StatusOK,
+			wantEtag:   weakEtag,
+			wantBody:   etagBody,
+		},
+		{
+			name:        "weak etag returns 304 when If-None-Match matches",
+			path:        "/etag/weak",
+			ifNoneMatch: weakEtag,
+			wantStatus:  http.StatusNotModified,
+			wantEtag:    weakEtag,
+			wantBody:    "",
+		},
+		{
+			name:        "weak etag returns 200 when If-None-Match does not match",
+			path:        "/etag/weak",
+			ifNoneMatch: invalidEtag,
+			wantStatus:  http.StatusOK,
+			wantEtag:    weakEtag,
+			wantBody:    etagBody,
+		},
+		{
+			name:         "no content response passes through without an etag",
+			path:         "/etag/nocontent",
+			wantStatus:   http.StatusNoContent,
+			wantBody:     "",
+			wantNoEtagHd: true,
+		},
+		{
+			name:         "skipper bypasses the middleware entirely",
+			path:         "/etag/skipped",
+			wantStatus:   http.StatusOK,
+			wantBody:     etagBody,
+			wantNoEtagHd: true,
+		},
+	}
+
+	e := newEtagServer()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			if tt.ifNoneMatch != "" {
+				req.Header.Set("If-None-Match", tt.ifNoneMatch)
+			}
+			rec := httptest.NewRecorder()
+
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.wantStatus, rec.Code)
+			assert.Equal(t, tt.wantBody, rec.Body.String())
+			if tt.wantNoEtagHd {
+				assert.Empty(t, rec.Header().Get("Etag"))
+				return
+			}
+			assert.Equal(t, tt.wantEtag, rec.Header().Get("Etag"))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/labstack/echo-contrib v0.50.1
 	github.com/labstack/echo/v4 v4.15.4
 	github.com/luci/go-render v0.0.0-20160219211803-9a04cc21af0f
-	github.com/pablor21/echo-etag/v4 v4.0.5
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.3
 	github.com/prometheus/common v0.71.0

--- a/go.sum
+++ b/go.sum
@@ -860,8 +860,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/pablor21/echo-etag/v4 v4.0.5 h1:4OCHTp18L3+zfyM8/E+SFU5T5hov1Rbjg2AnJqsj5RI=
-github.com/pablor21/echo-etag/v4 v4.0.5/go.mod h1:Wh7xE/urCbRcyZPQjDGVKQawWMGSy/EjX6XrsSKS6OY=
 github.com/pb33f/ordered-map/v2 v2.3.1 h1:5319HDO0aw4DA4gzi+zv4FXU9UlSs3xGZ40wcP1nBjY=
 github.com/pb33f/ordered-map/v2 v2.3.1/go.mod h1:qxFQgd0PkVUtOMCkTapqotNgzRhMPL7VvaHKbd1HnmQ=
 github.com/pborman/getopt v0.0.0-20180729010549-6fdd0a2c7117/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
refactor: vendor the etag middleware into cmdhelpers/api/middleware
END_COMMIT_OVERRIDE

## Description

**What was the problem?**
`github.com/pablor21/echo-etag` has no Echo v5 release, and it is the only dependency in the relay proxy still blocking #5294. Upstream is effectively unmaintained (last push 2025-07-18, 11 stars).

**How it is resolved?**
The port is already open upstream — [pablor21/echo-etag#13](https://github.com/pablor21/echo-etag/issues/13) and [#14](https://github.com/pablor21/echo-etag/pull/14) — but untagged, so this PR carries a **temporary in-repo copy** until it ships.

- Added `cmdhelpers/api/middleware/etag.go` (~200 lines, MIT notice preserved).
- Kept **deliberately faithful** to upstream so the eventual removal is a clean deletion rather than a re-port. Only the exported names are prefixed to avoid over-generic identifiers in this shared package: `Config` → `EtagConfig`, `WithConfig` → `EtagWithConfig`. `Etag()` and `DefaultEtagConfig` are unchanged.
- A file header records the removal trigger.
- Dropped `github.com/pablor21/echo-etag/v4` from `go.mod`.

**How can we test the change?**
`make test`. New table-driven tests cover strong/weak etags, `If-None-Match` hit and miss, 204 passthrough, and the skipper path — 8 cases. Behaviour on the three affected endpoints (`/v1/flag/change`, `/v1/flag/configuration`, `/ofrep/v1/evaluate/flags`) is unchanged.

No breaking changes.

> [!NOTE]
> One inherited sharp edge is documented but intentionally **not** fixed, to keep the copy faithful: `writeRaw` calls `WriteHeader(hw.status)`, which panics if a handler returns `nil` having written neither status nor body. All three endpoints always write a body, so it is unreachable here.

## Closes issue(s)
Preparation for #5294 (does not close it).

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`) <!-- internal middleware, no user-facing change -->
- [x] I have followed the [contributing guide](CONTRIBUTING.md)

---
*Part 3/5 of the Echo v5 migration stack.*