### PR TITLE
docs: document GO Feature Flag with the Vercel Flags SDK

### DIFF
--- a/website/docs/sdk/server_providers/openfeature_javascript.mdx
+++ b/website/docs/sdk/server_providers/openfeature_javascript.mdx
@@ -311,7 +311,64 @@ featureFlagClient.track('user_action', context, {
 });
 ```
 
-## NextJS integration
+## Next.js
+
+### Vercel Flags SDK
+
+The [Flags SDK](https://flags-sdk.dev) is Vercel's toolkit to declare and use feature flags in Next.js.
+It works with GO Feature Flag through its **OpenFeature adapter**, which wraps any OpenFeature client, including GOFF.
+
+<Tabs groupId="code">
+  <TabItem value="yarn" label="yarn">
+
+```shell
+yarn add flags @flags-sdk/openfeature @openfeature/server-sdk @openfeature/go-feature-flag-provider
+```
+
+  </TabItem>
+  <TabItem value="npm" label="npm">
+
+```shell
+npm i flags @flags-sdk/openfeature @openfeature/server-sdk @openfeature/go-feature-flag-provider
+```
+
+  </TabItem>
+</Tabs>
+
+Create the adapter using the **asynchronous** form, since the GO Feature Flag provider initializes asynchronously:
+
+```typescript
+import { createOpenFeatureAdapter } from "@flags-sdk/openfeature";
+import { OpenFeature } from "@openfeature/server-sdk";
+import { GoFeatureFlagProvider } from "@openfeature/go-feature-flag-provider";
+
+export const openFeatureAdapter = createOpenFeatureAdapter(async () => {
+  await OpenFeature.setProviderAndWait(
+    new GoFeatureFlagProvider({
+      endpoint: "http://localhost:1031/", // DNS of your instance of relay proxy
+    }),
+  );
+  return OpenFeature.getClient();
+});
+```
+
+You can now declare your flags and use them anywhere in your Next.js application:
+
+```typescript
+import { flag } from "flags/next";
+import type { EvaluationContext } from "@openfeature/server-sdk";
+
+export const myFeatureFlag = flag<boolean, EvaluationContext>({
+  key: "my-feature-flag",
+  defaultValue: false,
+  adapter: openFeatureAdapter.booleanValue(),
+});
+```
+
+The adapter also exposes `stringValue()`, `numberValue()` and `objectValue()`, along with an `identify` function to build your evaluation context.
+Check the [Flags SDK OpenFeature documentation](https://flags-sdk.dev/providers/openfeature) for the full API and the [GO Feature Flag integration page](https://flags-sdk.dev/docs/providers/openfeature/go).
+
+### Loading the WASM binary
 
 :::warning
 If you're using NextJS with in-process evaluation mode, you might encounter issues loading the WASM binary.


### PR DESCRIPTION
## Description

Vercel lists GO Feature Flag as a provider usable with the [Flags SDK](https://flags-sdk.dev) through its OpenFeature adapter, but our documentation never mentioned it — the only Next.js content we had was the `serverExternalPackages` WASM workaround, so users had to piece the setup together from two different doc sites.

This PR turns the `NextJS integration` section of `website/docs/sdk/server_providers/openfeature_javascript.mdx` into a `Next.js` section with two subsections: **Vercel Flags SDK** (install, the async `createOpenFeatureAdapter` wiring with `GoFeatureFlagProvider`, and a `flag()` declaration, linking to https://flags-sdk.dev/providers/openfeature for the full API) and **Loading the WASM binary** (the existing caveat, now scoped explicitly to in-process evaluation, noting remote evaluation needs no extra config on Vercel/edge).

Docs-only change, placed on the Node.js provider page since Flags SDK evaluation is server-side and builds on `@openfeature/server-sdk` plus our Node provider. To test: `cd website && npm run build && npm run serve`, then check `/docs/sdk/server_providers/openfeature_javascript`.

## Closes issue(s)

Resolve #5872

## Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [x] I have updated the documentation (`README.md` and `/website/docs`)
- [x] I have followed the [contributing guide](CONTRIBUTING.md)