### PR TITLE
fix: register the version header middleware on the monitoring server

### DIFF
--- a/cmd/relayproxy/api/routes_cors_test.go
+++ b/cmd/relayproxy/api/routes_cors_test.go
@@ -1,0 +1,169 @@
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/metric"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/service"
+	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/service/stream"
+	"github.com/thomaspoignant/go-feature-flag/cmdhelpers/retrieverconf"
+	"github.com/thomaspoignant/go-feature-flag/testutils"
+)
+
+// testConfig returns a minimal HTTP relay proxy configuration listening on a free port.
+func testConfig(t *testing.T) *config.Config {
+	t.Helper()
+	return &config.Config{
+		CommonFlagSet: config.CommonFlagSet{
+			Retrievers: &[]retrieverconf.RetrieverConf{
+				{
+					Kind: "file",
+					Path: "../../../testdata/flag-config.yaml",
+				},
+			},
+		},
+		Server: config.Server{
+			Mode: config.ServerModeHTTP,
+			Port: testutils.GetFreePort(t),
+		},
+	}
+}
+
+// startTestServer boots a relay proxy from conf and returns its base URL. When a monitoring
+// port is configured it also waits for the monitoring server to accept connections, because
+// it is started in its own goroutine and serves the endpoints the API server no longer has.
+func startTestServer(t *testing.T, conf *config.Config) string {
+	t.Helper()
+	log := newTestLogger(t)
+
+	metricsV2, err := metric.NewMetrics()
+	require.NoError(t, err)
+	wsService := stream.NewWebsocketService()
+	t.Cleanup(wsService.Close)
+	flagsetManager, err := service.NewFlagsetManager(conf, log.ZapLogger, nil, nil)
+	require.NoError(t, err)
+
+	s := api.New(conf, service.Services{
+		MonitoringService: service.NewMonitoring(flagsetManager),
+		WebsocketService:  wsService,
+		FlagsetManager:    flagsetManager,
+		Metrics:           metricsV2,
+	}, log.ZapLogger)
+	go func() { s.StartWithContext(context.Background()) }()
+	t.Cleanup(func() { s.Stop(context.Background()) })
+
+	baseURL := fmt.Sprintf("http://localhost:%d", conf.ServerPort(log.ZapLogger))
+	if monitoringPort := conf.EffectiveMonitoringPort(log.ZapLogger); monitoringPort != 0 {
+		waitForServer(t, fmt.Sprintf("http://localhost:%d", monitoringPort))
+	}
+	waitForServer(t, baseURL)
+	return baseURL
+}
+
+// doRequest performs a request with the given headers and returns the response, the body being
+// closed for the caller since every assertion here is on headers and status code.
+func doRequest(t *testing.T, method, url string, headers map[string]string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, url, nil)
+	require.NoError(t, err)
+	for name, value := range headers {
+		req.Header.Set(name, value)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+// Test_CORS_SimpleRequest pins the behaviour of the default echo CORS middleware on the API
+// server: any origin is allowed and no CORS header leaks on a request without an Origin.
+func Test_CORS_SimpleRequest(t *testing.T) {
+	baseURL := startTestServer(t, testConfig(t))
+
+	tests := []struct {
+		name     string
+		endpoint string
+	}{
+		{name: "health endpoint", endpoint: "/health"},
+		{name: "evaluation endpoint", endpoint: "/v1/flag/change"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("with Origin header", func(t *testing.T) {
+				resp := doRequest(t, http.MethodGet, baseURL+tt.endpoint, map[string]string{
+					"Origin": "https://example.com",
+				})
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+				assert.Contains(t, resp.Header.Values("Vary"), "Origin")
+				assert.Empty(t, resp.Header.Get("Access-Control-Allow-Credentials"))
+				assert.Empty(t, resp.Header.Get("Access-Control-Expose-Headers"))
+			})
+
+			t.Run("without Origin header", func(t *testing.T) {
+				resp := doRequest(t, http.MethodGet, baseURL+tt.endpoint, nil)
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+			})
+		})
+	}
+}
+
+// Test_CORS_Preflight checks that a browser preflight is answered by the CORS middleware
+// before the authentication middleware runs, otherwise no browser could ever call an
+// authenticated endpoint of the relay proxy.
+func Test_CORS_Preflight(t *testing.T) {
+	conf := testConfig(t)
+	conf.AuthorizedKeys = config.APIKeys{Evaluation: []string{"my-key"}}
+	conf.ForceReloadAPIKeys()
+	baseURL := startTestServer(t, conf)
+
+	endpoints := []string{
+		"/health",
+		"/v1/allflags",
+		"/v1/feature/my-flag/eval",
+		"/ofrep/v1/evaluate/flags",
+	}
+
+	for _, endpoint := range endpoints {
+		t.Run(endpoint, func(t *testing.T) {
+			resp := doRequest(t, http.MethodOptions, baseURL+endpoint, map[string]string{
+				"Origin":                         "https://example.com",
+				"Access-Control-Request-Method":  http.MethodPost,
+				"Access-Control-Request-Headers": "content-type,authorization",
+			})
+			assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+			assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+			assert.Contains(t, resp.Header.Get("Access-Control-Allow-Methods"), http.MethodPost)
+			assert.Equal(t,
+				"content-type,authorization",
+				resp.Header.Get("Access-Control-Allow-Headers"))
+			// MaxAge is not configured, so browsers are never told to cache the preflight.
+			assert.Empty(t, resp.Header.Get("Access-Control-Max-Age"))
+		})
+	}
+}
+
+// Test_CORS_MonitoringPort checks that the CORS middleware is also active on the monitoring
+// server when it runs on a dedicated port.
+func Test_CORS_MonitoringPort(t *testing.T) {
+	conf := testConfig(t)
+	conf.Server.MonitoringPort = testutils.GetFreePort(t)
+	startTestServer(t, conf)
+	monitoringURL := fmt.Sprintf("http://localhost:%d", conf.Server.MonitoringPort)
+
+	resp := doRequest(t, http.MethodGet, monitoringURL+"/health", map[string]string{
+		"Origin": "https://example.com",
+	})
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, resp.Header.Values("Vary"), "Origin")
+}

--- a/cmd/relayproxy/api/routes_monitoring.go
+++ b/cmd/relayproxy/api/routes_monitoring.go
@@ -19,7 +19,10 @@ func (s *Server) addMonitoringRoutes() {
 		s.monitoringEcho.Debug = s.config.IsDebugEnabled()
 		s.monitoringEcho.Use(helpermiddleware.ZapLogger(s.zapLog, s.config.IsDebugEnabled()))
 		s.monitoringEcho.Use(middleware.CORS())
-		s.apiEcho.Use(custommiddleware.VersionHeader(custommiddleware.VersionHeaderConfig{
+		s.monitoringEcho.Use(custommiddleware.VersionHeader(custommiddleware.VersionHeaderConfig{
+			Skipper: func(_ echo.Context) bool {
+				return s.config.DisableVersionHeader
+			},
 			RelayProxyConfig: s.config,
 		}))
 		s.monitoringEcho.Use(middleware.Recover())

--- a/cmd/relayproxy/api/routes_monitoring_test.go
+++ b/cmd/relayproxy/api/routes_monitoring_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/api"
 	"github.com/thomaspoignant/go-feature-flag/cmd/relayproxy/config"
@@ -81,6 +82,53 @@ func TestPprofEndpointsStarts(t *testing.T) {
 			require.NoError(t, err)
 			defer func() { _ = resp.Body.Close() }()
 			require.Equal(t, tt.expectedStatusCode, resp.StatusCode)
+		})
+	}
+}
+
+// Test_VersionHeader_On_MonitoringServer checks that the version header middleware is attached
+// to the monitoring server when it runs on a dedicated port, and that it honours
+// disableVersionHeader on both servers.
+func Test_VersionHeader_On_MonitoringServer(t *testing.T) {
+	tests := []struct {
+		name                 string
+		disableVersionHeader bool
+		expectedVersion      string
+	}{
+		{
+			name:                 "version header enabled",
+			disableVersionHeader: false,
+			expectedVersion:      "1.2.3",
+		},
+		{
+			name:                 "version header disabled",
+			disableVersionHeader: true,
+			expectedVersion:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conf := testConfig(t)
+			conf.Version = "1.2.3"
+			conf.DisableVersionHeader = tt.disableVersionHeader
+			conf.Server.MonitoringPort = testutils.GetFreePort(t)
+			baseURL := startTestServer(t, conf)
+			monitoringURL := fmt.Sprintf("http://localhost:%d", conf.Server.MonitoringPort)
+
+			monitoringResp := doRequest(t, http.MethodGet, monitoringURL+"/health", nil)
+			assert.Equal(t, http.StatusOK, monitoringResp.StatusCode)
+			assert.Equal(t,
+				tt.expectedVersion,
+				monitoringResp.Header.Get("X-GOFEATUREFLAG-VERSION"),
+				"monitoring server")
+
+			apiResp := doRequest(t, http.MethodGet, baseURL+"/v1/flag/change", nil)
+			assert.Equal(t, http.StatusOK, apiResp.StatusCode)
+			assert.Equal(t,
+				tt.expectedVersion,
+				apiResp.Header.Get("X-GOFEATUREFLAG-VERSION"),
+				"api server")
 		})
 	}
 }


### PR DESCRIPTION
## Description

`addMonitoringRoutes()` registered the `VersionHeader` middleware on `s.apiEcho` instead of `s.monitoringEcho`, and without the `Skipper` that honours `disableVersionHeader` — so whenever a dedicated `server.monitoringPort` is configured, the monitoring server never emitted `X-GOFEATUREFLAG-VERSION`, and `disableVersionHeader: true` was silently ignored on the **API** server because the duplicate registration set the header unconditionally.

This PR attaches the middleware to `monitoringEcho` with the same skipper used at `server.go:86`, and adds the first CORS test coverage for the relay proxy (there was none): `routes_cors_test.go` pins the behaviour of the default `middleware.CORS()` on both servers — `Access-Control-Allow-Origin: *` with `Vary: Origin` on simple requests, no CORS header without an `Origin`, and a `204` preflight on authenticated endpoints proving the CORS short-circuit runs ahead of `KeyAuthExtended` (otherwise no browser could call `/v1/*` or `/ofrep/*`).

To test: `go test ./cmd/relayproxy/...` — `Test_VersionHeader_On_MonitoringServer` fails on both rows before the fix and passes after; the CORS tests pass either way since they pin existing behaviour.

No breaking change: the only behaviour difference is the version header now appearing on the monitoring port and correctly disappearing when `disableVersionHeader` is set.

## Closes issue(s)

_No linked issue — found while adding the CORS test coverage._

## Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the documentation (`README.md` and `/website/docs`) — not needed, no configuration surface changed
- [x] I have followed the [contributing guide](CONTRIBUTING.md)